### PR TITLE
Only delete A RR, not any RR for the FQDN

### DIFF
--- a/ddclient
+++ b/ddclient
@@ -3854,7 +3854,7 @@ zone $zone.
 EoINSTR1
 		foreach (@hosts) {
 			$instructions .= <<EoINSTR2;
-update delete $_.
+update delete $_. A
 update add $_. $config{$_}{'ttl'} A $ip
 EoINSTR2
 		}


### PR DESCRIPTION
Make the delete command specific to A RRs.  This prevents ddclient from
deleting other RRs unrelated to the dynamic address, but on the same
FQDN.  This can be specifically a problem with KEY RRs when using SIG(0)
instead of symmetric keys.

Reported by:    Wellie Chao
Bug report: http://sourceforge.net/p/ddclient/bugs/71/
