### PR TITLE
Interfaces can be named almost anything on modern systems.

### DIFF
--- a/ddclient
+++ b/ddclient
@@ -1753,7 +1753,7 @@ sub check_value {
 	return undef if $value eq "";
 
     } elsif ($type eq T_IF) {
-	return undef if $value !~ /^[a-z0-9:._-]+$/;
+	return undef if $value !~ /^[a-zA-Z0-9:._-]+$/;
 
     } elsif ($type eq T_PROG) {
 	return undef if $value eq "";


### PR DESCRIPTION
The old regex needlessly restricted the interface names beyond what modern systems allow.

My own system has 2 interfaces named for what they do - ethLAN and ethWAN.

Further improvment might be to actually verify the requested interface against the list of existing interfaces.

This patch just adds the option to use uppercase alphabet characters in interface names.
