### PR TITLE
Bugfix: Long username-password-combinations will not result in an authen...

### DIFF
--- a/ddclient
+++ b/ddclient
@@ -1875,7 +1875,7 @@ sub geturl {
     $request .= "/$url HTTP/1.0\n";
     $request .= "Host: $server\n";
 
-    my $auth = encode_base64("${login}:${password}");
+    my $auth = encode_base64("${login}:${password}", "");
     $request .= "Authorization: Basic $auth\n" if $login || $password;
     $request .= "User-Agent: ${program}/${version}\n";
     $request .= "Connection: close\n";


### PR DESCRIPTION
...tication error anymore.

If a username-password-combination is too long, perl's encode_base64 method will break the encoded string (stored in $auth) up into multiple lines of no more than 74 chars[0]. This breaks HTTP's authorization, since long values must not be folded into multiple lines[1].

[0] http://perldoc.perl.org/MIME/Base64.html
[1] http://tools.ietf.org/html/rfc7230#section-3.2.4
