### PR TITLE
FIxing warnings on FreeDNS update NOP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ===============================================================================
-# DDCLIENT v3.8.2
+# DDCLIENT v3.8.3
 
 ddclient is a Perl client used to update dynamic DNS entries for accounts
 on many dynamic DNS services.

--- a/ddclient
+++ b/ddclient
@@ -44,24 +44,24 @@ local $lineno = '';
 
 $ENV{'PATH'} = (exists($ENV{PATH}) ? "$ENV{PATH}:" : "") . "/sbin:/usr/sbin:/bin:/usr/bin:/etc:/usr/lib:";
 
-sub T_ANY	{'any'};
-sub T_STRING	{'string'};
-sub T_EMAIL	{'e-mail address'};
-sub T_NUMBER	{'number'};
-sub T_DELAY	{'time delay (ie. 1d, 1hour, 1m)'};
-sub T_LOGIN	{'login'};
-sub T_PASSWD	{'password'};
-sub T_BOOL	{'boolean value'};
-sub T_FQDN	{'fully qualified host name'};
-sub T_OFQDN	{'optional fully qualified host name'};
-sub T_FILE	{'file name'};
-sub T_FQDNP	{'fully qualified host name and optional port number'};
-sub T_PROTO	{'protocol'}
-sub T_USE	{'ip strategy'}
+sub T_ANY   {'any'};
+sub T_STRING    {'string'};
+sub T_EMAIL {'e-mail address'};
+sub T_NUMBER    {'number'};
+sub T_DELAY {'time delay (ie. 1d, 1hour, 1m)'};
+sub T_LOGIN {'login'};
+sub T_PASSWD    {'password'};
+sub T_BOOL  {'boolean value'};
+sub T_FQDN  {'fully qualified host name'};
+sub T_OFQDN {'optional fully qualified host name'};
+sub T_FILE  {'file name'};
+sub T_FQDNP {'fully qualified host name and optional port number'};
+sub T_PROTO {'protocol'}
+sub T_USE   {'ip strategy'}
 sub T_IF        {'interface'}
 sub T_PROG      {'program name'}
 sub T_IP        {'ip'}
-sub T_POSTS	{'postscript'};
+sub T_POSTS {'postscript'};
 
 ## strategies for obtaining an ip address.
 my %builtinweb = (
@@ -72,100 +72,100 @@ my %builtinweb = (
 );
 my %builtinfw = (
     'watchguard-soho'        => {
-				  'name' => 'Watchguard SOHO FW',
-				  'url'  => '/pubnet.htm',
-				  'skip' => 'NAME=IPAddress VALUE=',
-			        },
+                  'name' => 'Watchguard SOHO FW',
+                  'url'  => '/pubnet.htm',
+                  'skip' => 'NAME=IPAddress VALUE=',
+                    },
     'netopia-r910'           => {
-				  'name' => 'Netopia R910 FW',
-				  'url'  => '/WanEvtLog',
-				  'skip' => 'local:',                
-			        },
+                  'name' => 'Netopia R910 FW',
+                  'url'  => '/WanEvtLog',
+                  'skip' => 'local:',                
+                    },
     'smc-barricade'          => {
-				  'name' => 'SMC Barricade FW',
-				  'url'  => '/status.htm',
-				  'skip' => 'IP Address',
-			        },
+                  'name' => 'SMC Barricade FW',
+                  'url'  => '/status.htm',
+                  'skip' => 'IP Address',
+                    },
     'smc-barricade-alt'      => {
-				  'name' => 'SMC Barricade FW (alternate config)',
-				  'url'  => '/status.HTM',
-				  'skip' => 'WAN IP',
-			        },
+                  'name' => 'SMC Barricade FW (alternate config)',
+                  'url'  => '/status.HTM',
+                  'skip' => 'WAN IP',
+                    },
     'smc-barricade-7401bra'  => {
-				  'name' => 'SMC Barricade 7401BRA FW',
-				  'url'  => '/admin/wan1.htm',
-				  'skip' => 'IP Address',
-			        },
+                  'name' => 'SMC Barricade 7401BRA FW',
+                  'url'  => '/admin/wan1.htm',
+                  'skip' => 'IP Address',
+                    },
     'netgear-rt3xx'          => {
-				  'name' => 'Netgear FW',
-				  'url'  => '/mtenSysStatus.html',
-				  'skip' => 'IP Address',
-			        },
+                  'name' => 'Netgear FW',
+                  'url'  => '/mtenSysStatus.html',
+                  'skip' => 'IP Address',
+                    },
     'elsa-lancom-dsl10'      => {
-				  'name' => 'ELSA LanCom DSL/10 DSL FW',
-				  'url'  => '/config/1/6/8/3/',
-				  'skip' => 'IP.Address',
-			        },
+                  'name' => 'ELSA LanCom DSL/10 DSL FW',
+                  'url'  => '/config/1/6/8/3/',
+                  'skip' => 'IP.Address',
+                    },
     'elsa-lancom-dsl10-ch01' => { 
-	 			  'name' => 'ELSA LanCom DSL/10 DSL FW (isdn ch01)',
-				  'url'  => '/config/1/6/8/3/',
-				  'skip' => 'IP.Address.*?CH01',     
-			        },  
+                  'name' => 'ELSA LanCom DSL/10 DSL FW (isdn ch01)',
+                  'url'  => '/config/1/6/8/3/',
+                  'skip' => 'IP.Address.*?CH01',     
+                    },  
     'elsa-lancom-dsl10-ch02' => { 
-	                          'name' => 'ELSA LanCom DSL/10 DSL FW (isdn ch01)',
-				  'url'  => '/config/1/6/8/3/',
-				  'skip' => 'IP.Address.*?CH02',
-			        },  
+                              'name' => 'ELSA LanCom DSL/10 DSL FW (isdn ch01)',
+                  'url'  => '/config/1/6/8/3/',
+                  'skip' => 'IP.Address.*?CH02',
+                    },  
     'linksys'                => {
-	                          'name' => 'Linksys FW',
-				  'url'  => '/Status.htm',
-				  'skip' => 'WAN.*?Address',      
-			        },
+                              'name' => 'Linksys FW',
+                  'url'  => '/Status.htm',
+                  'skip' => 'WAN.*?Address',      
+                    },
     'linksys-ver2'                => {
-	                          'name' => 'Linksys FW version 2',
-				  'url'  => '/RouterStatus.htm',
-				  'skip' => 'WAN.*?Address',      
-			        },
+                              'name' => 'Linksys FW version 2',
+                  'url'  => '/RouterStatus.htm',
+                  'skip' => 'WAN.*?Address',      
+                    },
     'linksys-ver3'                => {
-	                          'name' => 'Linksys FW version 3',
+                              'name' => 'Linksys FW version 3',
                                  'url'  => '/Status_Router.htm',
-				  'skip' => 'WAN.*?Address',      
-			        },
+                  'skip' => 'WAN.*?Address',      
+                    },
      'linksys-wrt854g'        => {
                                  'name' => 'Linksys WRT854G FW',
                                  'url'  => '/Status_Router.asp',
                                  'skip' => 'IP Address:',
                                },
     'maxgate-ugate3x00'      => {
-	                          'name' => 'MaxGate UGATE-3x00 FW',
-	                          'url'  => '/Status.htm',
-				  'skip' => 'WAN.*?IP Address',
+                              'name' => 'MaxGate UGATE-3x00 FW',
+                              'url'  => '/Status.htm',
+                  'skip' => 'WAN.*?IP Address',
                                 },
      'netcomm-nb3' => { 
-				'name' => 'NetComm NB3', 
-				'url' => '/MainPage?id=6', 
-				'skip' => 'ppp-0', 
-				}, 
+                'name' => 'NetComm NB3', 
+                'url' => '/MainPage?id=6', 
+                'skip' => 'ppp-0', 
+                }, 
     '3com-3c886a'            => {
-    				  'name' => '3com 3c886a 56k Lan Modem',
+                      'name' => '3com 3c886a 56k Lan Modem',
                                   'url'  => '/stat3.htm',
                                   'skip' => 'IP address in use',     
                                 },
     'sohoware-nbg800'        => {
-    				  'name' => 'SOHOWare BroadGuard NBG800',
+                      'name' => 'SOHOWare BroadGuard NBG800',
                                   'url'  => '/status.htm',
                                   'skip' => 'Internet IP',     
                                 },
-    'xsense-aero'	     => {
-	                          'name' => 'Xsense Aero',
-	                          'url'  => '/A_SysInfo.htm',
-				  'skip' => 'WAN.*?IP Address',
+    'xsense-aero'        => {
+                              'name' => 'Xsense Aero',
+                              'url'  => '/A_SysInfo.htm',
+                  'skip' => 'WAN.*?IP Address',
                                 },
     'alcatel-stp'            => {
-				  'name' => 'Alcatel Speed Touch Pro',
-				  'url'  => '/cgi/router/',
+                  'name' => 'Alcatel Speed Touch Pro',
+                  'url'  => '/cgi/router/',
                                   'skip' => 'Brt',
-				},
+                },
     'alcatel-510'            => {
                                   'name' => 'Alcatel Speed Touch 510',
                                   'url'  => '/cgi/ip/',
@@ -177,45 +177,45 @@ my %builtinfw = (
                                   'skip' => 'WAN',
                                 },
     '3com-oc-remote812'      => {
-    				  'name' => '3com OfficeConnect Remote 812',
+                      'name' => '3com OfficeConnect Remote 812',
                                   'url'  => '/callEvent',
                                   'skip' => '.*LOCAL',
                                 },
-    'e-tech'		     => {
-				  'name' => 'E-tech Router',
-				  'url'  => '/Status.htm',
-				  'skip' => 'Public IP Address',
+    'e-tech'             => {
+                  'name' => 'E-tech Router',
+                  'url'  => '/Status.htm',
+                  'skip' => 'Public IP Address',
                               },
-    'cayman-3220h'	     => {
-				  'name' => 'Cayman 3220-H DSL',
-				  'url'  => '/shell/show+ip+interfaces',
-				  'skip' => '.*inet',
+    'cayman-3220h'       => {
+                  'name' => 'Cayman 3220-H DSL',
+                  'url'  => '/shell/show+ip+interfaces',
+                  'skip' => '.*inet',
                               },
     'vigor-2200usb'           => {
-				  'name' => 'Vigor 2200 USB',
-				  'url'  => '/doc/online.sht',
-				  'skip' => 'PPPoA',
-			      },
+                  'name' => 'Vigor 2200 USB',
+                  'url'  => '/doc/online.sht',
+                  'skip' => 'PPPoA',
+                  },
     'dlink-614'            => {
-				  'name' => 'D-Link DI-614+',
-				  'url'  => '/st_devic.html',
-				  'skip' => 'WAN',
-			      },
+                  'name' => 'D-Link DI-614+',
+                  'url'  => '/st_devic.html',
+                  'skip' => 'WAN',
+                  },
     'dlink-604'            => {
-				  'name' => 'D-Link DI-604',
-				  'url'  => '/st_devic.html',
-				  'skip' => 'WAN.*?IP.*Address',
-			      },
+                  'name' => 'D-Link DI-604',
+                  'url'  => '/st_devic.html',
+                  'skip' => 'WAN.*?IP.*Address',
+                  },
     'olitec-SX200'            => {
-				  'name' => 'olitec-SX200',
-				  'url'  => '/doc/wan.htm',
-				  'skip' => 'st_wan_ip[0] = "',
-			      },
+                  'name' => 'olitec-SX200',
+                  'url'  => '/doc/wan.htm',
+                  'skip' => 'st_wan_ip[0] = "',
+                  },
     'westell-6100'            => {
-				  'name' => 'Westell C90-610015-06 DSL Router',
-				  'url'  => '/advstat.htm',
-				  'skip' => 'IP.+?Address',
-			      },
+                  'name' => 'Westell C90-610015-06 DSL Router',
+                  'url'  => '/advstat.htm',
+                  'skip' => 'IP.+?Address',
+                  },
      '2wire'                  => {
                                  'name' => '2Wire 1701HG Gateway',
                                  'url'  => '/xslt?PAGE=B01',
@@ -302,168 +302,168 @@ sub ip_strategies_usage {
 }
 
 my %web_strategies = (
-	'dyndns'=> 1,
-	'dnspark'=> 1,
-	'loopia'=> 1,
+    'dyndns'=> 1,
+    'dnspark'=> 1,
+    'loopia'=> 1,
 );
 
 sub setv {
     return {
-	'type'     => shift,
-	'required' => shift,
-	'cache'    => shift,
-	'config'   => shift,
-	'default'  => shift,
-	'minimum'  => shift,
+    'type'     => shift,
+    'required' => shift,
+    'cache'    => shift,
+    'config'   => shift,
+    'default'  => shift,
+    'minimum'  => shift,
     };
 };
 my %variables = (
     'global-defaults'    => {
-	'daemon'              => setv(T_DELAY, 0, 0, 1, 0,                    interval('60s')),
-	'foreground'          => setv(T_BOOL,  0, 0, 1, 0,                    undef),
-	'file'                => setv(T_FILE,  0, 0, 1, "$etc$program.conf",  undef),
-	'cache'               => setv(T_FILE,  0, 0, 1, "$cachedir$program.cache", undef),
-	'pid'                 => setv(T_FILE,  0, 0, 1, "",                   undef),
-	'proxy'               => setv(T_FQDNP, 0, 0, 1, '',                   undef),
-	'protocol'            => setv(T_PROTO, 0, 0, 1, 'dyndns2',            undef),
+    'daemon'              => setv(T_DELAY, 0, 0, 1, 0,                    interval('60s')),
+    'foreground'          => setv(T_BOOL,  0, 0, 1, 0,                    undef),
+    'file'                => setv(T_FILE,  0, 0, 1, "$etc$program.conf",  undef),
+    'cache'               => setv(T_FILE,  0, 0, 1, "$cachedir$program.cache", undef),
+    'pid'                 => setv(T_FILE,  0, 0, 1, "",                   undef),
+    'proxy'               => setv(T_FQDNP, 0, 0, 1, '',                   undef),
+    'protocol'            => setv(T_PROTO, 0, 0, 1, 'dyndns2',            undef),
 
-	'use'                 => setv(T_USE,   0, 0, 1, 'ip',                 undef),
-	'ip'                  => setv(T_IP,    0, 0, 1, undef,                undef),
-	'if'                  => setv(T_IF,    0, 0, 1, 'ppp0',               undef),
-	'if-skip'             => setv(T_STRING,1, 0, 1, '',                   undef),
-	'web'                 => setv(T_STRING,0, 0, 1, 'dyndns',             undef),
-	'web-skip'            => setv(T_STRING,1, 0, 1, '',                   undef),
-	'fw'                  => setv(T_ANY,   0, 0, 1, '', 		      undef),
-	'fw-skip'             => setv(T_STRING,1, 0, 1, '',                   undef),
-	'fw-banlocal'         => setv(T_BOOL,  0, 0, 1, 0,                    undef),
-	'fw-login'            => setv(T_LOGIN, 1, 0, 1, '',                   undef),
-	'fw-password'         => setv(T_PASSWD,1, 0, 1, '',                   undef),
-	'cmd'                 => setv(T_PROG,  0, 0, 1, '',                   undef),
-	'cmd-skip'            => setv(T_STRING,1, 0, 1, '',                   undef),
+    'use'                 => setv(T_USE,   0, 0, 1, 'ip',                 undef),
+    'ip'                  => setv(T_IP,    0, 0, 1, undef,                undef),
+    'if'                  => setv(T_IF,    0, 0, 1, 'ppp0',               undef),
+    'if-skip'             => setv(T_STRING,1, 0, 1, '',                   undef),
+    'web'                 => setv(T_STRING,0, 0, 1, 'dyndns',             undef),
+    'web-skip'            => setv(T_STRING,1, 0, 1, '',                   undef),
+    'fw'                  => setv(T_ANY,   0, 0, 1, '',               undef),
+    'fw-skip'             => setv(T_STRING,1, 0, 1, '',                   undef),
+    'fw-banlocal'         => setv(T_BOOL,  0, 0, 1, 0,                    undef),
+    'fw-login'            => setv(T_LOGIN, 1, 0, 1, '',                   undef),
+    'fw-password'         => setv(T_PASSWD,1, 0, 1, '',                   undef),
+    'cmd'                 => setv(T_PROG,  0, 0, 1, '',                   undef),
+    'cmd-skip'            => setv(T_STRING,1, 0, 1, '',                   undef),
 
-	'timeout'             => setv(T_DELAY, 0, 0, 1, interval('120s'),     interval('120s')),
-	'retry'               => setv(T_BOOL,  0, 0, 0, 0,                    undef),
-	'force'               => setv(T_BOOL,  0, 0, 0, 0,                    undef),
-	'ssl'                 => setv(T_BOOL,  0, 0, 0, 0,                    undef),
+    'timeout'             => setv(T_DELAY, 0, 0, 1, interval('120s'),     interval('120s')),
+    'retry'               => setv(T_BOOL,  0, 0, 0, 0,                    undef),
+    'force'               => setv(T_BOOL,  0, 0, 0, 0,                    undef),
+    'ssl'                 => setv(T_BOOL,  0, 0, 0, 0,                    undef),
 
-	'syslog'              => setv(T_BOOL,  0, 0, 1, 0,                    undef),
-	'facility'            => setv(T_STRING,0, 0, 1, 'daemon',             undef),
-	'priority'            => setv(T_STRING,0, 0, 1, 'notice',             undef),
+    'syslog'              => setv(T_BOOL,  0, 0, 1, 0,                    undef),
+    'facility'            => setv(T_STRING,0, 0, 1, 'daemon',             undef),
+    'priority'            => setv(T_STRING,0, 0, 1, 'notice',             undef),
         'mail'                => setv(T_EMAIL, 0, 0, 1, '',                   undef),
         'mail-failure'        => setv(T_EMAIL, 0, 0, 1, '',                   undef),
 
-	'exec'                => setv(T_BOOL,  0, 0, 1, 1,                    undef),
-	'debug'               => setv(T_BOOL,  0, 0, 1, 0,                    undef),
-	'verbose'             => setv(T_BOOL,  0, 0, 1, 0,                    undef),
-	'quiet'               => setv(T_BOOL,  0, 0, 1, 0,                    undef),
-	'help'                => setv(T_BOOL,  0, 0, 1, 0,                    undef),
-	'test'                => setv(T_BOOL,  0, 0, 1, 0,                    undef),
-	'geturl'              => setv(T_STRING,0, 0, 0, '',                   undef),
+    'exec'                => setv(T_BOOL,  0, 0, 1, 1,                    undef),
+    'debug'               => setv(T_BOOL,  0, 0, 1, 0,                    undef),
+    'verbose'             => setv(T_BOOL,  0, 0, 1, 0,                    undef),
+    'quiet'               => setv(T_BOOL,  0, 0, 1, 0,                    undef),
+    'help'                => setv(T_BOOL,  0, 0, 1, 0,                    undef),
+    'test'                => setv(T_BOOL,  0, 0, 1, 0,                    undef),
+    'geturl'              => setv(T_STRING,0, 0, 0, '',                   undef),
 
-	'postscript'          => setv(T_POSTS, 0, 0, 1, '',                   undef),
+    'postscript'          => setv(T_POSTS, 0, 0, 1, '',                   undef),
     },
     'service-common-defaults'       => {
-	'server'	      => setv(T_FQDNP,  1, 0, 1, 'members.dyndns.org', undef),
-	'login'               => setv(T_LOGIN,  1, 0, 1, '',                  undef),
-	'password'            => setv(T_PASSWD, 1, 0, 1, '',                  undef),
-	'host'                => setv(T_STRING, 1, 1, 1, '',                  undef),
+    'server'          => setv(T_FQDNP,  1, 0, 1, 'members.dyndns.org', undef),
+    'login'               => setv(T_LOGIN,  1, 0, 1, '',                  undef),
+    'password'            => setv(T_PASSWD, 1, 0, 1, '',                  undef),
+    'host'                => setv(T_STRING, 1, 1, 1, '',                  undef),
 
-	'use'                 => setv(T_USE,   0, 0, 1, 'ip',                 undef),
-	'if'                  => setv(T_IF,    0, 0, 1, 'ppp0',               undef),
-	'if-skip'             => setv(T_STRING,0, 0, 1, '',                   undef),
-	'web'                 => setv(T_STRING,0, 0, 1, 'dyndns',             undef),
-	'web-skip'            => setv(T_STRING,0, 0, 1, '',                   undef),
-	'fw'                  => setv(T_ANY,   0, 0, 1, '', 		      undef),
-	'fw-skip'             => setv(T_STRING,0, 0, 1, '',                   undef),
-	'fw-banlocal'         => setv(T_BOOL,  0, 0, 1, 0,                    undef),
-	'fw-login'            => setv(T_LOGIN, 0, 0, 1, '',                   undef),
-	'fw-password'         => setv(T_PASSWD,0, 0, 1, '',                   undef),
-	'cmd'                 => setv(T_PROG,  0, 0, 1, '',                   undef),
-	'cmd-skip'            => setv(T_STRING,0, 0, 1, '',                   undef),
+    'use'                 => setv(T_USE,   0, 0, 1, 'ip',                 undef),
+    'if'                  => setv(T_IF,    0, 0, 1, 'ppp0',               undef),
+    'if-skip'             => setv(T_STRING,0, 0, 1, '',                   undef),
+    'web'                 => setv(T_STRING,0, 0, 1, 'dyndns',             undef),
+    'web-skip'            => setv(T_STRING,0, 0, 1, '',                   undef),
+    'fw'                  => setv(T_ANY,   0, 0, 1, '',               undef),
+    'fw-skip'             => setv(T_STRING,0, 0, 1, '',                   undef),
+    'fw-banlocal'         => setv(T_BOOL,  0, 0, 1, 0,                    undef),
+    'fw-login'            => setv(T_LOGIN, 0, 0, 1, '',                   undef),
+    'fw-password'         => setv(T_PASSWD,0, 0, 1, '',                   undef),
+    'cmd'                 => setv(T_PROG,  0, 0, 1, '',                   undef),
+    'cmd-skip'            => setv(T_STRING,0, 0, 1, '',                   undef),
 
-	'ip'                  => setv(T_IP,     0, 1, 0, undef,               undef),
-	'wtime'               => setv(T_DELAY,  0, 1, 1, 0,                   interval('30s')),
-	'mtime'               => setv(T_NUMBER, 0, 1, 0, 0,                   undef),
-	'atime'               => setv(T_NUMBER, 0, 1, 0, 0,                   undef),
-	'status'              => setv(T_ANY,    0, 1, 0, '',                  undef),
-	'min-interval'        => setv(T_DELAY,  0, 0, 1, interval('30s'),     0),
-	'max-interval'        => setv(T_DELAY,  0, 0, 1, interval('25d'),     0),
-	'min-error-interval'  => setv(T_DELAY,  0, 0, 1, interval('5m'),      0),
+    'ip'                  => setv(T_IP,     0, 1, 0, undef,               undef),
+    'wtime'               => setv(T_DELAY,  0, 1, 1, 0,                   interval('30s')),
+    'mtime'               => setv(T_NUMBER, 0, 1, 0, 0,                   undef),
+    'atime'               => setv(T_NUMBER, 0, 1, 0, 0,                   undef),
+    'status'              => setv(T_ANY,    0, 1, 0, '',                  undef),
+    'min-interval'        => setv(T_DELAY,  0, 0, 1, interval('30s'),     0),
+    'max-interval'        => setv(T_DELAY,  0, 0, 1, interval('25d'),     0),
+    'min-error-interval'  => setv(T_DELAY,  0, 0, 1, interval('5m'),      0),
 
-	'warned-min-interval'       => setv(T_ANY,    0, 1, 0, 0,             undef),
-	'warned-min-error-interval' => setv(T_ANY,    0, 1, 0, 0,             undef),
+    'warned-min-interval'       => setv(T_ANY,    0, 1, 0, 0,             undef),
+    'warned-min-error-interval' => setv(T_ANY,    0, 1, 0, 0,             undef),
     },
     'dyndns-common-defaults'       => {
-	'static'              => setv(T_BOOL,   0, 1, 1, 0,                   undef),
-	'wildcard'            => setv(T_BOOL,   0, 1, 1, 0,                   undef),
-	'mx'	              => setv(T_OFQDN,  0, 1, 1, '',                  undef),
-	'backupmx'            => setv(T_BOOL,   0, 1, 1, 0,                   undef),
+    'static'              => setv(T_BOOL,   0, 1, 1, 0,                   undef),
+    'wildcard'            => setv(T_BOOL,   0, 1, 1, 0,                   undef),
+    'mx'                  => setv(T_OFQDN,  0, 1, 1, '',                  undef),
+    'backupmx'            => setv(T_BOOL,   0, 1, 1, 0,                   undef),
     },
     'easydns-common-defaults'       => {
-	'wildcard'            => setv(T_BOOL,   0, 1, 1, 0,                   undef),
-	'mx'	              => setv(T_OFQDN,  0, 1, 1, '',                  undef),
-	'backupmx'            => setv(T_BOOL,   0, 1, 1, 0,                   undef),
+    'wildcard'            => setv(T_BOOL,   0, 1, 1, 0,                   undef),
+    'mx'                  => setv(T_OFQDN,  0, 1, 1, '',                  undef),
+    'backupmx'            => setv(T_BOOL,   0, 1, 1, 0,                   undef),
     },
     'dnspark-common-defaults'       => {
-	'mx'	              => setv(T_OFQDN,  0, 1, 1, '',                  undef),
-	'mxpri'               => setv(T_NUMBER, 0, 0, 1, 5,                   undef),
+    'mx'                  => setv(T_OFQDN,  0, 1, 1, '',                  undef),
+    'mxpri'               => setv(T_NUMBER, 0, 0, 1, 5,                   undef),
     },
     'noip-common-defaults'       => {
-	'static'              => setv(T_BOOL,   0, 1, 1, 0,                   undef),
+    'static'              => setv(T_BOOL,   0, 1, 1, 0,                   undef),
     },
     'noip-service-common-defaults'       => {
-	'server'	      => setv(T_FQDNP,  1, 0, 1, 'dynupdate.no-ip.com', undef),
-	'login'               => setv(T_LOGIN,  1, 0, 1, '',                  undef),
-	'password'            => setv(T_PASSWD, 1, 0, 1, '',                  undef),
-	'host'                => setv(T_STRING, 1, 1, 1, '',                  undef),
-	'ip'                  => setv(T_IP,     0, 1, 0, undef,               undef),
-	'wtime'               => setv(T_DELAY,  0, 1, 1, 0,                   interval('30s')),
-	'mtime'               => setv(T_NUMBER, 0, 1, 0, 0,                   undef),
-	'atime'               => setv(T_NUMBER, 0, 1, 0, 0,                   undef),
-	'status'              => setv(T_ANY,    0, 1, 0, '',                  undef),
-	'min-interval'        => setv(T_DELAY,  0, 0, 1, interval('30s'),     0),
-	'max-interval'        => setv(T_DELAY,  0, 0, 1, interval('25d'),     0),
-	'min-error-interval'  => setv(T_DELAY,  0, 0, 1, interval('5m'),      0),
-	'warned-min-interval'       => setv(T_ANY,    0, 1, 0, 0,             undef),
-	'warned-min-error-interval' => setv(T_ANY,    0, 1, 0, 0,             undef),
+    'server'          => setv(T_FQDNP,  1, 0, 1, 'dynupdate.no-ip.com', undef),
+    'login'               => setv(T_LOGIN,  1, 0, 1, '',                  undef),
+    'password'            => setv(T_PASSWD, 1, 0, 1, '',                  undef),
+    'host'                => setv(T_STRING, 1, 1, 1, '',                  undef),
+    'ip'                  => setv(T_IP,     0, 1, 0, undef,               undef),
+    'wtime'               => setv(T_DELAY,  0, 1, 1, 0,                   interval('30s')),
+    'mtime'               => setv(T_NUMBER, 0, 1, 0, 0,                   undef),
+    'atime'               => setv(T_NUMBER, 0, 1, 0, 0,                   undef),
+    'status'              => setv(T_ANY,    0, 1, 0, '',                  undef),
+    'min-interval'        => setv(T_DELAY,  0, 0, 1, interval('30s'),     0),
+    'max-interval'        => setv(T_DELAY,  0, 0, 1, interval('25d'),     0),
+    'min-error-interval'  => setv(T_DELAY,  0, 0, 1, interval('5m'),      0),
+    'warned-min-interval'       => setv(T_ANY,    0, 1, 0, 0,             undef),
+    'warned-min-error-interval' => setv(T_ANY,    0, 1, 0, 0,             undef),
     },
     'zoneedit-service-common-defaults'       => {
         'zone'                => setv(T_OFQDN,  0, 0, 1, undef,               undef),
     },
     'dtdns-common-defaults'       => {
-	'login'               => setv(T_LOGIN,  0, 0, 0, 'unused',            undef),
-	'client'              => setv(T_STRING, 0, 1, 1, $program,            undef),
+    'login'               => setv(T_LOGIN,  0, 0, 0, 'unused',            undef),
+    'client'              => setv(T_STRING, 0, 1, 1, $program,            undef),
     },
     'nsupdate-common-defaults' => {
-	'ttl'                 => setv(T_NUMBER, 0, 1, 0, 600,                 undef),
-	'zone'                => setv(T_STRING, 1, 1, 1, '',                  undef),
+    'ttl'                 => setv(T_NUMBER, 0, 1, 0, 600,                 undef),
+    'zone'                => setv(T_STRING, 1, 1, 1, '',                  undef),
     },
-	'cloudflare-common-defaults'       => {
-		'server'	      => setv(T_FQDNP,  1, 0, 1, 'www.cloudflare.com', undef),
-		'zone'                => setv(T_FQDN,   1, 0, 1, '',                  undef),
-		'static'              => setv(T_BOOL,   0, 1, 1, 0,                   undef),
-		'wildcard'            => setv(T_BOOL,   0, 1, 1, 0,                   undef),
-		'mx'	              => setv(T_OFQDN,  0, 1, 1, '',                  undef),
-		'backupmx'            => setv(T_BOOL,   0, 1, 1, 0,                   undef),
-		'ttl'		      => setv(T_NUMBER, 1, 0, 1, 1,                   undef),
-	},
-	'googledomains-common-defaults'       => {
-		'server'	      => setv(T_FQDNP,  1, 0, 1, 'domains.google.com', undef),
-	},
-	'duckdns-common-defaults'       => {
-			'server'              => setv(T_FQDNP,  1, 0, 1, 'www.duckdns.org', undef),
-			'login'               => setv(T_LOGIN,  0, 0, 0, 'unused',            undef),
-	},
+    'cloudflare-common-defaults'       => {
+        'server'          => setv(T_FQDNP,  1, 0, 1, 'www.cloudflare.com', undef),
+        'zone'                => setv(T_FQDN,   1, 0, 1, '',                  undef),
+        'static'              => setv(T_BOOL,   0, 1, 1, 0,                   undef),
+        'wildcard'            => setv(T_BOOL,   0, 1, 1, 0,                   undef),
+        'mx'                  => setv(T_OFQDN,  0, 1, 1, '',                  undef),
+        'backupmx'            => setv(T_BOOL,   0, 1, 1, 0,                   undef),
+        'ttl'             => setv(T_NUMBER, 1, 0, 1, 1,                   undef),
+    },
+    'googledomains-common-defaults'       => {
+        'server'          => setv(T_FQDNP,  1, 0, 1, 'domains.google.com', undef),
+    },
+    'duckdns-common-defaults'       => {
+            'server'              => setv(T_FQDNP,  1, 0, 1, 'www.duckdns.org', undef),
+            'login'               => setv(T_LOGIN,  0, 0, 0, 'unused',            undef),
+    },
     'woima-common-defaults'       => {
         'static'              => setv(T_BOOL,   0, 1, 1, 0,                   undef),
         'wildcard'            => setv(T_BOOL,   0, 1, 1, 0,                   undef),
-        'mx'	              => setv(T_OFQDN,  0, 1, 1, '',                  undef),
+        'mx'                  => setv(T_OFQDN,  0, 1, 1, '',                  undef),
         'backupmx'            => setv(T_BOOL,   0, 1, 1, 0,                   undef),
         'custom'              => setv(T_BOOL,   0, 1, 1, 0,                   undef),
         'script'              => setv(T_STRING, 1, 1, 1, '/nic/update',       undef),
     },
     'woima-service-common-defaults'       => {
-        'server'	          => setv(T_FQDNP,  1, 0, 1, 'dyn.woima.fi',      undef),
+        'server'              => setv(T_FQDNP,  1, 0, 1, 'dyn.woima.fi',      undef),
         'login'               => setv(T_LOGIN,  1, 0, 1, '',                  undef),
         'password'            => setv(T_PASSWD, 1, 0, 1, '',                  undef),
         'ip'                  => setv(T_IP,     0, 1, 0, undef,               undef),
@@ -480,35 +480,35 @@ my %variables = (
 );
 my %services = (
     'dyndns1' => {
-	'updateable' => \&nic_dyndns2_updateable,
-	'update'     => \&nic_dyndns1_update,
-	'examples'   => \&nic_dyndns1_examples,
-	'variables'  => merge(
-			  $variables{'dyndns-common-defaults'},
-			  $variables{'service-common-defaults'},
-		        ),
+    'updateable' => \&nic_dyndns2_updateable,
+    'update'     => \&nic_dyndns1_update,
+    'examples'   => \&nic_dyndns1_examples,
+    'variables'  => merge(
+              $variables{'dyndns-common-defaults'},
+              $variables{'service-common-defaults'},
+                ),
     },
     'dyndns2' => {
-	'updateable' => \&nic_dyndns2_updateable,
-	'update'     => \&nic_dyndns2_update,
-	'examples'   => \&nic_dyndns2_examples,
-	'variables'  => merge(
-			  { 'custom'  => setv(T_BOOL,   0, 1, 1, 0, undef),	},
-			  { 'script'  => setv(T_STRING, 1, 1, 1, '/nic/update', undef),	},
-#			  { 'offline' => setv(T_BOOL,   0, 1, 1, 0, undef),	},
-			  $variables{'dyndns-common-defaults'},
-			  $variables{'service-common-defaults'},
-		        ),
+    'updateable' => \&nic_dyndns2_updateable,
+    'update'     => \&nic_dyndns2_update,
+    'examples'   => \&nic_dyndns2_examples,
+    'variables'  => merge(
+              { 'custom'  => setv(T_BOOL,   0, 1, 1, 0, undef), },
+              { 'script'  => setv(T_STRING, 1, 1, 1, '/nic/update', undef), },
+#             { 'offline' => setv(T_BOOL,   0, 1, 1, 0, undef), },
+              $variables{'dyndns-common-defaults'},
+              $variables{'service-common-defaults'},
+                ),
     },
     'noip' => {
-	'updateable' => undef,
-	'update'     => \&nic_noip_update,
-	'examples'   => \&nic_noip_examples,
-	'variables'  => merge(
-			  { 'custom'  => setv(T_BOOL,   0, 1, 1, 0, undef),	},
-			  $variables{'noip-common-defaults'},
-			  $variables{'noip-service-common-defaults'},
-		        ),
+    'updateable' => undef,
+    'update'     => \&nic_noip_update,
+    'examples'   => \&nic_noip_examples,
+    'variables'  => merge(
+              { 'custom'  => setv(T_BOOL,   0, 1, 1, 0, undef), },
+              $variables{'noip-common-defaults'},
+              $variables{'noip-service-common-defaults'},
+                ),
     },
     'concont' => {
         'updateable' => undef,
@@ -521,56 +521,56 @@ my %services = (
                         ),
     },  
     'dslreports1' => {
-	'updateable' => undef,
-	'update'     => \&nic_dslreports1_update,
-	'examples'   => \&nic_dslreports1_examples,
-	'variables'  => merge(
-			  { 'host' => setv(T_NUMBER,   1, 1, 1, 0, undef)       },
-			  $variables{'service-common-defaults'},
-		        ),
+    'updateable' => undef,
+    'update'     => \&nic_dslreports1_update,
+    'examples'   => \&nic_dslreports1_examples,
+    'variables'  => merge(
+              { 'host' => setv(T_NUMBER,   1, 1, 1, 0, undef)       },
+              $variables{'service-common-defaults'},
+                ),
     },
     'hammernode1' => {
-	'updateable' => undef,
-	'update'     => \&nic_hammernode1_update,
-	'examples'   => \&nic_hammernode1_examples,
-	'variables'  => merge(
-			  { 'server'       => setv(T_FQDNP,  1, 0, 1, 'dup.hn.org',   undef)    },
-			  { 'min-interval' => setv(T_DELAY,  0, 0, 1, interval('5m'), 0),},
- 			  $variables{'service-common-defaults'},
-		        ),
+    'updateable' => undef,
+    'update'     => \&nic_hammernode1_update,
+    'examples'   => \&nic_hammernode1_examples,
+    'variables'  => merge(
+              { 'server'       => setv(T_FQDNP,  1, 0, 1, 'dup.hn.org',   undef)    },
+              { 'min-interval' => setv(T_DELAY,  0, 0, 1, interval('5m'), 0),},
+              $variables{'service-common-defaults'},
+                ),
     },
     'zoneedit1' => {
-	'updateable' => undef,
-	'update'     => \&nic_zoneedit1_update,
-	'examples'   => \&nic_zoneedit1_examples,
-	'variables'  => merge(
-			  { 'server'       => setv(T_FQDNP,  1, 0, 1, 'dynamic.zoneedit.com', undef)          },
-			  { 'min-interval' => setv(T_DELAY,  0, 0, 1, interval('5m'), 0),},
- 			  $variables{'service-common-defaults'},
- 			  $variables{'zoneedit-service-common-defaults'},
-		        ),
+    'updateable' => undef,
+    'update'     => \&nic_zoneedit1_update,
+    'examples'   => \&nic_zoneedit1_examples,
+    'variables'  => merge(
+              { 'server'       => setv(T_FQDNP,  1, 0, 1, 'dynamic.zoneedit.com', undef)          },
+              { 'min-interval' => setv(T_DELAY,  0, 0, 1, interval('5m'), 0),},
+              $variables{'service-common-defaults'},
+              $variables{'zoneedit-service-common-defaults'},
+                ),
     },
     'easydns' => {
-	'updateable' => undef,
-	'update'     => \&nic_easydns_update,
-	'examples'   => \&nic_easydns_examples,
-	'variables'  => merge(
-			  { 'server'       => setv(T_FQDNP,  1, 0, 1, 'members.easydns.com', undef)          },
-			  { 'min-interval' => setv(T_DELAY,  0, 0, 1, interval('5m'), 0),},
-			  $variables{'easydns-common-defaults'},
- 			  $variables{'service-common-defaults'},
-		        ),
+    'updateable' => undef,
+    'update'     => \&nic_easydns_update,
+    'examples'   => \&nic_easydns_examples,
+    'variables'  => merge(
+              { 'server'       => setv(T_FQDNP,  1, 0, 1, 'members.easydns.com', undef)          },
+              { 'min-interval' => setv(T_DELAY,  0, 0, 1, interval('5m'), 0),},
+              $variables{'easydns-common-defaults'},
+              $variables{'service-common-defaults'},
+                ),
     },
     'dnspark' => {
-	'updateable' => undef,
-	'update'     => \&nic_dnspark_update,
-	'examples'   => \&nic_dnspark_examples,
-	'variables'  => merge(
-			  { 'server'       => setv(T_FQDNP,  1, 0, 1, 'www.dnspark.com', undef)          },
-			  { 'min-interval' => setv(T_DELAY,  0, 0, 1, interval('5m'), 0),},
-			  $variables{'dnspark-common-defaults'},
- 			  $variables{'service-common-defaults'},
-		        ),
+    'updateable' => undef,
+    'update'     => \&nic_dnspark_update,
+    'examples'   => \&nic_dnspark_examples,
+    'variables'  => merge(
+              { 'server'       => setv(T_FQDNP,  1, 0, 1, 'www.dnspark.com', undef)          },
+              { 'min-interval' => setv(T_DELAY,  0, 0, 1, interval('5m'), 0),},
+              $variables{'dnspark-common-defaults'},
+              $variables{'service-common-defaults'},
+                ),
     },
     'namecheap' => {
         'updateable' => undef,
@@ -597,39 +597,39 @@ my %services = (
         'update'     => \&nic_freedns_update,
         'examples'   => \&nic_freedns_examples,
         'variables'  => merge(
-			  { 'server'       => setv(T_FQDNP,  1, 0, 1, 'freedns.afraid.org',    undef)    },
-			  { 'min-interval' => setv(T_DELAY,  0, 0, 1, 0, interval('5m')),},
-			  $variables{'service-common-defaults'},
-			),
+              { 'server'       => setv(T_FQDNP,  1, 0, 1, 'freedns.afraid.org',    undef)    },
+              { 'min-interval' => setv(T_DELAY,  0, 0, 1, 0, interval('5m')),},
+              $variables{'service-common-defaults'},
+            ),
     },
     'changeip' => {
         'updateable' => undef,
         'update'     => \&nic_changeip_update,
         'examples'   => \&nic_changeip_examples,
         'variables'  => merge(
-			  { 'server'       => setv(T_FQDNP,  1, 0, 1, 'nic.changeip.com',    undef)    },
-			  { 'min-interval' => setv(T_DELAY,  0, 0, 1, 0, interval('5m')),},
-			  $variables{'service-common-defaults'},
-			),
+              { 'server'       => setv(T_FQDNP,  1, 0, 1, 'nic.changeip.com',    undef)    },
+              { 'min-interval' => setv(T_DELAY,  0, 0, 1, 0, interval('5m')),},
+              $variables{'service-common-defaults'},
+            ),
     },
     'dtdns' => {
-	'updateable' => undef,
-	'update'     => \&nic_dtdns_update,
-	'examples'   => \&nic_dtdns_examples,
-	'variables'  => merge(
-			  $variables{'dtdns-common-defaults'},
-			  $variables{'service-common-defaults'},
-		        ),
+    'updateable' => undef,
+    'update'     => \&nic_dtdns_update,
+    'examples'   => \&nic_dtdns_examples,
+    'variables'  => merge(
+              $variables{'dtdns-common-defaults'},
+              $variables{'service-common-defaults'},
+                ),
     },
     'nsupdate' => {
-	'updateable' => undef,
-	'update'     => \&nic_nsupdate_update,
-	'examples'   => \&nic_nsupdate_examples,
-	'variables'  => merge(
-			  { 'login'        => setv(T_LOGIN, 1, 0, 1, '/usr/bin/nsupdate', undef), },
-			  $variables{'nsupdate-common-defaults'},
-			  $variables{'service-common-defaults'},
-	),
+    'updateable' => undef,
+    'update'     => \&nic_nsupdate_update,
+    'examples'   => \&nic_nsupdate_examples,
+    'variables'  => merge(
+              { 'login'        => setv(T_LOGIN, 1, 0, 1, '/usr/bin/nsupdate', undef), },
+              $variables{'nsupdate-common-defaults'},
+              $variables{'service-common-defaults'},
+    ),
     },
     'cloudflare' => {
         'updateable' => undef,
@@ -672,9 +672,9 @@ my %services = (
     },
 );
 $variables{'merged'} = merge($variables{'global-defaults'},
-			     $variables{'service-common-defaults'},
-			     $variables{'dyndns-common-defaults'},
-			     map { $services{$_}{'variables'} } keys %services,
+                 $variables{'service-common-defaults'},
+                 $variables{'dyndns-common-defaults'},
+                 map { $services{$_}{'variables'} } keys %services,
 );
 
 my @opt = (
@@ -688,12 +688,12 @@ my @opt = (
     [ "file",        "=s", "-file path            : load configuration information from 'path'" ],
     [ "cache",       "=s", "-cache path           : record address used in 'path'" ],
     [ "pid",         "=s", "-pid path             : record process id in 'path'" ],
-    "",			     
+    "",              
     [ "use",         "=s", "-use which            : how the should IP address be obtained." ],
                                                   &ip_strategies_usage(),
-    "",			     
+    "",              
     [ "ip",          "=s", "-ip address           : set the IP address to 'address'" ],
-    "",			     
+    "",              
     [ "if",          "=s", "-if interface         : obtain IP address from 'interface'" ],
     [ "if-skip",     "=s", "-if-skip pattern      : skip any IP addresses before 'pattern' in the output of ifconfig {if}" ],
     "",
@@ -705,16 +705,16 @@ my @opt = (
     [ "fw-banlocal", "!", "-fw-banlocal           : ignore local IP addresses on the firewall address|url" ],
     [ "fw-login",    "=s", "-fw-login login       :   use 'login' when getting IP from fw" ],
     [ "fw-password", "=s", "-fw-password secret   :   use password 'secret' when getting IP from fw" ],
-    "",			     
+    "",              
     [ "cmd",         "=s", "-cmd program          : obtain IP address from by calling {program}" ],
     [ "cmd-skip",    "=s", "-cmd-skip pattern     : skip any IP addresses before 'pattern' in the output of {cmd}" ],
-    "",			     
+    "",              
     [ "login",       "=s", "-login user           : login as 'user'" ],
     [ "password",    "=s", "-password secret      : use password 'secret'" ],
     [ "host",        "=s", "-host host            : update DNS information for 'host'" ],
-    "",			     
+    "",              
     [ "options",     "=s",  "-options opt,opt     : optional per-service arguments (see below)" ],
-    "",			     
+    "",              
     [ "ssl",         "!",  "-{no}ssl              : do updates over encrypted SSL connection" ],
     [ "retry",       "!",  "-{no}retry            : retry failed updates." ],
     [ "force",       "!",  "-{no}force            : force an update even if the update may be unnecessary" ],
@@ -778,10 +778,10 @@ if (opt('foreground') || opt('force')) {
     $SIG{'CHLD'}   = 'IGNORE';
     my $pid = fork;
     if ($pid < 0) {
-	print STDERR "${program}: can not fork ($!)\n";
-	exit -1;
+    print STDERR "${program}: can not fork ($!)\n";
+    exit -1;
     } elsif ($pid) {
-	exit 0;
+    exit 0;
     }
     $SIG{'CHLD'}   = 'DEFAULT';
     open(STDOUT, ">/dev/null");
@@ -803,9 +803,9 @@ do {
     %opt = %saved_opt;
     if (opt('help')) {
             *STDERR = *STDOUT;
-    		printf("Help found");
-	           # usage();
-		        }
+            printf("Help found");
+               # usage();
+                }
 
     read_config(define($opt{'file'}, default('file')), \%config, \%globals);
     init_config();
@@ -822,29 +822,29 @@ do {
     update_nics();
 
     if ($daemon) {
-	debug("sleep %s",  $daemon);
-	sendmail();
+    debug("sleep %s",  $daemon);
+    sendmail();
 
-	my $left = $daemon;
-	while (($left > 0) && !$caught_hup && !$caught_term && !$caught_kill) {
-		my $delay = $left > 10 ? 10 : $left;
+    my $left = $daemon;
+    while (($left > 0) && !$caught_hup && !$caught_term && !$caught_kill) {
+        my $delay = $left > 10 ? 10 : $left;
 
-		$0 = sprintf("%s - sleeping for %s seconds", $program, $left);
-        	$left -= sleep $delay;
-		# preventing deep sleep - see [bugs:#46]
-		if ($left > $daemon) {
-			$left = $daemon;
-		}
-	}
-	$caught_hup = 0;
-	$result = 0;
+        $0 = sprintf("%s - sleeping for %s seconds", $program, $left);
+            $left -= sleep $delay;
+        # preventing deep sleep - see [bugs:#46]
+        if ($left > $daemon) {
+            $left = $daemon;
+        }
+    }
+    $caught_hup = 0;
+    $result = 0;
 
     } elsif (! scalar(%config)) {
-	warning("no hosts to update.") unless !opt('quiet') || opt('verbose') || !$daemon;
-	$result = 1;
+    warning("no hosts to update.") unless !opt('quiet') || opt('verbose') || !$daemon;
+    $result = 1;
 
     } else {
-	$result = $result eq 'OK' ? 0 : 1;
+    $result = $result eq 'OK' ? 0 : 1;
     }
 } while ($daemon && !$result && !$caught_term && !$caught_kill);
 
@@ -859,81 +859,81 @@ exit($result);
 ######################################################################
 
 sub runpostscript {
-	my ($ip) = @_;
+    my ($ip) = @_;
 
-	if ( defined $globals{postscript} ) {
-		if ( -x $globals{postscript}) {
-			system ("$globals{postscript} $ip &");
-		} else {
-			warning ("Can not execute post script: %s", $globals{postscript}); 
-		}
-	}
+    if ( defined $globals{postscript} ) {
+        if ( -x $globals{postscript}) {
+            system ("$globals{postscript} $ip &");
+        } else {
+            warning ("Can not execute post script: %s", $globals{postscript}); 
+        }
+    }
 } 
 
 ######################################################################
 ## update_nics
 ######################################################################
 sub update_nics {
-	my %examined = ();
-	my %iplist = ();
+    my %examined = ();
+    my %iplist = ();
 
-	foreach my $s (sort keys %services) {
-		my (@hosts, %ips) = ();
-		my $updateable = $services{$s}{'updateable'};
-		my $update     = $services{$s}{'update'};
+    foreach my $s (sort keys %services) {
+        my (@hosts, %ips) = ();
+        my $updateable = $services{$s}{'updateable'};
+        my $update     = $services{$s}{'update'};
 
-		foreach my $h (sort keys %config) {
-			next if $config{$h}{'protocol'} ne lc($s);
-			$examined{$h} = 1;
-			# we only do this once per 'use' and argument combination
-			my $use = opt('use', $h);
-			my $arg_ip = opt('ip', $h) || '';
-			my $arg_fw = opt('fw', $h) || '';
-			my $arg_if = opt('if', $h) || '';
-			my $arg_web = opt('web', $h) || '';
-			my $arg_cmd = opt('cmd', $h) || '';
-			my $ip = "";
-			if (exists $iplist{$use}{$arg_ip}{$arg_fw}{$arg_if}{$arg_web}{$arg_cmd}) {
-				$ip = $iplist{$use}{$arg_ip}{$arg_fw}{$arg_if}{$arg_web}{$arg_cmd};
-			} else {
-				$ip = get_ip($use, $h);
-				if (!defined $ip || !$ip) {
-					warning("unable to determine IP address")
-						if !$daemon || opt('verbose');
-					next;
-				}
-				if ($ip !~ /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/) {
-					warning("malformed IP address (%s)", $ip);
-					next;
-				}
-				$iplist{$use}{$arg_ip}{$arg_fw}{$arg_if}{$arg_web}{$arg_cmd} = $ip;
-			}
-			$config{$h}{'wantip'} = $ip;
-			next if !nic_updateable($h, $updateable);
-			push @hosts, $h;
-			$ips{$ip} = $h;
-		}
-		if (@hosts) {
-			$0 = sprintf("%s - updating %s", $program, join(',', @hosts));
-			&$update(@hosts);
-			runpostscript(join ' ', keys %ips);
-		}
-	}
-	foreach my $h (sort keys %config) {
-		if (!exists $examined{$h}) {
-			failed("%s was not updated because protocol %s is not supported.", 
-					$h, define($config{$h}{'protocol'}, '<undefined>')
-				  );
-		}
-	}
-	write_cache(opt('cache'));
+        foreach my $h (sort keys %config) {
+            next if $config{$h}{'protocol'} ne lc($s);
+            $examined{$h} = 1;
+            # we only do this once per 'use' and argument combination
+            my $use = opt('use', $h);
+            my $arg_ip = opt('ip', $h) || '';
+            my $arg_fw = opt('fw', $h) || '';
+            my $arg_if = opt('if', $h) || '';
+            my $arg_web = opt('web', $h) || '';
+            my $arg_cmd = opt('cmd', $h) || '';
+            my $ip = "";
+            if (exists $iplist{$use}{$arg_ip}{$arg_fw}{$arg_if}{$arg_web}{$arg_cmd}) {
+                $ip = $iplist{$use}{$arg_ip}{$arg_fw}{$arg_if}{$arg_web}{$arg_cmd};
+            } else {
+                $ip = get_ip($use, $h);
+                if (!defined $ip || !$ip) {
+                    warning("unable to determine IP address")
+                        if !$daemon || opt('verbose');
+                    next;
+                }
+                if ($ip !~ /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/) {
+                    warning("malformed IP address (%s)", $ip);
+                    next;
+                }
+                $iplist{$use}{$arg_ip}{$arg_fw}{$arg_if}{$arg_web}{$arg_cmd} = $ip;
+            }
+            $config{$h}{'wantip'} = $ip;
+            next if !nic_updateable($h, $updateable);
+            push @hosts, $h;
+            $ips{$ip} = $h;
+        }
+        if (@hosts) {
+            $0 = sprintf("%s - updating %s", $program, join(',', @hosts));
+            &$update(@hosts);
+            runpostscript(join ' ', keys %ips);
+        }
+    }
+    foreach my $h (sort keys %config) {
+        if (!exists $examined{$h}) {
+            failed("%s was not updated because protocol %s is not supported.", 
+                    $h, define($config{$h}{'protocol'}, '<undefined>')
+                  );
+        }
+    }
+    write_cache(opt('cache'));
 }
 ######################################################################
 ## unlink_pid()
 ######################################################################
 sub unlink_pid {
-    if (opt('pid') && opt('daemon')) {	
-	unlink opt('pid');
+    if (opt('pid') && opt('daemon')) {  
+    unlink opt('pid');
     }
 }
 
@@ -943,15 +943,15 @@ sub unlink_pid {
 sub write_pid {
     my $file = opt('pid');
 
-    if ($file && opt('daemon')) {	
+    if ($file && opt('daemon')) {   
         local *FD;
-	if (! open(FD, "> $file")) {
-	    warning("Cannot create file '%s'. ($!)", $file);
+    if (! open(FD, "> $file")) {
+        warning("Cannot create file '%s'. ($!)", $file);
 
-    	} else {
-       	    printf FD "$$\n";
-	    close(FD);
-	}
+        } else {
+            printf FD "$$\n";
+        close(FD);
+    }
     }
 }
 
@@ -963,35 +963,35 @@ sub write_cache {
 
     ## merge the updated host entries into the cache.
     foreach my $h (keys %config) {
-	if (! exists $cache{$h} || $config{$h}{'update'}) {
-	    map {$cache{$h}{$_} = $config{$h}{$_} } @{$config{$h}{'cacheable'}};
+    if (! exists $cache{$h} || $config{$h}{'update'}) {
+        map {$cache{$h}{$_} = $config{$h}{$_} } @{$config{$h}{'cacheable'}};
 
-	} else {
-	    map {$cache{$h}{$_} = $config{$h}{$_} } qw(atime wtime status);
-	}
+    } else {
+        map {$cache{$h}{$_} = $config{$h}{$_} } qw(atime wtime status);
+    }
     }
 
     ## construct the cache file.
     my $cache = "";
     foreach my $h (sort keys %cache) {
-    	my $opt = join(',', map { "$_=".define($cache{$h}{$_},'') } sort keys %{$cache{$h}});
-	    
+        my $opt = join(',', map { "$_=".define($cache{$h}{$_},'') } sort keys %{$cache{$h}});
+        
         $cache .= sprintf "%s%s%s\n", $opt, ($opt ? ' ' : ''), $h;
     }
     $file = '' if defined($saved_cache) && $cache eq $saved_cache;
 
     ## write the updates and other entries to the cache file.
     if ($file) {
-	$saved_cache = undef;
-	local *FD;
-	if (! open(FD, "> $file")) {
-	    fatal("Cannot create file '%s'. ($!)", $file);
-	}
-	printf FD "## $program-$version\n";
-	printf FD "## last updated at %s (%d)\n", prettytime($now), $now;
-	printf FD $cache;
+    $saved_cache = undef;
+    local *FD;
+    if (! open(FD, "> $file")) {
+        fatal("Cannot create file '%s'. ($!)", $file);
+    }
+    printf FD "## $program-$version\n";
+    printf FD "## last updated at %s (%d)\n", prettytime($now), $now;
+    printf FD $cache;
 
-	close(FD);
+    close(FD);
     }
 }
 ######################################################################
@@ -1005,18 +1005,18 @@ sub read_cache {
     %{$config} = ();
     ## read the cache file ignoring anything on the command-line.
     if (-e $file) {
-	my %saved = %opt;
-	%opt   = ();
-	$saved_cache = _read_config($config, $globals, "##\\s*$program-$version\\s*", $file);
-	%opt   = %saved;
+    my %saved = %opt;
+    %opt   = ();
+    $saved_cache = _read_config($config, $globals, "##\\s*$program-$version\\s*", $file);
+    %opt   = %saved;
 
-	foreach my $h (keys %cache) {
-	    if (exists $config->{$h}) {
-		foreach (qw(atime mtime wtime ip status)) {
-	    	    $config->{$h}{$_} = $cache{$h}{$_} if exists $cache{$h}{$_};
-		}
-	    }
-	}
+    foreach my $h (keys %cache) {
+        if (exists $config->{$h}) {
+        foreach (qw(atime mtime wtime ip status)) {
+                $config->{$h}{$_} = $cache{$h}{$_} if exists $cache{$h}{$_};
+        }
+        }
+    }
     }
 }
 ######################################################################
@@ -1030,13 +1030,13 @@ sub parse_assignments {
     my ($name, $value);
 
     while (1) {
-	$rest =~ s/^\s+//;
+    $rest =~ s/^\s+//;
         ($name, $value, $rest) = parse_assignment($rest, @args);
-	if (defined $name) {
-	    $variables{$name} = $value;
-	} else {
-	    last;
-	}
+    if (defined $name) {
+        $variables{$name} = $value;
+    } else {
+        last;
+    }
     }
     return ($rest, %variables);
 }
@@ -1047,25 +1047,25 @@ sub parse_assignment {
     my ($escape, $quote) = (0, '');
 
     if ($rest =~ /^\s*([a-z][a-z_-]*)=(.*)/i) {
-	($name, $rest, $value) = ($1, $2, '');
+    ($name, $rest, $value) = ($1, $2, '');
 
-	while (length($c = substr($rest,0,1))) {
-	    $rest = substr($rest,1);
-	    if ($escape) {
-		$value .= $c;
-		$escape = 0;
-	    } elsif ($c eq "\\") {
-		$escape = 1;
-	    } elsif ($quote && $c eq $quote) {
-		$quote = ''
-	    } elsif (!$quote && $c =~ /[\'\"]/) {
-		$quote = $c;
-	    } elsif (!$quote && $c =~ /^${stop}/) {
-		last;
-	    } else {
-		$value .= $c;
-	    }
-	}
+    while (length($c = substr($rest,0,1))) {
+        $rest = substr($rest,1);
+        if ($escape) {
+        $value .= $c;
+        $escape = 0;
+        } elsif ($c eq "\\") {
+        $escape = 1;
+        } elsif ($quote && $c eq $quote) {
+        $quote = ''
+        } elsif (!$quote && $c =~ /[\'\"]/) {
+        $quote = $c;
+        } elsif (!$quote && $c =~ /^${stop}/) {
+        last;
+        } else {
+        $value .= $c;
+        }
+    }
     }
     warning("assignment ended with an open quote") if $quote;
     return ($name, $value, $rest);
@@ -1092,78 +1092,78 @@ sub _read_config {
 
     local *FD;
     if (! open(FD, "< $file")) {
-	# fatal("Cannot open file '%s'. ($!)", $file);
-	warning("Cannot open file '%s'. ($!)", $file);
+    # fatal("Cannot open file '%s'. ($!)", $file);
+    warning("Cannot open file '%s'. ($!)", $file);
     }
     # Check for only owner has any access to config file
     my ($dev, $ino, $mode, @statrest) = stat(FD);
     if ($mode & 077) {                          
-	if (-f FD && (chmod 0600, $file)) {
-	    warning("file $file must be accessible only by its owner (fixed).");
-	} else {
-	    # fatal("file $file must be accessible only by its owner.");
-	    warning("file $file must be accessible only by its owner.");
-	}
+    if (-f FD && (chmod 0600, $file)) {
+        warning("file $file must be accessible only by its owner (fixed).");
+    } else {
+        # fatal("file $file must be accessible only by its owner.");
+        warning("file $file must be accessible only by its owner.");
+    }
     }
 
     local $lineno       = 0;
     my    $continuation = '';
     my    %passwords    = ();
     while (<FD>) {
-	s/[\r\n]//g;
+    s/[\r\n]//g;
 
-	$lineno++;
+    $lineno++;
 
-	## check for the program version stamp
-	if (($. == 1) && $stamp && ($_ !~ /^$stamp$/i)) {
-	    warning("program version mismatch; ignoring %s", $file);
-	    last;
-	}
+    ## check for the program version stamp
+    if (($. == 1) && $stamp && ($_ !~ /^$stamp$/i)) {
+        warning("program version mismatch; ignoring %s", $file);
+        last;
+    }
     if (/\\\s+$/) {
-	    warning("whitespace follows the \\ at the end-of-line.\nIf you meant to have a line continuation, remove the trailing whitespace.");
+        warning("whitespace follows the \\ at the end-of-line.\nIf you meant to have a line continuation, remove the trailing whitespace.");
     }
 
     $content .= "$_\n" unless /^#/;
 
-	## parsing passwords is special
-	if (/^([^#]*\s)?([^#]*?password\S*?)\s*=\s*('.*'|[^']\S*)(.*)/) {
-	    my ($head, $key, $value, $tail) = ($1 || '', $2, $3, $4);
-	    $value = $1 if $value =~ /^'(.*)'$/;
-	    $passwords{$key} = $value;
-	    $_ = "${head}${key}=dummy${tail}";
-	}
+    ## parsing passwords is special
+    if (/^([^#]*\s)?([^#]*?password\S*?)\s*=\s*('.*'|[^']\S*)(.*)/) {
+        my ($head, $key, $value, $tail) = ($1 || '', $2, $3, $4);
+        $value = $1 if $value =~ /^'(.*)'$/;
+        $passwords{$key} = $value;
+        $_ = "${head}${key}=dummy${tail}";
+    }
 
         ## remove comments
-	s/#.*//;
+    s/#.*//;
 
-	## handle continuation lines
-	$_ = "$continuation$_";
-	if (/\\$/) {
-	    chop;
-	    $continuation = $_;
-	    next;
-	}
-	$continuation = '';
+    ## handle continuation lines
+    $_ = "$continuation$_";
+    if (/\\$/) {
+        chop;
+        $continuation = $_;
+        next;
+    }
+    $continuation = '';
 
-	s/^\s+//;		# remove leading white space
-	s/\s+$//;		# remove trailing white space
-	s/\s+/ /g;		# canonify
-	next if /^$/;
+    s/^\s+//;       # remove leading white space
+    s/\s+$//;       # remove trailing white space
+    s/\s+/ /g;      # canonify
+    next if /^$/;
 
-	## expected configuration line is:
-	##   [opt=value,opt=..] [host [login [password]]]
-	my %locals;
-	($_, %locals) = parse_assignments($_);
-	s/\s*,\s*/,/g;
-	my @args = split;
-	
-	## verify that keywords are valid...and check the value
-	foreach my $k (keys %locals) {
-	    $locals{$k} = $passwords{$k} if defined $passwords{$k};
-	    if (!exists $variables{'merged'}{$k}) {
+    ## expected configuration line is:
+    ##   [opt=value,opt=..] [host [login [password]]]
+    my %locals;
+    ($_, %locals) = parse_assignments($_);
+    s/\s*,\s*/,/g;
+    my @args = split;
+    
+    ## verify that keywords are valid...and check the value
+    foreach my $k (keys %locals) {
+        $locals{$k} = $passwords{$k} if defined $passwords{$k};
+        if (!exists $variables{'merged'}{$k}) {
             warning("unrecognized keyword '%s' (ignored)", $k);
             delete $locals{$k};
-	    } else {
+        } else {
             my $def = $variables{'merged'}{$k};
             my $value = check_value($locals{$k}, $def);
             if (!defined($value)) {
@@ -1171,34 +1171,34 @@ sub _read_config {
                 delete $locals{$k};
             } else { $locals{$k} = $value; }
         }
-	}
-	if (exists($locals{'host'})) {
-	    $args[0] = @args ? "$args[0],$locals{host}" : "$locals{host}";
-	}
-	## accumulate globals
-	if ($#args < 0) {
-	    map { $globals{$_} = $locals{$_} } keys %locals;
-	}
-	
-	## process this host definition
-	if (@args) {
-	    my ($host, $login, $password) = @args;
-	    
-	    ## add in any globals..
-	    %locals = %{ merge(\%locals, \%globals) };
-	    
-	    ## override login and password if specified the old way.
-	    $locals{'login'}    = $login    if defined $login;
-	    $locals{'password'} = $password if defined $password;
-	    
-	    ## allow {host} to be a comma separated list of hosts 
-	    foreach my $h (split_by_comma($host)) {
-		## save a copy of the current globals
-		$config{$h}         = { %locals };
-		$config{$h}{'host'} = $h;
-	    }
-	}
-	%passwords = ();
+    }
+    if (exists($locals{'host'})) {
+        $args[0] = @args ? "$args[0],$locals{host}" : "$locals{host}";
+    }
+    ## accumulate globals
+    if ($#args < 0) {
+        map { $globals{$_} = $locals{$_} } keys %locals;
+    }
+    
+    ## process this host definition
+    if (@args) {
+        my ($host, $login, $password) = @args;
+        
+        ## add in any globals..
+        %locals = %{ merge(\%locals, \%globals) };
+        
+        ## override login and password if specified the old way.
+        $locals{'login'}    = $login    if defined $login;
+        $locals{'password'} = $password if defined $password;
+        
+        ## allow {host} to be a comma separated list of hosts 
+        foreach my $h (split_by_comma($host)) {
+        ## save a copy of the current globals
+        $config{$h}         = { %locals };
+        $config{$h}{'host'} = $h;
+        }
+    }
+    %passwords = ();
     }
     close(FD);
     
@@ -1240,56 +1240,56 @@ sub init_config {
     
     ## define or modify host options specified on the command-line
     if (exists $opt{'options'} && defined $opt{'options'}) {
-	## collect cmdline configuration options.
-	my %options = ();
-	foreach my $opt (split_by_comma($opt{'options'})) {
-	    my ($name,$var) = split /\s*=\s*/, $opt;
-	    $options{$name} = $var;
-	}
-	## determine hosts specified with -host
-	my @hosts = ();
-	if (exists  $opt{'host'}) {
-	    foreach my $h (split_by_comma($opt{'host'})) {
-		push @hosts, $h;
-	    }
-	}
-	## and those in -options=...
-	if (exists  $options{'host'}) {
-	    foreach my $h (split_by_comma($options{'host'})) {
-		push @hosts, $h;
-	    }
-	    delete $options{'host'};
-	}
-	## merge options into host definitions or globals
-	if (@hosts) {
-	    foreach my $h (@hosts) {
-		$config{$h} = merge(\%options, $config{$h});
-	    }
-	    $opt{'host'} = join(',', @hosts);
-	} else {
-	    %globals = %{ merge(\%options, \%globals) };
-	}
+    ## collect cmdline configuration options.
+    my %options = ();
+    foreach my $opt (split_by_comma($opt{'options'})) {
+        my ($name,$var) = split /\s*=\s*/, $opt;
+        $options{$name} = $var;
+    }
+    ## determine hosts specified with -host
+    my @hosts = ();
+    if (exists  $opt{'host'}) {
+        foreach my $h (split_by_comma($opt{'host'})) {
+        push @hosts, $h;
+        }
+    }
+    ## and those in -options=...
+    if (exists  $options{'host'}) {
+        foreach my $h (split_by_comma($options{'host'})) {
+        push @hosts, $h;
+        }
+        delete $options{'host'};
+    }
+    ## merge options into host definitions or globals
+    if (@hosts) {
+        foreach my $h (@hosts) {
+        $config{$h} = merge(\%options, $config{$h});
+        }
+        $opt{'host'} = join(',', @hosts);
+    } else {
+        %globals = %{ merge(\%options, \%globals) };
+    }
     }
 
     ## override global options with those on the command-line.
     foreach my $o (keys %opt) {
-	if (defined $opt{$o} && exists $variables{'global-defaults'}{$o}) {
-	    $globals{$o} = $opt{$o};
-	}
+    if (defined $opt{$o} && exists $variables{'global-defaults'}{$o}) {
+        $globals{$o} = $opt{$o};
+    }
     }
 
     ## sanity check
     if (defined $opt{'host'} && defined $opt{'retry'}) {
-	usage("options -retry and -host (or -option host=..) are mutually exclusive");
+    usage("options -retry and -host (or -option host=..) are mutually exclusive");
     }
 
     ## determine hosts to update (those on the cmd-line, config-file, or failed cached)
     my @hosts = keys %config;
     if (opt('host')) {
-	@hosts = split_by_comma($opt{'host'});
+    @hosts = split_by_comma($opt{'host'});
     }
     if (opt('retry')) {
-	@hosts = map { $_ if $cache{$_}{'status'} ne 'good' } keys %cache;
+    @hosts = map { $_ if $cache{$_}{'status'} ne 'good' } keys %cache;
     }
 
     ## remove any other hosts 
@@ -1299,60 +1299,60 @@ sub init_config {
 
     ## collect the cacheable variables.
     foreach my $proto (keys %services) {
-	my @cacheable = ();
-	foreach my $k (keys %{$services{$proto}{'variables'}}) {
-	    push @cacheable, $k if $services{$proto}{'variables'}{$k}{'cache'};
-	}
-	$services{$proto}{'cacheable'} = [ @cacheable ];
+    my @cacheable = ();
+    foreach my $k (keys %{$services{$proto}{'variables'}}) {
+        push @cacheable, $k if $services{$proto}{'variables'}{$k}{'cache'};
+    }
+    $services{$proto}{'cacheable'} = [ @cacheable ];
     }
 
     ## sanity check..
     ## make sure config entries have all defaults and they meet minimums
     ## first the globals...
     foreach my $k (keys %globals) {
-	my $def    = $variables{'merged'}{$k};
-	my $ovalue = define($globals{$k}, $def->{'default'});
-	my $value  = check_value($ovalue, $def);
-	if ($def->{'required'} && !defined $value) {
-	    $value = default($k);
-	    warning("'%s=%s' is an invalid %s. (using default of %s)", $k, $ovalue, $def->{'type'}, $value);
-	}
-	$globals{$k} = $value;
+    my $def    = $variables{'merged'}{$k};
+    my $ovalue = define($globals{$k}, $def->{'default'});
+    my $value  = check_value($ovalue, $def);
+    if ($def->{'required'} && !defined $value) {
+        $value = default($k);
+        warning("'%s=%s' is an invalid %s. (using default of %s)", $k, $ovalue, $def->{'type'}, $value);
+    }
+    $globals{$k} = $value;
     }
 
     ## now the host definitions...
   HOST:
     foreach my $h (keys %config) {
-	my $proto;
-	$proto = $config{$h}{'protocol'};
-	$proto = opt('protocol')          if !defined($proto);
+    my $proto;
+    $proto = $config{$h}{'protocol'};
+    $proto = opt('protocol')          if !defined($proto);
 
-	load_sha1_support() if ($proto eq "freedns");
-	load_json_support() if ($proto eq "cloudflare");
+    load_sha1_support() if ($proto eq "freedns");
+    load_json_support() if ($proto eq "cloudflare");
 
- 	if (!exists($services{$proto})) {
-	    warning("skipping host: %s: unrecognized protocol '%s'", $h, $proto);
-	    delete $config{$h};
+    if (!exists($services{$proto})) {
+        warning("skipping host: %s: unrecognized protocol '%s'", $h, $proto);
+        delete $config{$h};
 
-	} else {
-	    my $svars    = $services{$proto}{'variables'};
-	    my $conf     = { 'protocol' => $proto };
+    } else {
+        my $svars    = $services{$proto}{'variables'};
+        my $conf     = { 'protocol' => $proto };
 
-	    foreach my $k (keys %$svars) {
-		my $def    = $svars->{$k};
-		my $ovalue = define($config{$h}{$k}, $def->{'default'});
-		my $value  = check_value($ovalue, $def);
-		if ($def->{'required'} && !defined $value) {
-		    warning("skipping host: %s: '%s=%s' is an invalid %s.", $h, $k, $ovalue, $def->{'type'});
-		    delete $config{$h};
-		    next HOST;
-		}
-		$conf->{$k} = $value;
+        foreach my $k (keys %$svars) {
+        my $def    = $svars->{$k};
+        my $ovalue = define($config{$h}{$k}, $def->{'default'});
+        my $value  = check_value($ovalue, $def);
+        if ($def->{'required'} && !defined $value) {
+            warning("skipping host: %s: '%s=%s' is an invalid %s.", $h, $k, $ovalue, $def->{'type'});
+            delete $config{$h};
+            next HOST;
+        }
+        $conf->{$k} = $value;
 
-	    }
-	    $config{$h} = $conf;
-	    $config{$h}{'cacheable'} = [ @{$services{$proto}{'cacheable'}} ];
-	}
+        }
+        $config{$h} = $conf;
+        $config{$h}{'cacheable'} = [ @{$services{$proto}{'cacheable'}} ];
+    }
     }
 }
 
@@ -1364,10 +1364,10 @@ sub usage {
     $exitcode = shift if @_ != 0; # use first arg if given
     my $msg = '';
     if (@_) {
-	my $format = shift;
-	$msg .= sprintf $format, @_;
-	1 while chomp($msg);
-    	$msg .= "\n";
+    my $format = shift;
+    $msg .= sprintf $format, @_;
+    1 while chomp($msg);
+        $msg .= "\n";
     }
     printf STDERR "%s%s\n", $msg, $opt_usage;
     sendmail();
@@ -1383,39 +1383,39 @@ sub process_args {
     my %opts  = ();
     
     foreach (@_) {
-	if (ref $_) {
-	    my ($key, $specifier, $arg_usage) = @$_;
-	    my $value = default($key);
-	    
-	    ## add a option specifier
-	    push @spec, $key . $specifier;
-	    
-	    ## define the default value which can be overwritten later
-	    $opt{$key} = undef;
-	    
-	    next unless $arg_usage;
+    if (ref $_) {
+        my ($key, $specifier, $arg_usage) = @$_;
+        my $value = default($key);
+        
+        ## add a option specifier
+        push @spec, $key . $specifier;
+        
+        ## define the default value which can be overwritten later
+        $opt{$key} = undef;
+        
+        next unless $arg_usage;
 
-	    ## add a line to the usage;
-	    $usage .= "  $arg_usage";
-	    if (defined($value) && $value ne '') {
-		$usage .= " (default: ";
-		if ($specifier eq '!') {
-		    $usage .= "no" if ($specifier eq '!') && !$value;
-		    $usage .= $key;
-		} else {
-		    $usage .= $value;
-		}
-		$usage .= ")";
-	    }
-	    $usage .= ".";
-	} else {
-	    $usage .= $_;
-	}
-	$usage .= "\n";
+        ## add a line to the usage;
+        $usage .= "  $arg_usage";
+        if (defined($value) && $value ne '') {
+        $usage .= " (default: ";
+        if ($specifier eq '!') {
+            $usage .= "no" if ($specifier eq '!') && !$value;
+            $usage .= $key;
+        } else {
+            $usage .= $value;
+        }
+        $usage .= ")";
+        }
+        $usage .= ".";
+    } else {
+        $usage .= $_;
+    }
+    $usage .= "\n";
     }
     ## process the arguments
     if (! GetOptions(\%opt, @spec)) {
-	$opt{"help"} = 1;
+    $opt{"help"} = 1;
     }
     return ($usage, %opt);
 }
@@ -1426,40 +1426,40 @@ sub test_possible_ip {
     local $opt{'debug'} = 0;
 
     printf "use=ip, ip=%s address is %s\n", opt('ip'), define(get_ip('ip'), 'NOT FOUND')
-	if defined opt('ip');
+    if defined opt('ip');
 
     {
-	local $opt{'use'} = 'if';
-	foreach my $if (grep {/^[a-zA-Z]/} `ifconfig -a`) {
-	    $if =~ s/:?\s.*//is;
-	    local $opt{'if'} = $if;
-	    printf "use=if, if=%s address is %s\n", opt('if'), define(get_ip('if'), 'NOT FOUND');
-	}
+    local $opt{'use'} = 'if';
+    foreach my $if (grep {/^[a-zA-Z]/} `ifconfig -a`) {
+        $if =~ s/:?\s.*//is;
+        local $opt{'if'} = $if;
+        printf "use=if, if=%s address is %s\n", opt('if'), define(get_ip('if'), 'NOT FOUND');
+    }
     }
     if (opt('fw')) {
-	if (opt('fw') !~ m%/%) {
-	    foreach my $fw (sort keys %builtinfw) {
-	    	local $opt{'use'} = $fw;
-	    	printf "use=$fw address is %s\n", define(get_ip($fw), 'NOT FOUND');
-	    }
-	}
-	local $opt{'use'} = 'fw';
-	printf "use=fw, fw=%s address is %s\n", opt('fw'), define(get_ip(opt('fw')), 'NOT FOUND')
-	    if ! exists $builtinfw{opt('fw')};
-	
+    if (opt('fw') !~ m%/%) {
+        foreach my $fw (sort keys %builtinfw) {
+            local $opt{'use'} = $fw;
+            printf "use=$fw address is %s\n", define(get_ip($fw), 'NOT FOUND');
+        }
+    }
+    local $opt{'use'} = 'fw';
+    printf "use=fw, fw=%s address is %s\n", opt('fw'), define(get_ip(opt('fw')), 'NOT FOUND')
+        if ! exists $builtinfw{opt('fw')};
+    
     }
     {
-	local $opt{'use'} = 'web';
-	foreach my $web (sort keys %builtinweb) {
-	    local $opt{'web'} = $web;
-	    printf "use=web, web=$web address is %s\n", define(get_ip('web'), 'NOT FOUND');
-	}
-	printf "use=web, web=%s address is %s\n", opt('web'), define(get_ip('web'), 'NOT FOUND')
-	    if ! exists $builtinweb{opt('web')};
+    local $opt{'use'} = 'web';
+    foreach my $web (sort keys %builtinweb) {
+        local $opt{'web'} = $web;
+        printf "use=web, web=$web address is %s\n", define(get_ip('web'), 'NOT FOUND');
+    }
+    printf "use=web, web=%s address is %s\n", opt('web'), define(get_ip('web'), 'NOT FOUND')
+        if ! exists $builtinweb{opt('web')};
     }
     if (opt('cmd')) {
-	local $opt{'use'} = 'cmd';
-	printf "use=cmd, cmd=%s address is %s\n", opt('cmd'), define(get_ip('cmd'), 'NOT FOUND');
+    local $opt{'use'} = 'cmd';
+    printf "use=cmd, cmd=%s address is %s\n", opt('cmd'), define(get_ip('cmd'), 'NOT FOUND');
     }
     exit 0 unless opt('debug');
 }
@@ -1482,17 +1482,17 @@ sub load_file {
     my $buffer = '';
 
     if (exists($ENV{'TEST_CASE'})) {
-	my $try = "$file-$ENV{'TEST_CASE'}";
-	$file = $try if -f $try;
+    my $try = "$file-$ENV{'TEST_CASE'}";
+    $file = $try if -f $try;
     }
 
     local *FD;
     if (open(FD, "< $file")) {
-	read(FD, $buffer, -s FD);
-	close(FD);
-	debug("Loaded %d bytes from %s", length($buffer), $file);
+    read(FD, $buffer, -s FD);
+    close(FD);
+    debug("Loaded %d bytes from %s", length($buffer), $file);
     } else {
-	debug("Load failed from %s ($!)", $file);
+    debug("Load failed from %s ($!)", $file);
     }
     return $buffer
 }
@@ -1504,16 +1504,16 @@ sub save_file {
 
     $file .= "-$ENV{'TEST_CASE'}" if exists $ENV{'TEST_CASE'};
     if (defined $opt) {
-	my $i = 0;
-	while (-f "$file-$i") {
-	    if ('unique' =~ /^$opt/i) {
-		my $a = join('\n', grep {!/^Date:/} split /\n/, $buffer);
-		my $b = join('\n', grep {!/^Date:/} split /\n/, load_file("$file-$i"));
-		last if $a eq $b;
-	    }
-	    $i++;
-	}
-	$file = "$file-$i";
+    my $i = 0;
+    while (-f "$file-$i") {
+        if ('unique' =~ /^$opt/i) {
+        my $a = join('\n', grep {!/^Date:/} split /\n/, $buffer);
+        my $b = join('\n', grep {!/^Date:/} split /\n/, load_file("$file-$i"));
+        last if $a eq $b;
+        }
+        $i++;
+    }
+    $file = "$file-$i";
     }
     debug("Saving to %s", $file);
     local *FD;
@@ -1536,10 +1536,10 @@ sub _print_hash {
     if (! defined($ptr)) {
         $value = "<undefined>";
     } elsif (ref $ptr eq 'HASH') {
-	foreach my $key (sort keys %$ptr) {
-	    _print_hash("${string}\{$key\}", $ptr->{$key});
-	}
-	return;
+    foreach my $key (sort keys %$ptr) {
+        _print_hash("${string}\{$key\}", $ptr->{$key});
+    }
+    return;
     }
     printf "%-36s : %s\n", $string, $value;
 }
@@ -1559,7 +1559,7 @@ sub print_info {
     print_cache();
 }
 ######################################################################
-## pipecmd	- run an external command
+## pipecmd  - run an external command
 ## logger
 ## sendmail
 ######################################################################
@@ -1577,28 +1577,28 @@ sub pipecmd {
     ## execute the command.
     local *FD;
     if (! open(FD, $cmd)) {
-	printf STDERR "$program: cannot execute command %s.\n", $cmd;
+    printf STDERR "$program: cannot execute command %s.\n", $cmd;
 
     } elsif ($stdin && (! print FD "$stdin\n")) {
-	printf STDERR "$program: failed writting to %s.\n", $cmd;
-	close(FD);
+    printf STDERR "$program: failed writting to %s.\n", $cmd;
+    close(FD);
 
     } elsif (! close(FD)) {
-	printf STDERR "$program: failed closing %s.($@)\n", $cmd;
+    printf STDERR "$program: failed closing %s.($@)\n", $cmd;
 
     } elsif (opt('exec') && $?) {
-	printf STDERR "$program: failed %s. ($@)\n", $cmd;
+    printf STDERR "$program: failed %s. ($@)\n", $cmd;
 
     } else {
-	$ok = 1;
+    $ok = 1;
     }
     return $ok;
 }
 sub logger {
     if (opt('syslog') && opt('facility') &&  opt('priority')) { 
-	my $facility = opt('facility');
-	my $priority = opt('priority');
-    	return pipecmd("logger -p$facility.$priority -t${program}\[$$\]", @_);
+    my $facility = opt('facility');
+    my $priority = opt('priority');
+        return pipecmd("logger -p$facility.$priority -t${program}\[$$\]", @_);
     }
     return 1;
 }
@@ -1606,28 +1606,28 @@ sub sendmail {
     my $recipients = opt('mail');
 
     if (opt('mail-failure') && ($result ne 'OK' && $result ne '0')) {
-	$recipients = opt('mail-failure');
+    $recipients = opt('mail-failure');
     }
     if ($msgs && $recipients && $msgs ne $last_msgs) {
-	pipecmd("sendmail -oi $recipients",
-		"To: $recipients",
-		"Subject: status report from $program\@$hostname",
-		"\r\n",
-		$msgs,
-		"",
-		"regards,",
-		"   $program\@$hostname (version $version)"
-	);
+    pipecmd("sendmail -oi $recipients",
+        "To: $recipients",
+        "Subject: status report from $program\@$hostname",
+        "\r\n",
+        $msgs,
+        "",
+        "regards,",
+        "   $program\@$hostname (version $version)"
+    );
     }
     $last_msgs = $msgs;
     $msgs      = '';
 }
 ######################################################################
-##  split_by_comma		
+##  split_by_comma      
 ##  merge
 ##  default    
 ##  minimum    
-##  opt		
+##  opt     
 ######################################################################
 sub split_by_comma {
     my $string = shift;
@@ -1638,9 +1638,9 @@ sub split_by_comma {
 sub merge {
     my %merged = ();
     foreach my $h (@_) {
-	foreach my $k (keys %$h) {
-	    $merged{$k} = $h->{$k} unless exists $merged{$k};
-	}
+    foreach my $k (keys %$h) {
+        $merged{$k} = $h->{$k} unless exists $merged{$k};
+    }
     }
     return \%merged;
 }
@@ -1656,22 +1656,22 @@ sub opt {
     my $v = shift;
     my $h = shift;
     return $config{$h}{$v}   if defined($h && $config{$h}{$v});
-    return $opt{$v} 	if defined $opt{$v};
-    return $globals{$v}	if defined $globals{$v};
+    return $opt{$v}     if defined $opt{$v};
+    return $globals{$v} if defined $globals{$v};
     return default($v)  if defined default($v);
     return undef;
 }
 sub min {
     my $min = shift;
     foreach my $arg (@_) {
-	$min = $arg if $arg < $min;
+    $min = $arg if $arg < $min;
     }
     return $min;
 }
 sub max {
     my $max = shift;
     foreach my $arg (@_) {
-	$max = $arg if $arg > $max;
+    $max = $arg if $arg > $max;
     }
     return $max;
 }
@@ -1680,7 +1680,7 @@ sub max {
 ######################################################################
 sub define {
     foreach (@_) {
-	return $_ if defined $_;
+    return $_ if defined $_;
     }
     return undef;
 }
@@ -1693,10 +1693,10 @@ sub ynu {
     return $no  if !defined($value) || !$value;
     return $yes if $value eq '1';
     foreach (qw(yes true)) {
-	return $yes if $_ =~ /^$value/i;
+    return $yes if $_ =~ /^$value/i;
     }
     foreach (qw(no false)) {
-	return $no if $_ =~ /^$value/i;
+    return $no if $_ =~ /^$value/i;
     }
     return $undef;
 }
@@ -1715,13 +1715,13 @@ sub _msg {
 
     $prefix = sprintf "%-9s ", $prefix if $prefix;
     if ($file) {
-	$prefix .= "file $file";
-	$prefix .= ", line $lineno" if $lineno;
-	$prefix .= ": ";
+    $prefix .= "file $file";
+    $prefix .= ", line $lineno" if $lineno;
+    $prefix .= ": ";
     }
     if ($prefix) {
-	$buffer = "$prefix$buffer";
-    	$buffer =~ s/\n/\n$prefix /g;
+    $buffer = "$prefix$buffer";
+        $buffer =~ s/\n/\n$prefix /g;
     }
     $buffer .= "\n";
     print $buffer;
@@ -1730,15 +1730,15 @@ sub _msg {
     logger($buffer)   if $log;
 
 }
-sub msg     { _msg(0, '',         @_);   	      			}
-sub verbose { _msg(1, @_)             if opt('verbose');		}
-sub info    { _msg(1, 'INFO:',    @_) if opt('verbose');	        }
-sub debug   { _msg(0, 'DEBUG:',   @_) if opt('debug');	                }
+sub msg     { _msg(0, '',         @_);                      }
+sub verbose { _msg(1, @_)             if opt('verbose');        }
+sub info    { _msg(1, 'INFO:',    @_) if opt('verbose');            }
+sub debug   { _msg(0, 'DEBUG:',   @_) if opt('debug');                  }
 sub debug2  { _msg(0, 'DEBUG:',   @_) if opt('debug') && opt('verbose');}
-sub warning { _msg(1, 'WARNING:', @_);			                }
-sub fatal   { _msg(1, 'FATAL:',   @_); sendmail(); exit(1);	        }
-sub success { _msg(1, 'SUCCESS:', @_);			                }
-sub failed  { _msg(1, 'FAILED:',  @_); $result = 'FAILED';	        }
+sub warning { _msg(1, 'WARNING:', @_);                          }
+sub fatal   { _msg(1, 'FATAL:',   @_); sendmail(); exit(1);         }
+sub success { _msg(1, 'SUCCESS:', @_);                          }
+sub failed  { _msg(1, 'FAILED:',  @_); $result = 'FAILED';          }
 sub prettytime   { return scalar(localtime(shift));   }
 
 sub prettyinterval {
@@ -1766,15 +1766,15 @@ sub prettyinterval {
 sub interval {
     my $value = shift;
     if ($value =~ /^(\d+)(seconds|s)/i) {
-	$value = $1;
+    $value = $1;
     } elsif ($value =~ /^(\d+)(minutes|m)/i) {
-	$value = $1 * 60;
+    $value = $1 * 60;
     } elsif ($value =~ /^(\d+)(hours|h)/i) {
-	$value = $1 * 60*60;
+    $value = $1 * 60*60;
     } elsif ($value =~ /^(\d+)(days|d)/i) {
-	$value = $1 * 60*60*24;
+    $value = $1 * 60*60*24;
     } elsif ($value !~ /^\d+$/) {
-	$value = undef;
+    $value = undef;
     }
     return $value;
 }
@@ -1800,57 +1800,57 @@ sub check_value {
     my $required = $def->{'required'};
 
     if (!defined $value && !$required) {
-	;
+    ;
 
     } elsif ($type eq T_DELAY) {
-	$value = interval($value);
-	$value = $min if defined($value) && defined($min) && $value < $min;
+    $value = interval($value);
+    $value = $min if defined($value) && defined($min) && $value < $min;
 
     } elsif ($type eq T_NUMBER) {
-	return undef if $value !~ /^\d+$/;
-	$value = $min if defined($min) && $value < $min;
+    return undef if $value !~ /^\d+$/;
+    $value = $min if defined($min) && $value < $min;
 
     } elsif ($type eq T_BOOL) {
-	if ($value =~ /^y(es)?$|^t(true)?$|^1$/i) {
-	    $value = 1;
-	} elsif ($value =~ /^n(o)?$|^f(alse)?$|^0$/i) {
-	    $value = 0;
-	} else {
-	    return undef;
-	}
+    if ($value =~ /^y(es)?$|^t(true)?$|^1$/i) {
+        $value = 1;
+    } elsif ($value =~ /^n(o)?$|^f(alse)?$|^0$/i) {
+        $value = 0;
+    } else {
+        return undef;
+    }
     } elsif ($type eq T_FQDN || $type eq T_OFQDN && $value ne '') {
-	$value = lc $value;
-	return undef if $value !~ /[^.]\.[^.]/;
+    $value = lc $value;
+    return undef if $value !~ /[^.]\.[^.]/;
 
     } elsif ($type eq T_FQDNP) {
-	$value = lc $value;
-	return undef if $value !~ /[^.]\.[^.].*(:\d+)?$/;
+    $value = lc $value;
+    return undef if $value !~ /[^.]\.[^.].*(:\d+)?$/;
 
     } elsif ($type eq T_PROTO) {
-	$value = lc $value;
-	return undef if ! exists $services{$value};
+    $value = lc $value;
+    return undef if ! exists $services{$value};
 
     } elsif ($type eq T_USE) {
-	$value = lc $value;
-	return undef if ! exists $ip_strategies{$value};
+    $value = lc $value;
+    return undef if ! exists $ip_strategies{$value};
 
     } elsif ($type eq T_FILE) {
-	return undef if $value eq "";
+    return undef if $value eq "";
 
     } elsif ($type eq T_IF) {
-	return undef if $value !~ /^[a-zA-Z0-9:._-]+$/;
+    return undef if $value !~ /^[a-zA-Z0-9:._-]+$/;
 
     } elsif ($type eq T_PROG) {
-	return undef if $value eq "";
+    return undef if $value eq "";
 
     } elsif ($type eq T_LOGIN) {
-	return undef if $value eq "";
+    return undef if $value eq "";
 
 #    } elsif ($type eq T_PASSWD) {
-#	return undef if $value =~ /:/;
+#   return undef if $value =~ /:/;
 
     } elsif ($type eq T_IP) {
-	return undef if $value !~ /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/;
+    return undef if $value !~ /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/;
     }
     return $value;
 }
@@ -1902,22 +1902,22 @@ On Debian, the package libdigest-sha1-perl or libdigest-sha-perl must be install
 EOM
     }
     if($sha1_loaded) {
-    	import  Digest::SHA1 (qw/sha1_hex/);
+        import  Digest::SHA1 (qw/sha1_hex/);
     } elsif($sha_loaded) {
-    	import  Digest::SHA (qw/sha1_hex/);
+        import  Digest::SHA (qw/sha1_hex/);
     }
 }
 ######################################################################
 ## load_json_support
 ######################################################################
 sub load_json_support {
-	my $json_loaded = eval {require JSON::Any};
-	unless ($json_loaded) {
-		fatal(<<"EOM");
+    my $json_loaded = eval {require JSON::Any};
+    unless ($json_loaded) {
+        fatal(<<"EOM");
 Error loading the Perl module JSON::Any needed for cloudflare update.
 EOM
-	}
-	import JSON::Any;
+    }
+    import JSON::Any;
 }
 ######################################################################
 ## geturl
@@ -1950,7 +1950,7 @@ sub geturl {
     if ( $force_ssl || ($globals{'ssl'} and (caller(1))[3] ne 'main::get_ip') ) {
         $use_ssl      = 1;
         $default_port = 443;
-		load_ssl_support;
+        load_ssl_support;
     } else {
         $use_ssl      = 0;
         $default_port = 80;
@@ -1984,71 +1984,71 @@ sub geturl {
     # local $^W = 0;
     $0 = sprintf("%s - connecting to %s port %s", $program, $peer, $port);
     if (! opt('exec')) {
-	debug("skipped network connection");
-	verbose("SENDING:", "%s", $request);
+    debug("skipped network connection");
+    verbose("SENDING:", "%s", $request);
     } elsif ($use_ssl) {
-	    $sd = IO::Socket::SSL->new(
+        $sd = IO::Socket::SSL->new(
             PeerAddr => $peer,
             PeerPort => $port,
             Proto => 'tcp',
             MultiHomed => 1,
             Timeout => opt('timeout'),
         );
-	    defined $sd or warning("cannot connect to $peer:$port socket: $@ " . IO::Socket::SSL::errstr());
+        defined $sd or warning("cannot connect to $peer:$port socket: $@ " . IO::Socket::SSL::errstr());
     } else {
-	    $sd = IO::Socket::INET->new(
+        $sd = IO::Socket::INET->new(
             PeerAddr => $peer,
             PeerPort => $port,
             Proto => 'tcp',
             MultiHomed => 1,
             Timeout => opt('timeout'),
         );
-	    defined $sd or warning("cannot connect to $peer:$port socket: $@");
+        defined $sd or warning("cannot connect to $peer:$port socket: $@");
     }
 
-	if (defined $sd) {
-		## send the request to the http server
-		verbose("CONNECTED: ", $use_ssl ? 'using SSL' : 'using HTTP');
-		verbose("SENDING:", "%s", $request);
+    if (defined $sd) {
+        ## send the request to the http server
+        verbose("CONNECTED: ", $use_ssl ? 'using SSL' : 'using HTTP');
+        verbose("SENDING:", "%s", $request);
 
-		$0 = sprintf("%s - sending to %s port %s", $program, $peer, $port);
-		my $result = syswrite $sd, $rq;
-		if ($result != length($rq)) {
-			warning("cannot send to $peer:$port ($!).");
-		} else {
-			$0 = sprintf("%s - reading from %s port %s", $program, $peer, $port);
-			eval {
-				local $SIG{'ALRM'} = sub { die "timeout";};
-				alarm(opt('timeout')) if opt('timeout') > 0;
-				while ($_ = <$sd>) {
-					$0 = sprintf("%s - read from %s port %s", $program, $peer, $port);
-					verbose("RECEIVE:", "%s", define($_, "<undefined>"));
-					$reply .= $_ if defined $_;
-				}
-				if (opt('timeout') > 0) {
-					alarm(0);
-				}
-			};
-			close($sd);
+        $0 = sprintf("%s - sending to %s port %s", $program, $peer, $port);
+        my $result = syswrite $sd, $rq;
+        if ($result != length($rq)) {
+            warning("cannot send to $peer:$port ($!).");
+        } else {
+            $0 = sprintf("%s - reading from %s port %s", $program, $peer, $port);
+            eval {
+                local $SIG{'ALRM'} = sub { die "timeout";};
+                alarm(opt('timeout')) if opt('timeout') > 0;
+                while ($_ = <$sd>) {
+                    $0 = sprintf("%s - read from %s port %s", $program, $peer, $port);
+                    verbose("RECEIVE:", "%s", define($_, "<undefined>"));
+                    $reply .= $_ if defined $_;
+                }
+                if (opt('timeout') > 0) {
+                    alarm(0);
+                }
+            };
+            close($sd);
 
-			if ($@ and $@ =~ /timeout/) {
-				warning("TIMEOUT: %s after %s seconds", $to, opt('timeout'));
-				$reply = '';
-			}
-			$reply = '' if !defined $reply;
-		}
-	}
-	$0 = sprintf("%s - closed %s port %s", $program, $peer, $port);
+            if ($@ and $@ =~ /timeout/) {
+                warning("TIMEOUT: %s after %s seconds", $to, opt('timeout'));
+                $reply = '';
+            }
+            $reply = '' if !defined $reply;
+        }
+    }
+    $0 = sprintf("%s - closed %s port %s", $program, $peer, $port);
 
     ## during testing simulate reading the URL
     if (opt('test')) {
-	my $filename = "$server/$url";
-	$filename =~ s|/|%2F|g;
-	if (opt('exec')) {
-	    $reply = save_file("${savedir}$filename", $reply, 'unique');
-	} else {
-	    $reply = load_file("${savedir}$filename");
-	}
+    my $filename = "$server/$url";
+    $filename =~ s|/|%2F|g;
+    if (opt('exec')) {
+        $reply = save_file("${savedir}$filename", $reply, 'unique');
+    } else {
+        $reply = load_file("${savedir}$filename");
+    }
     }
 
     $reply =~ s/\r//g if defined $reply;
@@ -2058,43 +2058,43 @@ sub geturl {
 ## un_zero_pad
 ######################################################################
 sub un_zero_pad {
-	my $in_str = shift(@_);
-	my @out_str = ();
+    my $in_str = shift(@_);
+    my @out_str = ();
 
-	if ($in_str eq '0.0.0.0') {
-	    return $in_str;
-	}
+    if ($in_str eq '0.0.0.0') {
+        return $in_str;
+    }
 
-	foreach my $block (split /\./, $in_str) {
-	    $block =~ s/^0+//;
-	    if ($block eq '') {
-		$block = '0';
-	    }
-	    push @out_str, $block;
-	}
-	return join('.', @out_str);
+    foreach my $block (split /\./, $in_str) {
+        $block =~ s/^0+//;
+        if ($block eq '') {
+        $block = '0';
+        }
+        push @out_str, $block;
+    }
+    return join('.', @out_str);
 }
 ######################################################################
 ## filter_local
 ######################################################################
 sub filter_local {
-	my $in_ip = shift(@_);
+    my $in_ip = shift(@_);
 
-	if ($in_ip eq '0.0.0.0') {
-	    return $in_ip;
-	}
+    if ($in_ip eq '0.0.0.0') {
+        return $in_ip;
+    }
 
-	my @guess_local = (
-	    '^10\.',
-	    '^172\.(?:1[6-9]|2[0-9]|3[01])\.',
-	    '^192\.168'
-	);
-	foreach my $block (@guess_local) {
-	    if ($in_ip =~ /$block/) {
-		return '0.0.0.0';
-	    }
-	}
-	return $in_ip;
+    my @guess_local = (
+        '^10\.',
+        '^172\.(?:1[6-9]|2[0-9]|3[01])\.',
+        '^192\.168'
+    );
+    foreach my $block (@guess_local) {
+        if ($in_ip =~ /$block/) {
+        return '0.0.0.0';
+        }
+    }
+    return $in_ip;
 }
 ######################################################################
 ## get_ip
@@ -2106,98 +2106,98 @@ sub get_ip {
     $arg = '' unless $arg;
 
     if ($use eq 'ip') {
-	$ip  = opt('ip', $h);
-	$arg = 'ip';
+    $ip  = opt('ip', $h);
+    $arg = 'ip';
 
     } elsif ($use eq 'if') {
-	$skip  = opt('if-skip', $h)  || '';
-	$reply = `ifconfig $arg 2> /dev/null`;
-	$reply = `ip addr list dev $arg 2> /dev/null` if $?;
-	$reply = '' if $?;
+    $skip  = opt('if-skip', $h)  || '';
+    $reply = `ifconfig $arg 2> /dev/null`;
+    $reply = `ip addr list dev $arg 2> /dev/null` if $?;
+    $reply = '' if $?;
 
     } elsif ($use eq 'cmd') {
-	if ($arg) {
-	    $skip  = opt('cmd-skip', $h)  || '';
-	    $reply = `$arg`;
-	    $reply = '' if $?;
-	}
+    if ($arg) {
+        $skip  = opt('cmd-skip', $h)  || '';
+        $reply = `$arg`;
+        $reply = '' if $?;
+    }
 
     } elsif ($use eq 'web') {
-	$url  = opt('web', $h)       || '';
-	$skip = opt('web-skip', $h)  || '';
+    $url  = opt('web', $h)       || '';
+    $skip = opt('web-skip', $h)  || '';
 
-	if (exists $builtinweb{$url}) {
-	    $skip = $builtinweb{$url}->{'skip'} unless $skip;
-	    $url  = $builtinweb{$url}->{'url'};
-	}	    
-	$arg = $url;
+    if (exists $builtinweb{$url}) {
+        $skip = $builtinweb{$url}->{'skip'} unless $skip;
+        $url  = $builtinweb{$url}->{'url'};
+    }       
+    $arg = $url;
 
-	if ($url) {
-	    $reply = geturl(opt('proxy', $h), $url) || '';
+    if ($url) {
+        $reply = geturl(opt('proxy', $h), $url) || '';
         }
 
     } elsif (($use eq 'cisco')) {
-	# Stuff added to support Cisco router ip http daemon
-	# User fw-login should only have level 1 access to prevent
-	# password theft.  This is pretty harmless.
-	my $queryif  = opt('if', $h);
-	$skip = opt('fw-skip', $h)  || '';
+    # Stuff added to support Cisco router ip http daemon
+    # User fw-login should only have level 1 access to prevent
+    # password theft.  This is pretty harmless.
+    my $queryif  = opt('if', $h);
+    $skip = opt('fw-skip', $h)  || '';
 
-	# Convert slashes to protected value "\/"
-	$queryif =~ s%\/%\\\/%g;
+    # Convert slashes to protected value "\/"
+    $queryif =~ s%\/%\\\/%g;
 
-	# Protect special HTML characters (like '?')
-	$queryif =~ s/([\?&= ])/sprintf("%%%02x",ord($1))/ge;
+    # Protect special HTML characters (like '?')
+    $queryif =~ s/([\?&= ])/sprintf("%%%02x",ord($1))/ge;
 
-	$url   = "http://".opt('fw', $h)."/level/1/exec/show/ip/interface/brief/${queryif}/CR";
-	$reply = geturl('', $url, opt('fw-login', $h), opt('fw-password', $h)) || '';
-	$arg   = $url;
+    $url   = "http://".opt('fw', $h)."/level/1/exec/show/ip/interface/brief/${queryif}/CR";
+    $reply = geturl('', $url, opt('fw-login', $h), opt('fw-password', $h)) || '';
+    $arg   = $url;
 
     } elsif (($use eq 'cisco-asa')) {
-	# Stuff added to support Cisco ASA ip https daemon
-	# User fw-login should only have level 1 access to prevent
-	# password theft.  This is pretty harmless.
-	my $queryif  = opt('if', $h);
-	$skip = opt('fw-skip', $h)  || '';
+    # Stuff added to support Cisco ASA ip https daemon
+    # User fw-login should only have level 1 access to prevent
+    # password theft.  This is pretty harmless.
+    my $queryif  = opt('if', $h);
+    $skip = opt('fw-skip', $h)  || '';
 
-	# Convert slashes to protected value "\/"
-	$queryif =~ s%\/%\\\/%g;
+    # Convert slashes to protected value "\/"
+    $queryif =~ s%\/%\\\/%g;
 
-	# Protect special HTML characters (like '?')
-	$queryif =~ s/([\?&= ])/sprintf("%%%02x",ord($1))/ge;
+    # Protect special HTML characters (like '?')
+    $queryif =~ s/([\?&= ])/sprintf("%%%02x",ord($1))/ge;
 
-	$url   = "https://".opt('fw', $h)."/exec/show%20interface%20${queryif}";
-	$reply = geturl('', $url, opt('fw-login', $h), opt('fw-password', $h)) || '';
-	$arg   = $url;
+    $url   = "https://".opt('fw', $h)."/exec/show%20interface%20${queryif}";
+    $reply = geturl('', $url, opt('fw-login', $h), opt('fw-password', $h)) || '';
+    $arg   = $url;
 
     } else {
-	$url  = opt('fw', $h)       || '';
-	$skip = opt('fw-skip', $h)  || '';
+    $url  = opt('fw', $h)       || '';
+    $skip = opt('fw-skip', $h)  || '';
 
-	if (exists $builtinfw{$use}) {
-	    $skip = $builtinfw{$use}->{'skip'} unless $skip;
-	    $url  = "http://${url}" . $builtinfw{$use}->{'url'} unless $url =~ /\//;
-	}	    
-	$arg = $url;
+    if (exists $builtinfw{$use}) {
+        $skip = $builtinfw{$use}->{'skip'} unless $skip;
+        $url  = "http://${url}" . $builtinfw{$use}->{'url'} unless $url =~ /\//;
+    }       
+    $arg = $url;
 
-	if ($url) {
-	    $reply = geturl('', $url, opt('fw-login', $h), opt('fw-password', $h)) || '';
+    if ($url) {
+        $reply = geturl('', $url, opt('fw-login', $h), opt('fw-password', $h)) || '';
         }
     }
     if (!defined $reply) {
-	$reply = '';
+    $reply = '';
     }
     if ($skip) {
-	$skip  =~ s/ /\\s/is;
-    	$reply =~ s/^.*?${skip}//is;
+    $skip  =~ s/ /\\s/is;
+        $reply =~ s/^.*?${skip}//is;
     }
     if ($reply =~ /^.*?\b(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\b.*/is) {
-	$ip = $1;
-	$ip = un_zero_pad($ip);
-	$ip = filter_local($ip) if opt('fw-banlocal', $h);
+    $ip = $1;
+    $ip = un_zero_pad($ip);
+    $ip = filter_local($ip) if opt('fw-banlocal', $h);
     }
     if (($use ne 'ip') && (define($ip,'') eq '0.0.0.0')) {
-	$ip = undef;
+    $ip = undef;
     }
 
     debug("get_ip: using %s, %s reports %s", $use, $arg, define($ip, "<undefined>"));
@@ -2212,11 +2212,11 @@ sub group_hosts_by {
 
     my %groups = ();
     foreach my $h (@$hosts) {
-	my @keys = (@$attributes, 'wantip');
-	map { $config{$h}{$_} = '' unless exists $config{$h}{$_} } @keys;
-	my $sig  = join(',', map { "$_=$config{$h}{$_}" } @keys);
+    my @keys = (@$attributes, 'wantip');
+    map { $config{$h}{$_} = '' unless exists $config{$h}{$_} } @keys;
+    my $sig  = join(',', map { "$_=$config{$h}{$_}" } @keys);
 
-	push @{$groups{$sig}}, $h;
+    push @{$groups{$sig}}, $h;
     }
     return %groups;
 }
@@ -2227,15 +2227,15 @@ sub nic_examples {
     my $examples  = "";
     my $separator = "";
     foreach my $s (sort keys %services)  {
-	my $subr = $services{$s}{'examples'};
+    my $subr = $services{$s}{'examples'};
         my $example;
 
-	if (defined($subr) && ($example = &$subr())) {
-	    chomp($example);
-	    $examples  .= $example;
-	    $examples  .= "\n\n$separator";
-	    $separator  = "\n";
-	}
+    if (defined($subr) && ($example = &$subr())) {
+        chomp($example);
+        $examples  .= $example;
+        $examples  .= "\n\n$separator";
+        $separator  = "\n";
+    }
     }
     my $intro = <<EoEXAMPLE;
 == CONFIGURING ${program}
@@ -2295,71 +2295,71 @@ sub nic_updateable {
     my $ip     = $config{$host}{'wantip'};
 
     if ($config{$host}{'login'} eq '') {
-	warning("null login name specified for host %s.", $host);
+    warning("null login name specified for host %s.", $host);
 
     } elsif ($config{$host}{'password'} eq '') {
-	warning("null password specified for host %s.", $host);
+    warning("null password specified for host %s.", $host);
 
     } elsif ($opt{'force'}) {
-	info("forcing update of %s.", $host);
-	$update = 1;
+    info("forcing update of %s.", $host);
+    $update = 1;
 
     } elsif (!exists($cache{$host})) {
-	info("forcing updating %s because no cached entry exists.", $host);
-	$update = 1;
+    info("forcing updating %s because no cached entry exists.", $host);
+    $update = 1;
 
     } elsif ($cache{$host}{'wtime'} && $cache{$host}{'wtime'} > $now) {
-	warning("cannot update %s from %s to %s until after %s.", 
-		$host, 
-		($cache{$host}{'ip'} ? $cache{$host}{'ip'} : '<nothing>'), $ip,
-		prettytime($cache{$host}{'wtime'})
-	);
+    warning("cannot update %s from %s to %s until after %s.", 
+        $host, 
+        ($cache{$host}{'ip'} ? $cache{$host}{'ip'} : '<nothing>'), $ip,
+        prettytime($cache{$host}{'wtime'})
+    );
 
     } elsif ($cache{$host}{'mtime'} && interval_expired($host, 'mtime', 'max-interval')) {
-	warning("forcing update of %s from %s to %s; %s since last update on %s.", 
-		$host, 
-		($cache{$host}{'ip'} ? $cache{$host}{'ip'} : '<nothing>'), $ip,
-		prettyinterval($config{$host}{'max-interval'}),
-		prettytime($cache{$host}{'mtime'})
-	);
-	$update = 1;
+    warning("forcing update of %s from %s to %s; %s since last update on %s.", 
+        $host, 
+        ($cache{$host}{'ip'} ? $cache{$host}{'ip'} : '<nothing>'), $ip,
+        prettyinterval($config{$host}{'max-interval'}),
+        prettytime($cache{$host}{'mtime'})
+    );
+    $update = 1;
 
     } elsif ((!exists($cache{$host}{'ip'})) ||
-		    ("$cache{$host}{'ip'}" ne "$ip")) {
-	    if (($cache{$host}{'status'} eq 'good') && 
-			    !interval_expired($host, 'mtime', 'min-interval')) {
+            ("$cache{$host}{'ip'}" ne "$ip")) {
+        if (($cache{$host}{'status'} eq 'good') && 
+                !interval_expired($host, 'mtime', 'min-interval')) {
 
-	    warning("skipping update of %s from %s to %s.\nlast updated %s.\nWait at least %s between update attempts.", 
-		 $host, 
-		 ($cache{$host}{'ip'}    ? $cache{$host}{'ip'}                : '<nothing>'), 
-		 $ip,
-		 ($cache{$host}{'mtime'} ? prettytime($cache{$host}{'mtime'}) : '<never>'),
-		 prettyinterval($config{$host}{'min-interval'})		
-		 )
-		if opt('verbose') || !define($cache{$host}{'warned-min-interval'}, 0);
+        warning("skipping update of %s from %s to %s.\nlast updated %s.\nWait at least %s between update attempts.", 
+         $host, 
+         ($cache{$host}{'ip'}    ? $cache{$host}{'ip'}                : '<nothing>'), 
+         $ip,
+         ($cache{$host}{'mtime'} ? prettytime($cache{$host}{'mtime'}) : '<never>'),
+         prettyinterval($config{$host}{'min-interval'})     
+         )
+        if opt('verbose') || !define($cache{$host}{'warned-min-interval'}, 0);
 
-	    $cache{$host}{'warned-min-interval'} = $now;
-	    
-	} elsif (($cache{$host}{'status'} ne 'good') && !interval_expired($host, 'atime', 'min-error-interval')) {
+        $cache{$host}{'warned-min-interval'} = $now;
+        
+    } elsif (($cache{$host}{'status'} ne 'good') && !interval_expired($host, 'atime', 'min-error-interval')) {
 
-	    warning("skipping update of %s from %s to %s.\nlast updated %s but last attempt on %s failed.\nWait at least %s between update attempts.", 
-		 $host, 
-		 ($cache{$host}{'ip'}    ? $cache{$host}{'ip'}                : '<nothing>'), 
-		 $ip,
-		 ($cache{$host}{'mtime'} ? prettytime($cache{$host}{'mtime'}) : '<never>'),
-		 ($cache{$host}{'atime'} ? prettytime($cache{$host}{'atime'}) : '<never>'),
-		 prettyinterval($config{$host}{'min-error-interval'})		
-		 )
-		if opt('verbose') || !define($cache{$host}{'warned-min-error-interval'}, 0);
+        warning("skipping update of %s from %s to %s.\nlast updated %s but last attempt on %s failed.\nWait at least %s between update attempts.", 
+         $host, 
+         ($cache{$host}{'ip'}    ? $cache{$host}{'ip'}                : '<nothing>'), 
+         $ip,
+         ($cache{$host}{'mtime'} ? prettytime($cache{$host}{'mtime'}) : '<never>'),
+         ($cache{$host}{'atime'} ? prettytime($cache{$host}{'atime'}) : '<never>'),
+         prettyinterval($config{$host}{'min-error-interval'})       
+         )
+        if opt('verbose') || !define($cache{$host}{'warned-min-error-interval'}, 0);
 
-	    $cache{$host}{'warned-min-error-interval'} = $now;
+        $cache{$host}{'warned-min-error-interval'} = $now;
 
-	} else {
-	    $update = 1;
-	}
+    } else {
+        $update = 1;
+    }
 
     } elsif (defined($sub) && &$sub($host)) {
-	$update = 1;
+    $update = 1;
     } elsif ((defined($cache{$host}{'static'}) && defined($config{$host}{'static'}) &&
               ($cache{$host}{'static'} ne $config{$host}{'static'})) ||
              (defined($cache{$host}{'wildcard'}) && defined($config{$host}{'wildcard'}) &&
@@ -2368,26 +2368,26 @@ sub nic_updateable {
               ($cache{$host}{'mx'} ne $config{$host}{'mx'})) ||
              (defined($cache{$host}{'backupmx'}) && defined($config{$host}{'backupmx'}) &&
               ($cache{$host}{'backupmx'} ne $config{$host}{'backupmx'})) ) {
-	info("updating %s because host settings have been changed.", $host);
-	$update = 1;
+    info("updating %s because host settings have been changed.", $host);
+    $update = 1;
 
     } else {
-	success("%s: skipped: IP address was already set to %s.", $host, $ip)
-	    if opt('verbose');
+    success("%s: skipped: IP address was already set to %s.", $host, $ip)
+        if opt('verbose');
     }
     $config{$host}{'status'} = define($cache{$host}{'status'},'');
     $config{$host}{'update'} = $update;
     if ($update) {
-	$config{$host}{'status'}                    = 'noconnect';
-	$config{$host}{'atime'}                     = $now;
-	$config{$host}{'wtime'}                     = 0;
-	$config{$host}{'warned-min-interval'}       = 0;
-	$config{$host}{'warned-min-error-interval'} = 0;
+    $config{$host}{'status'}                    = 'noconnect';
+    $config{$host}{'atime'}                     = $now;
+    $config{$host}{'wtime'}                     = 0;
+    $config{$host}{'warned-min-interval'}       = 0;
+    $config{$host}{'warned-min-error-interval'} = 0;
 
-	delete $cache{$host}{'warned-min-interval'};
-	delete $cache{$host}{'warned-min-error-interval'};
+    delete $cache{$host}{'warned-min-interval'};
+    delete $cache{$host}{'warned-min-error-interval'};
     }
-	    
+        
     return $update;
 }
 ######################################################################
@@ -2398,17 +2398,17 @@ sub header_ok {
     my $ok = 0;
 
     if ($line =~ m%^s*HTTP/1.*\s+(\d+)%i) {
-	my $result = $1;
+    my $result = $1;
 
-	if ($result eq '200') {
-	    $ok = 1;
+    if ($result eq '200') {
+        $ok = 1;
 
-	} elsif ($result eq '401') {
-	    failed("updating %s: authorization failed (%s)", $host, $line);
-	}
-	
+    } elsif ($result eq '401') {
+        failed("updating %s: authorization failed (%s)", $host, $line);
+    }
+    
     } else {
-	failed("updating %s: unexpected line (%s)", $host, $line);
+    failed("updating %s: unexpected line (%s)", $host, $line);
     }
     return $ok;
 }
@@ -2456,50 +2456,50 @@ sub nic_dyndns1_update {
     debug("\nnic_dyndns1_update -------------------");
     ## update each configured host
     foreach my $h (@_) {
-	my $ip = delete $config{$h}{'wantip'};
-	info("setting IP address to %s for %s", $ip, $h);
-	verbose("UPDATE:","updating %s", $h);
+    my $ip = delete $config{$h}{'wantip'};
+    info("setting IP address to %s for %s", $ip, $h);
+    verbose("UPDATE:","updating %s", $h);
 
-	my $url;
-	$url   = "http://$config{$h}{'server'}/nic/";
-	$url  .= ynu($config{$h}{'static'}, 'statdns', 'dyndns', 'dyndns');
-	$url  .= "?action=edit&started=1&hostname=YES&host_id=$h";
-	$url  .= "&myip=";
-	$url  .= $ip            if $ip;
-	$url  .= "&wildcard=ON" if ynu($config{$h}{'wildcard'}, 1, 0, 0);
-	if ($config{$h}{'mx'}) {
-	    $url .= "&mx=$config{$h}{'mx'}";
-	    $url .= "&backmx=" . ynu($config{$h}{'backupmx'}, 'YES', 'NO');
-	}
-	
-	my $reply = geturl(opt('proxy'), $url, $config{$h}{'login'}, $config{$h}{'password'});
-	if (!defined($reply) || !$reply) {
-	    failed("updating %s: Could not connect to %s.", $h, $config{$h}{'server'});
-	    next;
-	}
-	last if !header_ok($h, $reply);
+    my $url;
+    $url   = "http://$config{$h}{'server'}/nic/";
+    $url  .= ynu($config{$h}{'static'}, 'statdns', 'dyndns', 'dyndns');
+    $url  .= "?action=edit&started=1&hostname=YES&host_id=$h";
+    $url  .= "&myip=";
+    $url  .= $ip            if $ip;
+    $url  .= "&wildcard=ON" if ynu($config{$h}{'wildcard'}, 1, 0, 0);
+    if ($config{$h}{'mx'}) {
+        $url .= "&mx=$config{$h}{'mx'}";
+        $url .= "&backmx=" . ynu($config{$h}{'backupmx'}, 'YES', 'NO');
+    }
+    
+    my $reply = geturl(opt('proxy'), $url, $config{$h}{'login'}, $config{$h}{'password'});
+    if (!defined($reply) || !$reply) {
+        failed("updating %s: Could not connect to %s.", $h, $config{$h}{'server'});
+        next;
+    }
+    last if !header_ok($h, $reply);
 
-	my @reply = split /\n/, $reply;
-	my ($title, $return_code, $error_code) = ('','','');
-	foreach my $line (@reply) {
-	    $title       = $1 if $line =~ m%<TITLE>\s*(.*)\s*</TITLE>%i;
-	    $return_code = $1 if $line =~ m%^return\s+code\s*:\s*(.*)\s*$%i;
-	    $error_code  = $1 if $line =~ m%^error\s+code\s*:\s*(.*)\s*$%i;
-	}
-	
-	if ($return_code ne 'NOERROR' || $error_code ne 'NOERROR' || !$title) {
-	    $config{$h}{'status'} = 'failed';
-	    $title = "incomplete response from $config{$h}{server}" unless $title;
-	    warning("SENT:    %s", $url) unless opt('verbose');
-	    warning("REPLIED: %s", $reply);
-	    failed("updating %s: %s", $h, $title);
-	    
-	} else {
-	    $config{$h}{'ip'}     = $ip;
-	    $config{$h}{'mtime'}  = $now;
-	    $config{$h}{'status'} = 'good';
-	    success("updating %s: %s: IP address set to %s (%s)", $h, $return_code, $ip, $title);
-	}
+    my @reply = split /\n/, $reply;
+    my ($title, $return_code, $error_code) = ('','','');
+    foreach my $line (@reply) {
+        $title       = $1 if $line =~ m%<TITLE>\s*(.*)\s*</TITLE>%i;
+        $return_code = $1 if $line =~ m%^return\s+code\s*:\s*(.*)\s*$%i;
+        $error_code  = $1 if $line =~ m%^error\s+code\s*:\s*(.*)\s*$%i;
+    }
+    
+    if ($return_code ne 'NOERROR' || $error_code ne 'NOERROR' || !$title) {
+        $config{$h}{'status'} = 'failed';
+        $title = "incomplete response from $config{$h}{server}" unless $title;
+        warning("SENT:    %s", $url) unless opt('verbose');
+        warning("REPLIED: %s", $reply);
+        failed("updating %s: %s", $h, $title);
+        
+    } else {
+        $config{$h}{'ip'}     = $ip;
+        $config{$h}{'mtime'}  = $now;
+        $config{$h}{'status'} = 'good';
+        success("updating %s: %s: IP address set to %s (%s)", $h, $return_code, $ip, $title);
+    }
     }
 }
 ######################################################################
@@ -2510,17 +2510,17 @@ sub nic_dyndns2_updateable {
     my $update = 0;
 
     if ($config{$host}{'mx'} ne $cache{$host}{'mx'}) {
-	info("forcing updating %s because 'mx' has changed to %s.", $host, $config{$host}{'mx'});
-	$update = 1;
+    info("forcing updating %s because 'mx' has changed to %s.", $host, $config{$host}{'mx'});
+    $update = 1;
 
     } elsif ($config{$host}{'mx'} && (ynu($config{$host}{'backupmx'},1,2,3) ne ynu($config{$host}{'backupmx'},1,2,3))) {
-	info("forcing updating %s because 'backupmx' has changed to %s.", $host, ynu($config{$host}{'backupmx'},"YES","NO","NO"));
-	$update = 1;
+    info("forcing updating %s because 'backupmx' has changed to %s.", $host, ynu($config{$host}{'backupmx'},"YES","NO","NO"));
+    $update = 1;
 
     } elsif ($config{$host}{'static'} ne $cache{$host}{'static'}) {
 
-	info("forcing updating %s because 'static' has changed to %s.", $host, ynu($config{$host}{'static'},"YES","NO","NO"));
-	$update = 1;
+    info("forcing updating %s because 'static' has changed to %s.", $host, ynu($config{$host}{'static'},"YES","NO","NO"));
+    $update = 1;
 
     }
     return $update;
@@ -2601,107 +2601,107 @@ sub nic_dyndns2_update {
 
     ## update each set of hosts that had similar configurations
     foreach my $sig (keys %groups) {
-	my @hosts = @{$groups{$sig}};
-	my $hosts = join(',', @hosts);
-	my $h     = $hosts[0];
-	my $ip    = $config{$h}{'wantip'};
-	delete $config{$_}{'wantip'} foreach @hosts;
+    my @hosts = @{$groups{$sig}};
+    my $hosts = join(',', @hosts);
+    my $h     = $hosts[0];
+    my $ip    = $config{$h}{'wantip'};
+    delete $config{$_}{'wantip'} foreach @hosts;
 
-	info("setting IP address to %s for %s", $ip, $hosts);
-	verbose("UPDATE:","updating %s", $hosts);
+    info("setting IP address to %s for %s", $ip, $hosts);
+    verbose("UPDATE:","updating %s", $hosts);
 
-	## Select the DynDNS system to update
-	my $url = "http://$config{$h}{'server'}$config{$h}{'script'}?system=";
-	if ($config{$h}{'custom'}) {
-	    warning("updating %s: 'custom' and 'static' may not be used together. ('static' ignored)", $hosts)
-	      if $config{$h}{'static'};
-#	    warning("updating %s: 'custom' and 'offline' may not be used together. ('offline' ignored)", $hosts)
-#	      if $config{$h}{'offline'};
-	    $url .= 'custom';
+    ## Select the DynDNS system to update
+    my $url = "http://$config{$h}{'server'}$config{$h}{'script'}?system=";
+    if ($config{$h}{'custom'}) {
+        warning("updating %s: 'custom' and 'static' may not be used together. ('static' ignored)", $hosts)
+          if $config{$h}{'static'};
+#       warning("updating %s: 'custom' and 'offline' may not be used together. ('offline' ignored)", $hosts)
+#         if $config{$h}{'offline'};
+        $url .= 'custom';
 
-	} elsif  ($config{$h}{'static'}) {
-#	    warning("updating %s: 'static' and 'offline' may not be used together. ('offline' ignored)", $hosts)
-#	      if $config{$h}{'offline'};
-	    $url .= 'statdns';
+    } elsif  ($config{$h}{'static'}) {
+#       warning("updating %s: 'static' and 'offline' may not be used together. ('offline' ignored)", $hosts)
+#         if $config{$h}{'offline'};
+        $url .= 'statdns';
 
-	} else {
-	    $url .= 'dyndns';
-	}
+    } else {
+        $url .= 'dyndns';
+    }
 
-	$url  .= "&hostname=$hosts";
-	$url  .= "&myip=";
-	$url  .= $ip            if $ip;
+    $url  .= "&hostname=$hosts";
+    $url  .= "&myip=";
+    $url  .= $ip            if $ip;
 
-	## some args are not valid for a custom domain.
-	$url  .= "&wildcard=ON" if ynu($config{$h}{'wildcard'}, 1, 0, 0);
-	if ($config{$h}{'mx'}) {
-	    $url .= "&mx=$config{$h}{'mx'}";
-	    $url .= "&backmx=" . ynu($config{$h}{'backupmx'}, 'YES', 'NO');
-	}
+    ## some args are not valid for a custom domain.
+    $url  .= "&wildcard=ON" if ynu($config{$h}{'wildcard'}, 1, 0, 0);
+    if ($config{$h}{'mx'}) {
+        $url .= "&mx=$config{$h}{'mx'}";
+        $url .= "&backmx=" . ynu($config{$h}{'backupmx'}, 'YES', 'NO');
+    }
 
-	my $reply = geturl(opt('proxy'), $url, $config{$h}{'login'}, $config{$h}{'password'});
-	if (!defined($reply) || !$reply) {
-	    failed("updating %s: Could not connect to %s.", $hosts, $config{$h}{'server'});
-	    last;
-	}
-	last if !header_ok($hosts, $reply);
+    my $reply = geturl(opt('proxy'), $url, $config{$h}{'login'}, $config{$h}{'password'});
+    if (!defined($reply) || !$reply) {
+        failed("updating %s: Could not connect to %s.", $hosts, $config{$h}{'server'});
+        last;
+    }
+    last if !header_ok($hosts, $reply);
 
-	my @reply = split /\n/, $reply;
-	my $state = 'header';
-	my $returnedip = $ip;
+    my @reply = split /\n/, $reply;
+    my $state = 'header';
+    my $returnedip = $ip;
 
-	foreach my $line (@reply) {
-	    if ($state eq 'header') {
-		$state = 'body';
-	    
-	    } elsif ($state eq 'body') {
-		$state = 'results' if $line eq '';
-	    
-	    } elsif ($state =~ /^results/) {
-		$state = 'results2';
+    foreach my $line (@reply) {
+        if ($state eq 'header') {
+        $state = 'body';
+        
+        } elsif ($state eq 'body') {
+        $state = 'results' if $line eq '';
+        
+        } elsif ($state =~ /^results/) {
+        $state = 'results2';
 
-		# bug #10: some dyndns providers does not return the IP so
-		# we can't use the returned IP
-		my ($status, $returnedip) = split / /, lc $line;
-		$ip = $returnedip if (not $ip);
-		my $h = shift @hosts;
-	    
-		$config{$h}{'status'} = $status;
-		if ($status eq 'good') {
-		    $config{$h}{'ip'}     = $ip;
-		    $config{$h}{'mtime'}  = $now;
-		    success("updating %s: %s: IP address set to %s", $h, $status, $ip);
-		
-		} elsif (exists $errors{$status}) {
-		    if ($status eq 'nochg') {
-			warning("updating %s: %s: %s", $h, $status, $errors{$status});
-			$config{$h}{'ip'}     = $ip;
-		    	$config{$h}{'mtime'}  = $now;
-			$config{$h}{'status'} = 'good';
-		    
-		    } else {
-			failed("updating %s: %s: %s", $h, $status, $errors{$status});
-		    }
+        # bug #10: some dyndns providers does not return the IP so
+        # we can't use the returned IP
+        my ($status, $returnedip) = split / /, lc $line;
+        $ip = $returnedip if (not $ip);
+        my $h = shift @hosts;
+        
+        $config{$h}{'status'} = $status;
+        if ($status eq 'good') {
+            $config{$h}{'ip'}     = $ip;
+            $config{$h}{'mtime'}  = $now;
+            success("updating %s: %s: IP address set to %s", $h, $status, $ip);
+        
+        } elsif (exists $errors{$status}) {
+            if ($status eq 'nochg') {
+            warning("updating %s: %s: %s", $h, $status, $errors{$status});
+            $config{$h}{'ip'}     = $ip;
+                $config{$h}{'mtime'}  = $now;
+            $config{$h}{'status'} = 'good';
+            
+            } else {
+            failed("updating %s: %s: %s", $h, $status, $errors{$status});
+            }
 
-		} elsif ($status =~ /w(\d+)(.)/) {
-		    my ($wait, $units) = ($1, lc $2);
-		    my ($sec,  $scale) = ($wait, 1);
-		
-		    ($scale, $units) = (1, 'seconds')   if $units eq 's';
-		    ($scale, $units) = (60, 'minutes')  if $units eq 'm';
-		    ($scale, $units) = (60*60, 'hours') if $units eq 'h';
+        } elsif ($status =~ /w(\d+)(.)/) {
+            my ($wait, $units) = ($1, lc $2);
+            my ($sec,  $scale) = ($wait, 1);
+        
+            ($scale, $units) = (1, 'seconds')   if $units eq 's';
+            ($scale, $units) = (60, 'minutes')  if $units eq 'm';
+            ($scale, $units) = (60*60, 'hours') if $units eq 'h';
 
-		    $sec = $wait * $scale;
-		    $config{$h}{'wtime'} = $now + $sec;
-		    warning("updating %s: %s: wait $wait $units before further updates", $h, $status, $ip);
-		
-		} else {
-		    failed("updating %s: %s: unexpected status (%s)", $h, $line);
-		} 	
-	    }
-	}
-	failed("updating %s: Could not connect to %s.", $hosts, $config{$h}{'server'})
-	    if $state ne 'results2';
+            $sec = $wait * $scale;
+            $config{$h}{'wtime'} = $now + $sec;
+            warning("updating %s: %s: wait $wait $units before further updates", $h, $status, $ip);
+        
+        } else {
+            failed("updating %s: %s: unexpected status (%s)", $h, $line);
+        }   
+        }
+    }
+    failed("updating %s: Could not connect to %s.", $hosts, $config{$h}{'server'})
+        if $state ne 'results2';
     }
 }
 
@@ -2729,79 +2729,79 @@ sub nic_noip_update {
 
     ## update each set of hosts that had similar configurations
     foreach my $sig (keys %groups) {
-	my @hosts = @{$groups{$sig}};
-	my $hosts = join(',', @hosts);
-	my $h     = $hosts[0];
-	my $ip    = $config{$h}{'wantip'};
-	delete $config{$_}{'wantip'} foreach @hosts;
+    my @hosts = @{$groups{$sig}};
+    my $hosts = join(',', @hosts);
+    my $h     = $hosts[0];
+    my $ip    = $config{$h}{'wantip'};
+    delete $config{$_}{'wantip'} foreach @hosts;
 
-	info("setting IP address to %s for %s", $ip, $hosts);
-	verbose("UPDATE:","updating %s", $hosts);
+    info("setting IP address to %s for %s", $ip, $hosts);
+    verbose("UPDATE:","updating %s", $hosts);
 
-	my $url = "http://$config{$h}{'server'}/nic/update?system=";
+    my $url = "http://$config{$h}{'server'}/nic/update?system=";
     $url .= 'noip';
-	$url  .= "&hostname=$hosts";
-	$url  .= "&myip=";
-	$url  .= $ip            if $ip;
+    $url  .= "&hostname=$hosts";
+    $url  .= "&myip=";
+    $url  .= $ip            if $ip;
 
-	my $reply = geturl(opt('proxy'), $url, $config{$h}{'login'}, $config{$h}{'password'});
-	if (!defined($reply) || !$reply) {
-	    failed("updating %s: Could not connect to %s.", $hosts, $config{$h}{'server'});
-	    last;
-	}
-	last if !header_ok($hosts, $reply);
+    my $reply = geturl(opt('proxy'), $url, $config{$h}{'login'}, $config{$h}{'password'});
+    if (!defined($reply) || !$reply) {
+        failed("updating %s: Could not connect to %s.", $hosts, $config{$h}{'server'});
+        last;
+    }
+    last if !header_ok($hosts, $reply);
 
-	my @reply = split /\n/, $reply;
-	my $state = 'header';
-	foreach my $line (@reply) {
-	    if ($state eq 'header') {
-		$state = 'body';
-	    
-	    } elsif ($state eq 'body') {
-		$state = 'results' if $line eq '';
-	    
-	    } elsif ($state =~ /^results/) {
-		$state = 'results2';
+    my @reply = split /\n/, $reply;
+    my $state = 'header';
+    foreach my $line (@reply) {
+        if ($state eq 'header') {
+        $state = 'body';
+        
+        } elsif ($state eq 'body') {
+        $state = 'results' if $line eq '';
+        
+        } elsif ($state =~ /^results/) {
+        $state = 'results2';
 
-		my ($status, $ip) = split / /, lc $line;
-		my $h = shift @hosts;
-	    
-		$config{$h}{'status'} = $status;
-		if ($status eq 'good') {
-		    $config{$h}{'ip'}     = $ip;
-		    $config{$h}{'mtime'}  = $now;
-		    success("updating %s: %s: IP address set to %s", $h, $status, $ip);
-		
-		} elsif (exists $errors{$status}) {
-		    if ($status eq 'nochg') {
-			warning("updating %s: %s: %s", $h, $status, $errors{$status});
-			$config{$h}{'ip'}     = $ip;
-		    	$config{$h}{'mtime'}  = $now;
-			$config{$h}{'status'} = 'good';
-		    
-		    } else {
-			failed("updating %s: %s: %s", $h, $status, $errors{$status});
-		    }
+        my ($status, $ip) = split / /, lc $line;
+        my $h = shift @hosts;
+        
+        $config{$h}{'status'} = $status;
+        if ($status eq 'good') {
+            $config{$h}{'ip'}     = $ip;
+            $config{$h}{'mtime'}  = $now;
+            success("updating %s: %s: IP address set to %s", $h, $status, $ip);
+        
+        } elsif (exists $errors{$status}) {
+            if ($status eq 'nochg') {
+            warning("updating %s: %s: %s", $h, $status, $errors{$status});
+            $config{$h}{'ip'}     = $ip;
+                $config{$h}{'mtime'}  = $now;
+            $config{$h}{'status'} = 'good';
+            
+            } else {
+            failed("updating %s: %s: %s", $h, $status, $errors{$status});
+            }
 
-		} elsif ($status =~ /w(\d+)(.)/) {
-		    my ($wait, $units) = ($1, lc $2);
-		    my ($sec,  $scale) = ($wait, 1);
-		
-		    ($scale, $units) = (1, 'seconds')   if $units eq 's';
-		    ($scale, $units) = (60, 'minutes')  if $units eq 'm';
-		    ($scale, $units) = (60*60, 'hours') if $units eq 'h';
+        } elsif ($status =~ /w(\d+)(.)/) {
+            my ($wait, $units) = ($1, lc $2);
+            my ($sec,  $scale) = ($wait, 1);
+        
+            ($scale, $units) = (1, 'seconds')   if $units eq 's';
+            ($scale, $units) = (60, 'minutes')  if $units eq 'm';
+            ($scale, $units) = (60*60, 'hours') if $units eq 'h';
 
-		    $sec = $wait * $scale;
-		    $config{$h}{'wtime'} = $now + $sec;
-		    warning("updating %s: %s: wait $wait $units before further updates", $h, $status, $ip);
-		
-		} else {
-		    failed("updating %s: %s: unexpected status (%s)", $h, $line);
-		} 	
-	    }
-	}
-	failed("updating %s: Could not connect to %s.", $hosts, $config{$h}{'server'})
-	    if $state ne 'results2';
+            $sec = $wait * $scale;
+            $config{$h}{'wtime'} = $now + $sec;
+            warning("updating %s: %s: wait $wait $units before further updates", $h, $status, $ip);
+        
+        } else {
+            failed("updating %s: %s: unexpected status (%s)", $h, $line);
+        }   
+        }
+    }
+    failed("updating %s: Could not connect to %s.", $hosts, $config{$h}{'server'})
+        if $state ne 'results2';
     }
 }
 ######################################################################
@@ -2816,7 +2816,7 @@ over an http request.  Details of the protocol are outlined at:
 http://www.no-ip.com/integrate/
 
 Configuration variables applicable to the 'noip' protocol are:
-  protocol=noip		           ## 
+  protocol=noip                ## 
   server=fqdn.of.service       ## defaults to dynupdate.no-ip.com
   login=service-login          ## login name and password  registered with the service
   password=service-password    ##
@@ -2872,7 +2872,7 @@ sub nic_concont_update {
 
     ## update each configured host
     foreach my $h (@_) {
-	my $ip = delete $config{$h}{'wantip'};
+    my $ip = delete $config{$h}{'wantip'};
         info("setting IP address to %s for %s", $ip, $h);
         verbose("UPDATE:","updating %s", $h);
 
@@ -2955,41 +2955,41 @@ sub nic_dslreports1_update {
     debug("\nnic_dslreports1_update -------------------");
     ## update each configured host
     foreach my $h (@_) {
-	my $ip = delete $config{$h}{'wantip'};
-	info("setting IP address to %s for %s", $ip, $h);
-	verbose("UPDATE:","updating %s", $h);
+    my $ip = delete $config{$h}{'wantip'};
+    info("setting IP address to %s for %s", $ip, $h);
+    verbose("UPDATE:","updating %s", $h);
 
-	my $url;
-	$url   = "http://$config{$h}{'server'}/nic/";
-	$url  .= ynu($config{$h}{'static'}, 'statdns', 'dyndns', 'dyndns');
-	$url  .= "?action=edit&started=1&hostname=YES&host_id=$h";
-	$url  .= "&myip=";
-	$url  .= $ip            if $ip;
-	
-	my $reply = geturl(opt('proxy'), $url, $config{$h}{'login'}, $config{$h}{'password'});
-	if (!defined($reply) || !$reply) {
-	    failed("updating %s: Could not connect to %s.", $h, $config{$h}{'server'});
-	    next;
-	}
-	
-	my @reply = split /\n/, $reply;
-	my $return_code = '';
-	foreach my $line (@reply) {
-	    $return_code = $1 if $line =~ m%^return\s+code\s*:\s*(.*)\s*$%i;
-	}
-	
-	if ($return_code !~ /NOERROR/) {
-	    $config{$h}{'status'} = 'failed';
-	    warning("SENT:    %s", $url) unless opt('verbose');
-	    warning("REPLIED: %s", $reply);
-	    failed("updating %s", $h);
-	    
-	} else {
-	    $config{$h}{'ip'}     = $ip;
-	    $config{$h}{'mtime'}  = $now;
-	    $config{$h}{'status'} = 'good';
-	    success("updating %s: %s: IP address set to %s", $h, $return_code, $ip);
-	}
+    my $url;
+    $url   = "http://$config{$h}{'server'}/nic/";
+    $url  .= ynu($config{$h}{'static'}, 'statdns', 'dyndns', 'dyndns');
+    $url  .= "?action=edit&started=1&hostname=YES&host_id=$h";
+    $url  .= "&myip=";
+    $url  .= $ip            if $ip;
+    
+    my $reply = geturl(opt('proxy'), $url, $config{$h}{'login'}, $config{$h}{'password'});
+    if (!defined($reply) || !$reply) {
+        failed("updating %s: Could not connect to %s.", $h, $config{$h}{'server'});
+        next;
+    }
+    
+    my @reply = split /\n/, $reply;
+    my $return_code = '';
+    foreach my $line (@reply) {
+        $return_code = $1 if $line =~ m%^return\s+code\s*:\s*(.*)\s*$%i;
+    }
+    
+    if ($return_code !~ /NOERROR/) {
+        $config{$h}{'status'} = 'failed';
+        warning("SENT:    %s", $url) unless opt('verbose');
+        warning("REPLIED: %s", $reply);
+        failed("updating %s", $h);
+        
+    } else {
+        $config{$h}{'ip'}     = $ip;
+        $config{$h}{'mtime'}  = $now;
+        $config{$h}{'status'} = 'good';
+        success("updating %s: %s: IP address set to %s", $h, $return_code, $ip);
+    }
     }
 }
 ######################################################################
@@ -3031,35 +3031,35 @@ sub nic_hammernode1_update {
 
     ## update each configured host
     foreach my $h (@_) {
-	my $ip = delete $config{$h}{'wantip'};
-	info("setting IP address to %s for %s", $ip, $h);
-	verbose("UPDATE:","updating %s", $h);
+    my $ip = delete $config{$h}{'wantip'};
+    info("setting IP address to %s for %s", $ip, $h);
+    verbose("UPDATE:","updating %s", $h);
 
-	my $url;
-	$url   = "http://$config{$h}{'server'}/vanity/update";
-	$url  .= "?ver=1";
-	$url  .= "&ip=";
-	$url  .= $ip if $ip;
-	
-	my $reply = geturl(opt('proxy'), $url, $config{$h}{'login'}, $config{$h}{'password'});
-	if (!defined($reply) || !$reply) {
-	    failed("updating %s: Could not connect to %s.", $h, $config{$h}{'server'});
-	    last;
-	}
-	last if !header_ok($h, $reply);
-	
-	my @reply = split /\n/, $reply;
-	if (grep /<!--\s+DDNS_Response_Code=101\s+-->/i, @reply) {
-	    $config{$h}{'ip'}     = $ip;
-	    $config{$h}{'mtime'}  = $now;
-	    $config{$h}{'status'} = 'good';
-	    success("updating %s: good: IP address set to %s", $h, $ip);
-	} else {
-	    $config{$h}{'status'} = 'failed';
-	    warning("SENT:    %s", $url) unless opt('verbose');
-	    warning("REPLIED: %s", $reply);
-	    failed("updating %s: Invalid reply.", $h);
-	}
+    my $url;
+    $url   = "http://$config{$h}{'server'}/vanity/update";
+    $url  .= "?ver=1";
+    $url  .= "&ip=";
+    $url  .= $ip if $ip;
+    
+    my $reply = geturl(opt('proxy'), $url, $config{$h}{'login'}, $config{$h}{'password'});
+    if (!defined($reply) || !$reply) {
+        failed("updating %s: Could not connect to %s.", $h, $config{$h}{'server'});
+        last;
+    }
+    last if !header_ok($h, $reply);
+    
+    my @reply = split /\n/, $reply;
+    if (grep /<!--\s+DDNS_Response_Code=101\s+-->/i, @reply) {
+        $config{$h}{'ip'}     = $ip;
+        $config{$h}{'mtime'}  = $now;
+        $config{$h}{'status'} = 'good';
+        success("updating %s: good: IP address set to %s", $h, $ip);
+    } else {
+        $config{$h}{'status'} = 'failed';
+        warning("SENT:    %s", $url) unless opt('verbose');
+        warning("REPLIED: %s", $reply);
+        failed("updating %s: Invalid reply.", $h);
+    }
     }
 }
 ######################################################################
@@ -3116,63 +3116,63 @@ sub nic_zoneedit1_update {
 
     ## update each set of hosts that had similar configurations
     foreach my $sig (keys %groups) {
-	my @hosts = @{$groups{$sig}};
-	my $hosts = join(',', @hosts);
-	my $h     = $hosts[0];
-	my $ip    = $config{$h}{'wantip'};
-	delete $config{$_}{'wantip'} foreach @hosts;
+    my @hosts = @{$groups{$sig}};
+    my $hosts = join(',', @hosts);
+    my $h     = $hosts[0];
+    my $ip    = $config{$h}{'wantip'};
+    delete $config{$_}{'wantip'} foreach @hosts;
 
-	info("setting IP address to %s for %s", $ip, $hosts);
-	verbose("UPDATE:","updating %s", $hosts);
+    info("setting IP address to %s for %s", $ip, $hosts);
+    verbose("UPDATE:","updating %s", $hosts);
 
-	my $url = '';
-	$url  .= "http://$config{$h}{'server'}/auth/dynamic.html";
-	$url  .= "?host=$hosts";
-	$url  .= "&dnsto=$ip"   if $ip;
-	$url  .= "&zone=$config{$h}{'zone'}" if defined $config{$h}{'zone'};
+    my $url = '';
+    $url  .= "http://$config{$h}{'server'}/auth/dynamic.html";
+    $url  .= "?host=$hosts";
+    $url  .= "&dnsto=$ip"   if $ip;
+    $url  .= "&zone=$config{$h}{'zone'}" if defined $config{$h}{'zone'};
 
-	my $reply = geturl(opt('proxy'), $url, $config{$h}{'login'}, $config{$h}{'password'});
-	if (!defined($reply) || !$reply) {
-	    failed("updating %s: Could not connect to %s.", $hosts, $config{$h}{'server'});
-	    last;
-	}
-	last if !header_ok($hosts, $reply);
-
-	my @reply = split /\n/, $reply;
-	foreach my $line (@reply) {
-	    if ($line =~ /^[^<]*<(SUCCESS|ERROR)\s+([^>]+)>(.*)/)  {
-		my ($status, $assignments, $rest) = ($1, $2, $3);
-		my ($left, %var) = parse_assignments($assignments);
-
-		if (keys %var) {
-		    my ($status_code, $status_text, $status_ip) = ('999', '', $ip);
-		    $status_code = $var{'CODE'} if exists $var{'CODE'};
-		    $status_text = $var{'TEXT'} if exists $var{'TEXT'};
-		    $status_ip   = $var{'IP'}   if exists $var{'IP'};
-
-		    if ($status eq 'SUCCESS' || ($status eq 'ERROR' && $var{'CODE'} eq '707')) {
-			$config{$h}{'ip'}     = $status_ip;
-			$config{$h}{'mtime'}  = $now;
-	    		$config{$h}{'status'} = 'good';
-
-			success("updating %s: IP address set to %s (%s: %s)", $h, $ip, $status_code, $status_text);
-
-		    } else {
-	    		$config{$h}{'status'} = 'failed';
-			failed("updating %s: %s: %s", $h, $status_code, $status_text);
-		    } 	
-		    shift @hosts;
-		    $h     = $hosts[0];
-		    $hosts = join(',', @hosts);
-		}
-		$line = $rest;
-		redo if $line;
-	    }
-	}
-	failed("updating %s: no response from %s", $hosts, $config{$h}{'server'})
-	      if @hosts;
+    my $reply = geturl(opt('proxy'), $url, $config{$h}{'login'}, $config{$h}{'password'});
+    if (!defined($reply) || !$reply) {
+        failed("updating %s: Could not connect to %s.", $hosts, $config{$h}{'server'});
+        last;
     }
-}	
+    last if !header_ok($hosts, $reply);
+
+    my @reply = split /\n/, $reply;
+    foreach my $line (@reply) {
+        if ($line =~ /^[^<]*<(SUCCESS|ERROR)\s+([^>]+)>(.*)/)  {
+        my ($status, $assignments, $rest) = ($1, $2, $3);
+        my ($left, %var) = parse_assignments($assignments);
+
+        if (keys %var) {
+            my ($status_code, $status_text, $status_ip) = ('999', '', $ip);
+            $status_code = $var{'CODE'} if exists $var{'CODE'};
+            $status_text = $var{'TEXT'} if exists $var{'TEXT'};
+            $status_ip   = $var{'IP'}   if exists $var{'IP'};
+
+            if ($status eq 'SUCCESS' || ($status eq 'ERROR' && $var{'CODE'} eq '707')) {
+            $config{$h}{'ip'}     = $status_ip;
+            $config{$h}{'mtime'}  = $now;
+                $config{$h}{'status'} = 'good';
+
+            success("updating %s: IP address set to %s (%s: %s)", $h, $ip, $status_code, $status_text);
+
+            } else {
+                $config{$h}{'status'} = 'failed';
+            failed("updating %s: %s: %s", $h, $status_code, $status_text);
+            }   
+            shift @hosts;
+            $h     = $hosts[0];
+            $hosts = join(',', @hosts);
+        }
+        $line = $rest;
+        redo if $line;
+        }
+    }
+    failed("updating %s: no response from %s", $hosts, $config{$h}{'server'})
+          if @hosts;
+    }
+}   
 ######################################################################
 ## nic_easydns_updateable
 ######################################################################
@@ -3181,17 +3181,17 @@ sub nic_easydns_updateable {
     my $update = 0;
 
     if ($config{$host}{'mx'} ne $cache{$host}{'mx'}) {
-	info("forcing updating %s because 'mx' has changed to %s.", $host, $config{$host}{'mx'});
-	$update = 1;
+    info("forcing updating %s because 'mx' has changed to %s.", $host, $config{$host}{'mx'});
+    $update = 1;
 
     } elsif ($config{$host}{'mx'} && (ynu($config{$host}{'backupmx'},1,2,3) ne ynu($config{$host}{'backupmx'},1,2,3))) {
-	info("forcing updating %s because 'backupmx' has changed to %s.", $host, ynu($config{$host}{'backupmx'},"YES","NO","NO"));
-	$update = 1;
+    info("forcing updating %s because 'backupmx' has changed to %s.", $host, ynu($config{$host}{'backupmx'},"YES","NO","NO"));
+    $update = 1;
 
     } elsif ($config{$host}{'static'} ne $cache{$host}{'static'}) {
 
-	info("forcing updating %s because 'static' has changed to %s.", $host, ynu($config{$host}{'static'},"YES","NO","NO"));
-	$update = 1;
+    info("forcing updating %s because 'static' has changed to %s.", $host, ynu($config{$host}{'static'},"YES","NO","NO"));
+    $update = 1;
 
     }
     return $update;
@@ -3261,81 +3261,81 @@ sub nic_easydns_update {
 
     ## update each set of hosts that had similar configurations
     foreach my $sig (keys %groups) {
-    	my @hosts = @{$groups{$sig}};
-    	my $hosts = join(',', @hosts);
-    	my $h     = $hosts[0];
-	my $ip    = $config{$h}{'wantip'};
-	delete $config{$_}{'wantip'} foreach @hosts;
+        my @hosts = @{$groups{$sig}};
+        my $hosts = join(',', @hosts);
+        my $h     = $hosts[0];
+    my $ip    = $config{$h}{'wantip'};
+    delete $config{$_}{'wantip'} foreach @hosts;
 
-	info("setting IP address to %s for %s", $ip, $hosts);
-	verbose("UPDATE:","updating %s", $hosts);
+    info("setting IP address to %s for %s", $ip, $hosts);
+    verbose("UPDATE:","updating %s", $hosts);
 
-	#'http://members.easydns.com/dyn/dyndns.php?hostname=test.burry.ca&myip=10.20.30.40&wildcard=ON'
+    #'http://members.easydns.com/dyn/dyndns.php?hostname=test.burry.ca&myip=10.20.30.40&wildcard=ON'
 
-	my $url;
-	$url   = "http://$config{$h}{'server'}/dyn/dyndns.php?";
-	$url  .= "hostname=$hosts";
-	$url  .= "&myip=";
-	$url  .= $ip            if $ip;
-	$url  .= "&wildcard=" . ynu($config{$h}{'wildcard'}, 'ON', 'OFF', 'OFF') if defined $config{$h}{'wildcard'};
+    my $url;
+    $url   = "http://$config{$h}{'server'}/dyn/dyndns.php?";
+    $url  .= "hostname=$hosts";
+    $url  .= "&myip=";
+    $url  .= $ip            if $ip;
+    $url  .= "&wildcard=" . ynu($config{$h}{'wildcard'}, 'ON', 'OFF', 'OFF') if defined $config{$h}{'wildcard'};
 
-	if ($config{$h}{'mx'}) {
-	    $url .= "&mx=$config{$h}{'mx'}";
-	    $url .= "&backmx=" . ynu($config{$h}{'backupmx'}, 'YES', 'NO');
-	}
-
-	my $reply = geturl(opt('proxy'), $url, $config{$h}{'login'}, $config{$h}{'password'});
-	if (!defined($reply) || !$reply) {
-	    failed("updating %s: Could not connect to %s.", $hosts, $config{$h}{'server'});
-	    last;
-	}
-	last if !header_ok($hosts, $reply);
-	
-	my @reply = split /\n/, $reply;
-	my $state = 'header';
-	foreach my $line (@reply) {
-	    if ($state eq 'header') {
-		$state = 'body';
-	    
-	    } elsif ($state eq 'body') {
-		$state = 'results' if $line eq '';
-	    
-	    } elsif ($state =~ /^results/) {
-		$state = 'results2';
-
-		my ($status) = $line =~ /^(\S*)\b.*/;
-		my $h = shift @hosts;
-	    
-		$config{$h}{'status'} = $status;
-		if ($status eq 'NOERROR') {
-		    $config{$h}{'ip'}     = $ip;
-		    $config{$h}{'mtime'}  = $now;
-		    success("updating %s: %s: IP address set to %s", $h, $status, $ip);
-		
-		} elsif ($status =~ /TOOSOON/) {
-		    ## make sure we wait at least a little
-		    my ($wait, $units) = (5, 'm');
-		    my ($sec,  $scale) = ($wait, 1);
-		
-		    ($scale, $units) = (1, 'seconds')   if $units eq 's';
-		    ($scale, $units) = (60, 'minutes')  if $units eq 'm';
-		    ($scale, $units) = (60*60, 'hours') if $units eq 'h';
-		    $config{$h}{'wtime'} = $now + $sec;
-		    warning("updating %s: %s: wait $wait $units before further updates", $h, $status, $ip);
-		
-		} elsif (exists $errors{$status}) {
-		    failed("updating %s: %s: %s", $h, $line, $errors{$status});
-
-		} else {
-		    failed("updating %s: %s: unexpected status (%s)", $h, $line);
-		} 	
-		last;
-	    }
-	}
-	failed("updating %s: Could not connect to %s.", $hosts, $config{$h}{'server'})
-	    if $state ne 'results2';
+    if ($config{$h}{'mx'}) {
+        $url .= "&mx=$config{$h}{'mx'}";
+        $url .= "&backmx=" . ynu($config{$h}{'backupmx'}, 'YES', 'NO');
     }
-}	
+
+    my $reply = geturl(opt('proxy'), $url, $config{$h}{'login'}, $config{$h}{'password'});
+    if (!defined($reply) || !$reply) {
+        failed("updating %s: Could not connect to %s.", $hosts, $config{$h}{'server'});
+        last;
+    }
+    last if !header_ok($hosts, $reply);
+    
+    my @reply = split /\n/, $reply;
+    my $state = 'header';
+    foreach my $line (@reply) {
+        if ($state eq 'header') {
+        $state = 'body';
+        
+        } elsif ($state eq 'body') {
+        $state = 'results' if $line eq '';
+        
+        } elsif ($state =~ /^results/) {
+        $state = 'results2';
+
+        my ($status) = $line =~ /^(\S*)\b.*/;
+        my $h = shift @hosts;
+        
+        $config{$h}{'status'} = $status;
+        if ($status eq 'NOERROR') {
+            $config{$h}{'ip'}     = $ip;
+            $config{$h}{'mtime'}  = $now;
+            success("updating %s: %s: IP address set to %s", $h, $status, $ip);
+        
+        } elsif ($status =~ /TOOSOON/) {
+            ## make sure we wait at least a little
+            my ($wait, $units) = (5, 'm');
+            my ($sec,  $scale) = ($wait, 1);
+        
+            ($scale, $units) = (1, 'seconds')   if $units eq 's';
+            ($scale, $units) = (60, 'minutes')  if $units eq 'm';
+            ($scale, $units) = (60*60, 'hours') if $units eq 'h';
+            $config{$h}{'wtime'} = $now + $sec;
+            warning("updating %s: %s: wait $wait $units before further updates", $h, $status, $ip);
+        
+        } elsif (exists $errors{$status}) {
+            failed("updating %s: %s: %s", $h, $line, $errors{$status});
+
+        } else {
+            failed("updating %s: %s: unexpected status (%s)", $h, $line);
+        }   
+        last;
+        }
+    }
+    failed("updating %s: Could not connect to %s.", $hosts, $config{$h}{'server'})
+        if $state ne 'results2';
+    }
+}   
 ######################################################################
 
 ######################################################################
@@ -3346,12 +3346,12 @@ sub nic_dnspark_updateable {
     my $update = 0;
 
     if ($config{$host}{'mx'} ne $cache{$host}{'mx'}) {
-	info("forcing updating %s because 'mx' has changed to %s.", $host, $config{$host}{'mx'});
-	$update = 1;
+    info("forcing updating %s because 'mx' has changed to %s.", $host, $config{$host}{'mx'});
+    $update = 1;
 
     } elsif ($config{$host}{'mx'} && ($config{$host}{'mxpri'} ne $cache{$host}{'mxpri'})) {
-	info("forcing updating %s because 'mxpri' has changed to %s.", $host, $config{$host}{'mxpri'});
-	$update = 1;
+    info("forcing updating %s because 'mxpri' has changed to %s.", $host, $config{$host}{'mxpri'});
+    $update = 1;
     }
     return $update;
 }
@@ -3387,7 +3387,7 @@ Example ${program}.conf file entries:
   login=my-dnspark.com-login,                               \\
   password=my-dnspark.com-password,                         \\
   mx=a.host.willing.to.mx.for.me,                           \\
-  mxpri=10, 	                                            \\
+  mxpri=10,                                                 \\
   my-toplevel-domain.com,my-other-domain.com
 
   ## multiple host update to the custom DNS service
@@ -3421,80 +3421,80 @@ sub nic_dnspark_update {
 
     ## update each set of hosts that had similar configurations
     foreach my $sig (keys %groups) {
-    	my @hosts = @{$groups{$sig}};
-    	my $hosts = join(',', @hosts);
-    	my $h     = $hosts[0];
-	my $ip    = $config{$h}{'wantip'};
-	delete $config{$_}{'wantip'} foreach @hosts;
+        my @hosts = @{$groups{$sig}};
+        my $hosts = join(',', @hosts);
+        my $h     = $hosts[0];
+    my $ip    = $config{$h}{'wantip'};
+    delete $config{$_}{'wantip'} foreach @hosts;
 
-	info("setting IP address to %s for %s", $ip, $hosts);
-	verbose("UPDATE:","updating %s", $hosts);
+    info("setting IP address to %s for %s", $ip, $hosts);
+    verbose("UPDATE:","updating %s", $hosts);
 
-	#'http://www.dnspark.com:80/visitors/update.html?myip=10.20.30.40&hostname=test.burry.ca'
+    #'http://www.dnspark.com:80/visitors/update.html?myip=10.20.30.40&hostname=test.burry.ca'
 
-	my $url;
-	$url   = "http://$config{$h}{'server'}/visitors/update.html";
-	$url  .= "?hostname=$hosts";
-	$url  .= "&myip=";
-	$url  .= $ip            if $ip;
+    my $url;
+    $url   = "http://$config{$h}{'server'}/visitors/update.html";
+    $url  .= "?hostname=$hosts";
+    $url  .= "&myip=";
+    $url  .= $ip            if $ip;
 
-	if ($config{$h}{'mx'}) {
-	    $url .= "&mx=$config{$h}{'mx'}";
-	    $url .= "&mxpri=" . $config{$h}{'mxpri'};
-	}
-
-	my $reply = geturl(opt('proxy'), $url, $config{$h}{'login'}, $config{$h}{'password'});
-	if (!defined($reply) || !$reply) {
-	    failed("updating %s: Could not connect to %s.", $hosts, $config{$h}{'server'});
-	    last;
-	}
-	last if !header_ok($hosts, $reply);
-	
-	my @reply = split /\n/, $reply;
-	my $state = 'header';
-	foreach my $line (@reply) {
-	    if ($state eq 'header') {
-		$state = 'body';
-	    
-	    } elsif ($state eq 'body') {
-		$state = 'results' if $line eq '';
-	    
-	    } elsif ($state =~ /^results/) {
-		$state = 'results2';
-
-		my ($status) = $line =~ /^(\S*)\b.*/;
-		my $h = pop @hosts;
-	    
-		$config{$h}{'status'} = $status;
-		if ($status eq 'ok') {
-		    $config{$h}{'ip'}     = $ip;
-		    $config{$h}{'mtime'}  = $now;
-		    success("updating %s: %s: IP address set to %s", $h, $status, $ip);
-		
-		} elsif ($status =~ /TOOSOON/) {
-		    ## make sure we wait at least a little
-		    my ($wait, $units) = (5, 'm');
-		    my ($sec,  $scale) = ($wait, 1);
-		
-		    ($scale, $units) = (1, 'seconds')   if $units eq 's';
-		    ($scale, $units) = (60, 'minutes')  if $units eq 'm';
-		    ($scale, $units) = (60*60, 'hours') if $units eq 'h';
-		    $config{$h}{'wtime'} = $now + $sec;
-		    warning("updating %s: %s: wait $wait $units before further updates", $h, $status, $ip);
-		
-		} elsif (exists $errors{$status}) {
-		    failed("updating %s: %s: %s", $h, $line, $errors{$status});
-
-		} else {
-		    failed("updating %s: %s: unexpected status (%s)", $h, $line);
-		} 	
-		last;
-	    }
-	}
-	failed("updating %s: Could not connect to %s.", $hosts, $config{$h}{'server'})
-	    if $state ne 'results2';
+    if ($config{$h}{'mx'}) {
+        $url .= "&mx=$config{$h}{'mx'}";
+        $url .= "&mxpri=" . $config{$h}{'mxpri'};
     }
-}	
+
+    my $reply = geturl(opt('proxy'), $url, $config{$h}{'login'}, $config{$h}{'password'});
+    if (!defined($reply) || !$reply) {
+        failed("updating %s: Could not connect to %s.", $hosts, $config{$h}{'server'});
+        last;
+    }
+    last if !header_ok($hosts, $reply);
+    
+    my @reply = split /\n/, $reply;
+    my $state = 'header';
+    foreach my $line (@reply) {
+        if ($state eq 'header') {
+        $state = 'body';
+        
+        } elsif ($state eq 'body') {
+        $state = 'results' if $line eq '';
+        
+        } elsif ($state =~ /^results/) {
+        $state = 'results2';
+
+        my ($status) = $line =~ /^(\S*)\b.*/;
+        my $h = pop @hosts;
+        
+        $config{$h}{'status'} = $status;
+        if ($status eq 'ok') {
+            $config{$h}{'ip'}     = $ip;
+            $config{$h}{'mtime'}  = $now;
+            success("updating %s: %s: IP address set to %s", $h, $status, $ip);
+        
+        } elsif ($status =~ /TOOSOON/) {
+            ## make sure we wait at least a little
+            my ($wait, $units) = (5, 'm');
+            my ($sec,  $scale) = ($wait, 1);
+        
+            ($scale, $units) = (1, 'seconds')   if $units eq 's';
+            ($scale, $units) = (60, 'minutes')  if $units eq 'm';
+            ($scale, $units) = (60*60, 'hours') if $units eq 'h';
+            $config{$h}{'wtime'} = $now + $sec;
+            warning("updating %s: %s: wait $wait $units before further updates", $h, $status, $ip);
+        
+        } elsif (exists $errors{$status}) {
+            failed("updating %s: %s: %s", $h, $line, $errors{$status});
+
+        } else {
+            failed("updating %s: %s: unexpected status (%s)", $h, $line);
+        }   
+        last;
+        }
+    }
+    failed("updating %s: Could not connect to %s.", $hosts, $config{$h}{'server'})
+        if $state ne 'results2';
+    }
+}   
 
 ######################################################################
 
@@ -3542,17 +3542,17 @@ sub nic_namecheap_update {
 
     ## update each configured host
     foreach my $h (@_) {
-	my $ip = delete $config{$h}{'wantip'};
+    my $ip = delete $config{$h}{'wantip'};
         info("setting IP address to %s for %s", $ip, $h);
         verbose("UPDATE:","updating %s", $h);
 
         my $url;
         $url   = "http://$config{$h}{'server'}/update";
-	my $domain = $config{$h}{'login'};
-	my $host = $h;
-	$host  =~ s/(.*)\.$domain(.*)/$1$2/;
-	$url  .= "?host=$host";
-	$url  .= "&domain=$domain";
+    my $domain = $config{$h}{'login'};
+    my $host = $h;
+    $host  =~ s/(.*)\.$domain(.*)/$1$2/;
+    $url  .= "?host=$host";
+    $url  .= "&domain=$domain";
         $url  .= "&password=$config{$h}{'password'}";
         $url  .= "&ip=";
         $url  .= $ip if $ip;
@@ -3628,7 +3628,7 @@ sub nic_sitelutions_update {
 
     ## update each configured host
     foreach my $h (@_) {
-	my $ip = delete $config{$h}{'wantip'};
+    my $ip = delete $config{$h}{'wantip'};
         info("setting IP address to %s for %s", $ip, $h);
         verbose("UPDATE:","updating %s", $h);
 
@@ -3714,53 +3714,53 @@ sub nic_freedns_update {
     my $reply = geturl(opt('proxy'), $url);
     if (!defined($reply) || !$reply || !header_ok($_[0], $reply)) {
         failed("updating %s: Could not connect to %s for site list.", $_[0], $url);
-	return;
+    return;
     }
     my @lines = split("\n", $reply);
     my %freedns_hosts;
     grep {
         my @rec = split(/\|/, $_);
-	$freedns_hosts{$rec[0]} = \@rec if ($#rec > 0);
+    $freedns_hosts{$rec[0]} = \@rec if ($#rec > 0);
     } @lines;
     if (!keys %freedns_hosts) {
-	failed("Could not get freedns update URLs from %s", $config{$_[0]}{'server'});
-	return;
+    failed("Could not get freedns update URLs from %s", $config{$_[0]}{'server'});
+    return;
     }
     ## update each configured host
     foreach my $h (@_) {
         if(!$h){ next };
         my $ip = delete $config{$h}{'wantip'};
-	info("setting IP address to %s for %s", $ip, $h);
-	verbose("UPDATE:","updating %s", $h);
+    info("setting IP address to %s for %s", $ip, $h);
+    verbose("UPDATE:","updating %s", $h);
 
-	if($ip eq $freedns_hosts{$h}->[1]) { 
-	    $config{$h}{'ip'}     = $ip; 
-	    $config{$h}{'mtime'}  = $now; 
-	    $config{$h}{'status'} = 'good'; 
-	    success("update not necessary %s: good: IP address already set to %s", $h, $ip); 
-	} else {
-	    my $reply = geturl(opt('proxy'), $freedns_hosts{$h}->[2]);
-	    if (!defined($reply) || !$reply) {
-	        failed("updating %s: Could not connect to %s.", $h, $freedns_hosts{$h}->[2]);
-		last;
-	    }
-	    if(!header_ok($h, $reply)) { 
-		$config{$h}{'status'} = 'failed'; 
-		last; 
-	    }
+    if($ip eq $freedns_hosts{$h}->[1]) { 
+        $config{$h}{'ip'}     = $ip; 
+        $config{$h}{'mtime'}  = $now; 
+        $config{$h}{'status'} = 'good'; 
+        success("update not necessary %s: good: IP address already set to %s", $h, $ip); 
+    } else {
+        my $reply = geturl(opt('proxy'), $freedns_hosts{$h}->[2]);
+        if (!defined($reply) || !$reply) {
+            failed("updating %s: Could not connect to %s.", $h, $freedns_hosts{$h}->[2]);
+        last;
+        }
+        if(!header_ok($h, $reply)) { 
+        $config{$h}{'status'} = 'failed'; 
+        last; 
+        }
 
-	    if($reply =~ /Updated.*$h.*to.*$ip/) { 
-		$config{$h}{'ip'}     = $ip; 
-		$config{$h}{'mtime'}  = $now; 
-		$config{$h}{'status'} = 'good'; 
-		success("updating %s: good: IP address set to %s", $h, $ip); 
-	    } else {
-	        $config{$h}{'status'} = 'failed';
-		warning("SENT: %s", $freedns_hosts{$h}->[2]) unless opt('verbose');
-		warning("REPLIED: %s", $reply);
-		failed("updating %s: Invalid reply.", $h);
-	    }
-	}
+        if($reply =~ /Updated.*$h.*to.*$ip/) { 
+        $config{$h}{'ip'}     = $ip; 
+        $config{$h}{'mtime'}  = $now; 
+        $config{$h}{'status'} = 'good'; 
+        success("updating %s: good: IP address set to %s", $h, $ip); 
+        } else {
+            $config{$h}{'status'} = 'failed';
+        warning("SENT: %s", $freedns_hosts{$h}->[2]) unless opt('verbose');
+        warning("REPLIED: %s", $reply);
+        failed("updating %s: Invalid reply.", $h);
+        }
+    }
     }
 }
 
@@ -3806,7 +3806,7 @@ sub nic_changeip_update {
 
     ## update each configured host
     foreach my $h (@_) {
-	my $ip = delete $config{$h}{'wantip'};
+    my $ip = delete $config{$h}{'wantip'};
         info("setting IP address to %s for %s", $ip, $h);
         verbose("UPDATE:","updating %s", $h);
 
@@ -3816,7 +3816,7 @@ sub nic_changeip_update {
         $url  .= "&ip=";
         $url  .= $ip if $ip;
 
-		my $reply = geturl(opt('proxy'), $url, $config{$h}{'login'}, $config{$h}{'password'});
+        my $reply = geturl(opt('proxy'), $url, $config{$h}{'login'}, $config{$h}{'password'});
         if (!defined($reply) || !$reply) {
             failed("updating %s: Could not connect to %s.", $h, $config{$h}{'server'});
             last;
@@ -3875,7 +3875,7 @@ sub nic_dtdns_update {
 
     ## update each configured host
     foreach my $h (@_) {
-	my $ip = delete $config{$h}{'wantip'};
+    my $ip = delete $config{$h}{'wantip'};
         info("setting IP address to %s for %s", $ip, $h);
         verbose("UPDATE:","updating %s", $h);
 
@@ -4043,58 +4043,58 @@ EoEXAMPLE
 ## by Daniel Roethlisberger <daniel@roe.ch>
 ######################################################################
 sub nic_nsupdate_update {
-	debug("\nnic_nsupdate_update -------------------");
+    debug("\nnic_nsupdate_update -------------------");
 
-	## group hosts with identical attributes together
-	my %groups = group_hosts_by([ @_ ], [ qw(login password server zone) ]);
+    ## group hosts with identical attributes together
+    my %groups = group_hosts_by([ @_ ], [ qw(login password server zone) ]);
 
-	## update each set of hosts that had similar configurations
-	foreach my $sig (keys %groups) {
-		my @hosts = @{$groups{$sig}};
-		my $hosts = join(',', @hosts);
-		my $h = $hosts[0];
-		my $binary = $config{$h}{'login'};
-		my $keyfile = $config{$h}{'password'};
-		my $server = $config{$h}{'server'};
-		my $zone = $config{$h}{'zone'};
-		my $ip = $config{$h}{'wantip'};
-		delete $config{$_}{'wantip'} foreach @hosts;
+    ## update each set of hosts that had similar configurations
+    foreach my $sig (keys %groups) {
+        my @hosts = @{$groups{$sig}};
+        my $hosts = join(',', @hosts);
+        my $h = $hosts[0];
+        my $binary = $config{$h}{'login'};
+        my $keyfile = $config{$h}{'password'};
+        my $server = $config{$h}{'server'};
+        my $zone = $config{$h}{'zone'};
+        my $ip = $config{$h}{'wantip'};
+        delete $config{$_}{'wantip'} foreach @hosts;
 
-		info("setting IP address to %s for %s", $ip, $hosts);
-		verbose("UPDATE:","updating %s", $hosts);
+        info("setting IP address to %s for %s", $ip, $hosts);
+        verbose("UPDATE:","updating %s", $hosts);
 
-		## send separate requests for each zone with all hosts in that zone
-		my $instructions = <<EoINSTR1;
+        ## send separate requests for each zone with all hosts in that zone
+        my $instructions = <<EoINSTR1;
 server $server
 zone $zone.
 EoINSTR1
-		foreach (@hosts) {
-			$instructions .= <<EoINSTR2;
+        foreach (@hosts) {
+            $instructions .= <<EoINSTR2;
 update delete $_. A
 update add $_. $config{$_}{'ttl'} A $ip
 EoINSTR2
-		}
-		$instructions .= <<EoINSTR3;
+        }
+        $instructions .= <<EoINSTR3;
 send
 EoINSTR3
-		my $command = "$binary -k $keyfile";
-		$command .= " -d" if (opt('debug'));
-		verbose("UPDATE:", "nsupdate command is: %s", $command);
-		verbose("UPDATE:", "nsupdate instructions are:\n%s", $instructions);
+        my $command = "$binary -k $keyfile";
+        $command .= " -d" if (opt('debug'));
+        verbose("UPDATE:", "nsupdate command is: %s", $command);
+        verbose("UPDATE:", "nsupdate instructions are:\n%s", $instructions);
 
-		my $status = pipecmd($command, $instructions);
-		if ($status eq 1) {
-			foreach (@hosts) {
-				$config{$_}{'ip'} = $ip;
-				$config{$_}{'mtime'} = $now;
-				success("updating %s: %s: IP address set to %s", $_, $status, $ip);
-			}
-		} else {
-			foreach (@hosts) {
-				failed("updating %s", $_);
-			}
-		}
-	}
+        my $status = pipecmd($command, $instructions);
+        if ($status eq 1) {
+            foreach (@hosts) {
+                $config{$_}{'ip'} = $ip;
+                $config{$_}{'mtime'} = $now;
+                success("updating %s: %s: IP address set to %s", $_, $status, $ip);
+            }
+        } else {
+            foreach (@hosts) {
+                failed("updating %s", $_);
+            }
+        }
+    }
 }
 
 ######################################################################
@@ -4138,88 +4138,88 @@ EoEXAMPLE
 ## nic_cloudflare_update
 ######################################################################
 sub nic_cloudflare_update {
-	debug("\nnic_cloudflare_update -------------------");
+    debug("\nnic_cloudflare_update -------------------");
 
-	## group hosts with identical attributes together 
-	my %groups = group_hosts_by([ @_ ], [ qw(ssh login password server wildcard mx backupmx zone) ]);
+    ## group hosts with identical attributes together 
+    my %groups = group_hosts_by([ @_ ], [ qw(ssh login password server wildcard mx backupmx zone) ]);
 
-	## update each set of hosts that had similar configurations
-	foreach my $sig (keys %groups) {
-		my @hosts = @{$groups{$sig}};
-		my $hosts = join(',', @hosts);
-		my $key   = $hosts[0];
-		my $ip    = $config{$key}{'wantip'};
+    ## update each set of hosts that had similar configurations
+    foreach my $sig (keys %groups) {
+        my @hosts = @{$groups{$sig}};
+        my $hosts = join(',', @hosts);
+        my $key   = $hosts[0];
+        my $ip    = $config{$key}{'wantip'};
 
-		# FQDNs
-		for my $domain (@hosts) {
-			(my $hostname = $domain) =~ s/\.$config{$key}{zone}$//;
-			delete $config{$domain}{'wantip'};
+        # FQDNs
+        for my $domain (@hosts) {
+            (my $hostname = $domain) =~ s/\.$config{$key}{zone}$//;
+            delete $config{$domain}{'wantip'};
 
-			info("setting IP address to %s for %s", $ip, $domain);
-			verbose("UPDATE:","updating %s", $domain);
+            info("setting IP address to %s for %s", $ip, $domain);
+            verbose("UPDATE:","updating %s", $domain);
 
-			# Get domain ID
-			my $url = "https://$config{$key}{'server'}/api_json.html?a=rec_load_all";
-			$url   .= "&z=".$config{$key}{'zone'};
-			$url   .= "&email=".$config{$key}{'login'};	
-			$url   .= "&tkn=".$config{$key}{'password'};
+            # Get domain ID
+            my $url = "https://$config{$key}{'server'}/api_json.html?a=rec_load_all";
+            $url   .= "&z=".$config{$key}{'zone'};
+            $url   .= "&email=".$config{$key}{'login'}; 
+            $url   .= "&tkn=".$config{$key}{'password'};
 
-			my $reply = geturl(opt('proxy'), $url);
-			unless ($reply) {
-				failed("updating %s: Could not connect to %s.", $domain, $config{$key}{'server'});
-				last;
-			}
-			last if !header_ok($domain, $reply);
+            my $reply = geturl(opt('proxy'), $url);
+            unless ($reply) {
+                failed("updating %s: Could not connect to %s.", $domain, $config{$key}{'server'});
+                last;
+            }
+            last if !header_ok($domain, $reply);
 
-			# Strip header
-			$reply =~ s/^.*?\n\n//s;
-			my $response = JSON::Any->jsonToObj($reply);
-			if ($response->{result} eq 'error') {
-				failed ("%s", $response->{msg});
-				next; 
-			}
+            # Strip header
+            $reply =~ s/^.*?\n\n//s;
+            my $response = JSON::Any->jsonToObj($reply);
+            if ($response->{result} eq 'error') {
+                failed ("%s", $response->{msg});
+                next; 
+            }
 
-			# Pull the ID out of the json, messy
-			my ($id) = map { $_->{name} eq $domain ? $_->{rec_id} : () } @{ $response->{response}->{recs}->{objs} };
-			unless($id) {
-				failed("updating %s: No domain ID found.", $domain);
-				next;
-			}
+            # Pull the ID out of the json, messy
+            my ($id) = map { $_->{name} eq $domain ? $_->{rec_id} : () } @{ $response->{response}->{recs}->{objs} };
+            unless($id) {
+                failed("updating %s: No domain ID found.", $domain);
+                next;
+            }
 
-			# Set domain
-			$url   = "https://$config{$key}{'server'}/api_json.html?a=rec_edit&type=A";
-			$url	 .= "&ttl=".$config{$key}{'ttl'};
-			$url     .= "&name=$hostname";
-			$url     .= "&z=".$config{$key}{'zone'};
-			$url     .= "&id=".$id;	
-			$url     .= "&email=".$config{$key}{'login'};	
-			$url     .= "&tkn=".$config{$key}{'password'};    
-			$url     .= "&content=";
-			$url     .= "$ip"       if $ip;
+            # Set domain
+            $url   = "https://$config{$key}{'server'}/api_json.html?a=rec_edit&type=A";
+            $url     .= "&ttl=".$config{$key}{'ttl'};
+            $url     .= "&name=$hostname";
+            $url     .= "&z=".$config{$key}{'zone'};
+            $url     .= "&id=".$id; 
+            $url     .= "&email=".$config{$key}{'login'};   
+            $url     .= "&tkn=".$config{$key}{'password'};    
+            $url     .= "&content=";
+            $url     .= "$ip"       if $ip;
 
-			$reply = geturl(opt('proxy'), $url);
-			unless ($reply) {
-				failed("updating %s: Could not connect to %s.", $domain, $config{$domain}{'server'});
-				last;
-			}
-			last if !header_ok($domain, $reply);
+            $reply = geturl(opt('proxy'), $url);
+            unless ($reply) {
+                failed("updating %s: Could not connect to %s.", $domain, $config{$domain}{'server'});
+                last;
+            }
+            last if !header_ok($domain, $reply);
 
-			# Strip header
-			$reply =~ s/^.*?\n\n//s;
-			$response = JSON::Any->jsonToObj($reply);
-			if ($response->{result} eq 'error') {
-				failed ("%s", $response->{msg});	
-			} else {
-				success ("%s -- Updated Successfully to %s", $domain, $ip);
+            # Strip header
+            $reply =~ s/^.*?\n\n//s;
+            $response = JSON::Any->jsonToObj($reply);
+            if ($response->{result} eq 'error') {
+                failed ("%s", $response->{msg});    
+            } else {
+                success ("%s -- Updated Successfully to %s", $domain, $ip);
 
-			}
+            }
 
-			# Cache
-			$config{$key}{'ip'}     = $ip;
-			$config{$key}{'mtime'}  = $now;
-			$config{$key}{'status'} = 'good';
-		}
-	}
+            # Cache
+            $config{$key}{'ip'}     = $ip;
+            $config{$key}{'mtime'}  = $now;
+            $config{$key}{'status'} = 'good';
+        }
+    }
 }
 
 ######################################################################
@@ -4387,13 +4387,13 @@ sub nic_woima_update {
         if ($config{$h}{'custom'}) {
             warning("updating %s: 'custom' and 'static' may not be used together. ('static' ignored)", $h)
             if $config{$h}{'static'};
-    #	    warning("updating %s: 'custom' and 'offline' may not be used together. ('offline' ignored)", $h)
-    #	      if $config{$h}{'offline'};
+    #       warning("updating %s: 'custom' and 'offline' may not be used together. ('offline' ignored)", $h)
+    #         if $config{$h}{'offline'};
             $url .= 'custom';
     
         } elsif  ($config{$h}{'static'}) {
-    #	    warning("updating %s: 'static' and 'offline' may not be used together. ('offline' ignored)", $h)
-    #	      if $config{$h}{'offline'};
+    #       warning("updating %s: 'static' and 'offline' may not be used together. ('offline' ignored)", $h)
+    #         if $config{$h}{'offline'};
             $url .= 'statdns';
     
         } else {
@@ -4469,7 +4469,7 @@ sub nic_woima_update {
                 
                 } else {
                     failed("updating %s: %s: unexpected status (%s)", $h, $line);
-                } 	
+                }   
             }
         }
         failed("updating %s: Could not connect to %s.", $h, $config{$h}{'server'})

--- a/ddclient
+++ b/ddclient
@@ -3751,8 +3751,12 @@ sub nic_freedns_update {
                 $config{$h}{'mtime'}  = $now; 
                 $config{$h}{'status'} = 'good'; 
                 success("updating %s: good: IP address set to %s", $h, $ip); 
-            } elsif ($reply =~ /Address .* has not changed/) {
-                success("updating %s: good: IP address has not changed", $h, $ip);
+            } elsif ($reply =~ /Address (\d+\.\d+\.\d+\.\d+) has not changed/) {
+                $ip = $1;
+                $config{$h}{'mtime'}  = $now; 
+                $config{$h}{'status'} = 'good'; 
+                $config{$h}{'ip'}     = $ip; 
+                success("updating %s: good: IP address %s has not changed", $h, $ip);
             } else {
                 $config{$h}{'status'} = 'failed';
                 warning("SENT: %s", $freedns_hosts{$h}->[2]) unless opt('verbose');

--- a/ddclient
+++ b/ddclient
@@ -25,7 +25,7 @@ use Getopt::Long;
 use Sys::Hostname;
 use IO::Socket;
 
-my $version  = "3.8.3";
+my $version  = "3.8.3.1-hank";
 my $programd  = $0; 
 $programd =~ s%^.*/%%;
 my $program   = $programd;
@@ -3704,63 +3704,62 @@ EoEXAMPLE
 ##
 ######################################################################
 sub nic_freedns_update {
-
-
     debug("\nnic_freedns_update -------------------");
-
     ## First get the list of updatable hosts
     my $url;
     $url = "http://$config{$_[0]}{'server'}/api/?action=getdyndns&sha=".&sha1_hex("$config{$_[0]}{'login'}|$config{$_[0]}{'password'}");
     my $reply = geturl(opt('proxy'), $url);
     if (!defined($reply) || !$reply || !header_ok($_[0], $reply)) {
         failed("updating %s: Could not connect to %s for site list.", $_[0], $url);
-    return;
+        return;
     }
     my @lines = split("\n", $reply);
     my %freedns_hosts;
     grep {
-        my @rec = split(/\|/, $_);
+    my @rec = split(/\|/, $_);
     $freedns_hosts{$rec[0]} = \@rec if ($#rec > 0);
     } @lines;
     if (!keys %freedns_hosts) {
-    failed("Could not get freedns update URLs from %s", $config{$_[0]}{'server'});
-    return;
+        failed("Could not get freedns update URLs from %s", $config{$_[0]}{'server'});
+        return;
     }
     ## update each configured host
     foreach my $h (@_) {
         if(!$h){ next };
         my $ip = delete $config{$h}{'wantip'};
-    info("setting IP address to %s for %s", $ip, $h);
-    verbose("UPDATE:","updating %s", $h);
+        info("setting IP address to %s for %s", $ip, $h);
+        verbose("UPDATE:","updating %s", $h);
 
-    if($ip eq $freedns_hosts{$h}->[1]) { 
-        $config{$h}{'ip'}     = $ip; 
-        $config{$h}{'mtime'}  = $now; 
-        $config{$h}{'status'} = 'good'; 
-        success("update not necessary %s: good: IP address already set to %s", $h, $ip); 
-    } else {
-        my $reply = geturl(opt('proxy'), $freedns_hosts{$h}->[2]);
-        if (!defined($reply) || !$reply) {
-            failed("updating %s: Could not connect to %s.", $h, $freedns_hosts{$h}->[2]);
-        last;
-        }
-        if(!header_ok($h, $reply)) { 
-        $config{$h}{'status'} = 'failed'; 
-        last; 
-        }
-
-        if($reply =~ /Updated.*$h.*to.*$ip/) { 
-        $config{$h}{'ip'}     = $ip; 
-        $config{$h}{'mtime'}  = $now; 
-        $config{$h}{'status'} = 'good'; 
-        success("updating %s: good: IP address set to %s", $h, $ip); 
+        if($ip eq $freedns_hosts{$h}->[1]) { 
+            $config{$h}{'ip'}     = $ip; 
+            $config{$h}{'mtime'}  = $now; 
+            $config{$h}{'status'} = 'good'; 
+            success("update not necessary %s: good: IP address already set to %s", $h, $ip); 
         } else {
-            $config{$h}{'status'} = 'failed';
-        warning("SENT: %s", $freedns_hosts{$h}->[2]) unless opt('verbose');
-        warning("REPLIED: %s", $reply);
-        failed("updating %s: Invalid reply.", $h);
+            my $reply = geturl(opt('proxy'), $freedns_hosts{$h}->[2]);
+            if (!defined($reply) || !$reply) {
+                failed("updating %s: Could not connect to %s.", $h, $freedns_hosts{$h}->[2]);
+                last;
+            }
+            if(!header_ok($h, $reply)) { 
+                $config{$h}{'status'} = 'failed'; 
+                last; 
+            }
+
+            if($reply =~ /Updated.*$h.*to.*$ip/) { 
+                $config{$h}{'ip'}     = $ip; 
+                $config{$h}{'mtime'}  = $now; 
+                $config{$h}{'status'} = 'good'; 
+                success("updating %s: good: IP address set to %s", $h, $ip); 
+            } elsif ($reply =~ /Address .* has not changed/) {
+                success("updating %s: good: IP address has not changed", $h, $ip);
+            } else {
+                $config{$h}{'status'} = 'failed';
+                warning("SENT: %s", $freedns_hosts{$h}->[2]) unless opt('verbose');
+                warning("REPLIED: %s", $reply);
+                failed("updating %s: Invalid reply.", $h);
+            }
         }
-    }
     }
 }
 


### PR DESCRIPTION
When FreeDNS was updating, I was noticing that it would send back an HTTP 200 with the text "Address [IP] has not changed", but ddclient was issuing a failed status for this and logging a ton of text to syslog.  I changed the function a tiny bit to allow this to be a success status.  I also reformatted the code to all spaces instead of mixed spaces and tabs, but you can take that or leave it - I don't really care, it was just a total whitespace disaster before.
