### PR TITLE
Use ipify as default web service

### DIFF
--- a/ddclient
+++ b/ddclient
@@ -304,6 +304,7 @@ sub ip_strategies_usage {
 }
 
 my %web_strategies = (
+	'ipify'=> 1,
 	'dyndns'=> 1,
 	'dnspark'=> 1,
 	'loopia'=> 1,
@@ -333,7 +334,7 @@ my %variables = (
 	'ip'                  => setv(T_IP,    0, 0, 1, undef,                undef),
 	'if'                  => setv(T_IF,    0, 0, 1, 'ppp0',               undef),
 	'if-skip'             => setv(T_STRING,1, 0, 1, '',                   undef),
-	'web'                 => setv(T_STRING,0, 0, 1, 'dyndns',             undef),
+	'web'                 => setv(T_STRING,0, 0, 1, 'ipify',             undef),
 	'web-skip'            => setv(T_STRING,1, 0, 1, '',                   undef),
 	'fw'                  => setv(T_ANY,   0, 0, 1, '', 		      undef),
 	'fw-skip'             => setv(T_STRING,1, 0, 1, '',                   undef),
@@ -373,7 +374,7 @@ my %variables = (
 	'use'                 => setv(T_USE,   0, 0, 1, 'ip',                 undef),
 	'if'                  => setv(T_IF,    0, 0, 1, 'ppp0',               undef),
 	'if-skip'             => setv(T_STRING,0, 0, 1, '',                   undef),
-	'web'                 => setv(T_STRING,0, 0, 1, 'dyndns',             undef),
+	'web'                 => setv(T_STRING,0, 0, 1, 'ipify',             undef),
 	'web-skip'            => setv(T_STRING,0, 0, 1, '',                   undef),
 	'fw'                  => setv(T_ANY,   0, 0, 1, '', 		      undef),
 	'fw-skip'             => setv(T_STRING,0, 0, 1, '',                   undef),

--- a/ddclient
+++ b/ddclient
@@ -66,6 +66,7 @@ sub T_POSTS	{'postscript'};
 
 ## strategies for obtaining an ip address.
 my %builtinweb = (
+   'ipify'        => { 'url' => 'https://api.ipify.org', },
    'dyndns'       => { 'url' => 'http://checkip.dyndns.org/', 'skip' =>
    'Current IP Address:', },
    'dnspark'      => { 'url' => 'http://ipdetect.dnspark.com/', 'skip' => 'Current Address:', },


### PR DESCRIPTION
Since many users including myself had problems with http://checkip.dyndns.org/ i suggest moving to ipify as default service
Info: https://www.ipify.org/
Pro:
-No limit in requests
-Very fast and responsive
-Open source
-https
-No Logging of visitors
-Works with IPv4 and IPv6

Con:
-?
