### PR TITLE
Example config showing how to retrieve IP from fritzbox via UPnP using ddclients cmd option

### DIFF
--- a/get-ip-from-fritzbox
+++ b/get-ip-from-fritzbox
@@ -1,0 +1,12 @@
+#!/bin/bash
+# All credits for this one liner go to the author of this blog:
+# http://scytale.name/blog/2010/01/fritzbox-wan-ip
+# As the author explains its not required to tamper with the provided IP for the FritzBox
+# as it always binds to that address for UPnP.
+# Disclaimer: It might be necessary to make the script executable
+
+curl -s -H 'Content-Type: text/xml; charset="utf-8"' \
+  -H 'SOAPAction: urn:schemas-upnp-org:service:WANIPConnection:1#GetExternalIPAddress' \
+  --data-binary '<?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><u:GetExternalIPAddress xmlns:u="urn:schemas-upnp-org:service:WANIPConnection:1" /></s:Body></s:Envelope>' \
+  http://169.254.1.1:49000/upnp/control/WANCommonIFC1 | \
+  sed -n -e 's#^.*<NewExternalIPAddress>\(.*\)</NewExternalIPAddress>.*$#\1#p'

--- a/sample-duckdns-etc_ddclient.conf
+++ b/sample-duckdns-etc_ddclient.conf
@@ -1,0 +1,28 @@
+######################################################################
+## 
+## Define default global variables with lines like:
+## 	var=value [, var=value]*
+## These values will be used for each following host unless overridden
+## with a local variable definition.
+##
+## Define local variables for one or more hosts with:
+## 	var=value [, var=value]* host.and.domain[,host2.and.domain...]
+##
+## Lines can be continued on the following line by ending the line
+## with a \
+##
+##
+## Warning: not all supported routers or dynamic DNS services 
+##          are mentioned here.
+##
+######################################################################
+daemon=60				# check every 60 seconds, fritz won't mind
+syslog=yes				# log update msgs to syslog
+mail=root				# mail all msgs to root
+mail-failure=root			# mail failed update msgs to root
+pid=/var/run/ddclient.pid		# record PID in file.
+ssl=yes					# use ssl-support.  Works with
+
+# this way the IP is retrieved from below script
+# check the details in the file 'get-ip-from-fritzbox'
+use=cmd, cmd=/etc/ddclient/get-ip-from-fritzbox


### PR DESCRIPTION
Pull requests consists out of 2 files. 
1) ddclient.conf stripped to bare minimum with required changes to use script output as source of IP
2) get-ip-from-fritzbox as the script that is the source of the IP 