### PR TITLE
Use JSON::PP instead of the (deprecated) JSON::Any

### DIFF
--- a/ddclient
+++ b/ddclient
@@ -1936,13 +1936,13 @@ EOM
 ## load_json_support
 ######################################################################
 sub load_json_support {
-	my $json_loaded = eval {require JSON::Any};
+	my $json_loaded = eval {require JSON::PP};
 	unless ($json_loaded) {
 		fatal(<<"EOM");
-Error loading the Perl module JSON::Any needed for cloudflare update.
+Error loading the Perl module JSON::PP needed for cloudflare update.
 EOM
 	}
-	import JSON::Any;
+	import JSON::PP (qw/decode_json/);
 }
 ######################################################################
 ## geturl
@@ -4263,9 +4263,9 @@ sub nic_cloudflare_update {
 
 			# Strip header
 			$reply =~ s/^.*?\n\n//s;
-			my $response = JSON::Any->jsonToObj($reply);
-			if ($response->{result} eq 'error') {
-				failed ("%s", $response->{msg});
+			my $response = eval {decode_json($reply)};
+ 			if (!defined $response || !defined $response->{result}) {
+				failed ("invalid json or result.");
 				next; 
 			}
 
@@ -4290,9 +4290,9 @@ sub nic_cloudflare_update {
 
 			# Strip header
 			$reply =~ s/^.*?\n\n//s;
-			$response = JSON::Any->jsonToObj($reply);
-			if ($response->{result} eq 'error') {
-				failed ("%s", $response->{msg});
+			$response = eval {decode_json($reply)};
+			if (!defined $response || !defined $response->{result}) {
+				failed ("invalid json or result.");
 				next; 
 			}
 
@@ -4316,9 +4316,9 @@ sub nic_cloudflare_update {
 
 			# Strip header
 			$reply =~ s/^.*?\n\n//s;
-			$response = JSON::Any->jsonToObj($reply);
-			if ($response->{result} eq 'error') {
-				failed ("%s", $response->{msg});	
+			$response = eval {decode_json($reply)};
+			if (!defined $response || !defined $response->{result}) {
+				failed ("invalid json or result.");
 			} else {
 				success ("%s -- Updated Successfully to %s", $domain, $ip);
 

--- a/ddclient
+++ b/ddclient
@@ -4264,7 +4264,7 @@ sub nic_cloudflare_update {
 			# Strip header
 			$reply =~ s/^.*?\n\n//s;
 			my $response = eval {decode_json($reply)};
- 			if (!defined $response || !defined $response->{result}) {
+			if (!defined $response || !defined $response->{result}) {
 				failed ("invalid json or result.");
 				next; 
 			}


### PR DESCRIPTION
In our project we use only a minimal perl, as such only ```JSON::PP``` is available for json support.

I have tested these changes with Cloudflare and it works as expected.  Additionally, it seems JSON::Any is deprecated.

This PR switches from using ```JSON::Any``` to using the more commonly available ```JSON::PP```.

PS:  I'm not a perl guru, so don't assume I am. :-)