### PR TITLE
dnsexit Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Dynamic DNS services currently supported include:
     Duckdns     - See https://duckdns.org/ for details
     Freemyip    - See https://freemyip.com for details
     woima.fi    - See https://woima.fi/ for details
-	dnsexit		- See https://dnsexit.com/ for details
+	dnsexit     - See https://dnsexit.com/ for details
 
 DDclient now supports many of cable/dsl broadband routers. 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ===============================================================================
-# DDCLIENT v3.8.2
+# DDCLIENT v3.8.3
 
 ddclient is a Perl client used to update dynamic DNS entries for accounts
 on many dynamic DNS services.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Dynamic DNS services currently supported include:
     Duckdns     - See https://duckdns.org/ for details
     Freemyip    - See https://freemyip.com for details
     woima.fi    - See https://woima.fi/ for details
+	dnsexit		- See https://dnsexit.com/ for details
 
 DDclient now supports many of cable/dsl broadband routers. 
 

--- a/ddclient
+++ b/ddclient
@@ -4720,7 +4720,7 @@ EoEXAMPLE
 ## nic_dnsexit_update
 ## Need update URL in this format:
 ##   http://update.dnsexit.com/RemoteUpdate.sv?login=yourlogin&password=your_ip_update_password&host=yourhost.yourdomain.com&myip=xxx.xx.xx.xxx
-## Successful responses are: '0=Success', '4=IP not changed. To save our system resources, please don't post updates unless the IP got changed.', '11=fail to find XXX.XXX.XXX.XXX'
+## Successful responses are: '0=Success', '1=IP is the same as the IP on the system', '4=IP not changed. To save our system resources, please don't post updates unless the IP got changed.'
 ######################################################################
 sub nic_dnsexit_update {
     debug("\nnic_dnsexit_update -------------------");
@@ -4754,7 +4754,7 @@ sub nic_dnsexit_update {
         last if !header_ok($h, $reply);
 
         # Response found, look for 0, 4, or 11 status as success"
-        if ($reply =~ /0=|4=|11=/)
+        if ($reply =~ /0=|4=|1=/)
         {
             $config{$h}{'ip'}     = $ip;
             $config{$h}{'mtime'}  = $now;

--- a/ddclient
+++ b/ddclient
@@ -4691,14 +4691,14 @@ sub nic_woima_update {
 sub nic_dnsexit_examples {
     return <<"EoEXAMPLE";
 o 'dnsexit'
-                          
+
 The 'dnsexit' protocol is the protocol used by the dynamic hostname services
 of the 'DnsExit' dns services. This is currently used by the free
 dynamic DNS service offered by www.dnsexit.com.
-    
+
 Configuration variables applicable to the 'dnsexit' protocol are:
   ssl=no                       ## turn off ssl
-  protocol=dnsexit             ## 
+  protocol=dnsexit             ##
   server=update.dnsexit.com    ## defaults to update.dnsexit.com
   use=web                      ## defaults to web
   web=update.dnsexit.com       ## defaults to update.dnsexit.com
@@ -4713,7 +4713,7 @@ Example ${program}.conf file entries:
   login=service-userid         \\
   password=service-password    \\
   fully.qualified.host
-                        
+
 EoEXAMPLE
 }
 ######################################################################
@@ -4724,21 +4724,17 @@ sub nic_dnsexit_update {
 
     ## update each configured host
     foreach my $h (@_) {
-	my $ip = delete $config{$h}{'wantip'};
+    my $ip = delete $config{$h}{'wantip'};
         info("setting IP address to %s for %s", $ip, $h);
         verbose("UPDATE:","updating %s", $h);
 		
         # Set the URL that we're going to update
         my $url;
         $url  = "http://$config{$h}{'server'}$config{$h}{'script'}";
-        $url .= "?login=";
-        $url .= $config{$h}{'login'};
-        $url .= "&password=";
-        $url .= $config{$h}{'password'};
-        $url .= "&host=";
-        $url .= $h;
-		$url .= "&myip=";
-		$url .= $ip;
+        $url .= "?login=$config{$h}{'login'}";
+        $url .= "&password=$config{$h}{'password'}";
+        $url .= "&host=$h";
+        $url .= "&myip=$ip";
 
         # Try to get URL
         my $reply = geturl(opt('proxy'), $url);
@@ -4757,9 +4753,7 @@ sub nic_dnsexit_update {
             $config{$h}{'mtime'}  = $now;
             $config{$h}{'status'} = 'good';
             success("updating %s: good: IP address set to %s", $h, $ip);
-         }
-         else
-         {
+         } else {
             my @reply = split /\n/, $reply;
             my $returned = pop(@reply);
             $config{$h}{'status'} = 'failed';

--- a/ddclient
+++ b/ddclient
@@ -4718,8 +4718,11 @@ EoEXAMPLE
 }
 ######################################################################
 ## nic_dnsexit_update
-## modified copy of nic_dtns_update above
-## by Dan Campbell
+## Need update URL in this format:
+##   http://update.dnsexit.com/RemoteUpdate.sv?login=yourlogin&password=your_ip_update_password&host=yourhost.yourdomain.com&myip=xxx.xx.xx.xxx
+## Successful response is:
+##    HTTP/1.1 200 OK
+##   0=Success
 ######################################################################
 sub nic_dnsexit_update {
     debug("\nnic_dnsexit_update -------------------");
@@ -4738,7 +4741,7 @@ sub nic_dnsexit_update {
         $url .= "&password=";
         $url .= $config{$h}{'password'};
         $url .= "&host=";
-        $url .= $h;
+        $url .= $ip;
 
         # Try to get URL
         my $reply = geturl(opt('proxy'), $url);
@@ -4750,8 +4753,8 @@ sub nic_dnsexit_update {
         }
         last if !header_ok($h, $reply);
 
-        # Response found, just declare as success (this is ugly, we need more error checking)
-        if ($reply =~ /success/i)
+        # Response found, look for "0=Success"
+        if ($reply =~ /0=Success/)
         {
             $config{$h}{'ip'}     = $ip;
             $config{$h}{'mtime'}  = $now;

--- a/ddclient
+++ b/ddclient
@@ -4720,9 +4720,7 @@ EoEXAMPLE
 ## nic_dnsexit_update
 ## Need update URL in this format:
 ##   http://update.dnsexit.com/RemoteUpdate.sv?login=yourlogin&password=your_ip_update_password&host=yourhost.yourdomain.com&myip=xxx.xx.xx.xxx
-## Successful response is:
-##    HTTP/1.1 200 OK
-##   0=Success
+## Successful responses are: '0=Success', '4=IP not changed. To save our system resources, please don't post updates unless the IP got changed.', '11=fail to find XXX.XXX.XXX.XXX'
 ######################################################################
 sub nic_dnsexit_update {
     debug("\nnic_dnsexit_update -------------------");
@@ -4741,7 +4739,9 @@ sub nic_dnsexit_update {
         $url .= "&password=";
         $url .= $config{$h}{'password'};
         $url .= "&host=";
-        $url .= $ip;
+        $url .= $h;
+		$url .= "&myip=";
+		$url .= $ip;
 
         # Try to get URL
         my $reply = geturl(opt('proxy'), $url);
@@ -4753,8 +4753,8 @@ sub nic_dnsexit_update {
         }
         last if !header_ok($h, $reply);
 
-        # Response found, look for "0=Success"
-        if ($reply =~ /0=Success/)
+        # Response found, look for 0, 4, or 11 status as success"
+        if ($reply =~ /0=|4=|11=/)
         {
             $config{$h}{'ip'}     = $ip;
             $config{$h}{'mtime'}  = $now;

--- a/ddclient
+++ b/ddclient
@@ -483,6 +483,12 @@ my %variables = (
         'warned-min-interval'       => setv(T_ANY,    0, 1, 0, 0,             undef),
         'warned-min-error-interval' => setv(T_ANY,    0, 1, 0, 0,             undef),
     },
+		'dnsexit-common-defaults'       => {
+		'ssl'         => setv(T_BOOL,    0, 1, 0, 0, undef),
+		'use'         => setv(T_USE,  0, 1, 1, 'web',undef),
+		'server'      => setv(T_FQDNP,  0, 1, 1, 'update.dnsexit.com', undef),
+		'script'      => setv(T_STRING,  0, 1, 1, '/RemoteUpdate.sv', undef),
++    },
 );
 my %services = (
     'dyndns1' => {
@@ -685,6 +691,15 @@ my %services = (
             $variables{'woima-service-common-defaults'},
         ),
     },
+	'dnsexit' => {
+	'updateable' => undef,
+	'update'     => \&nic_dnsexit_update,
+	'examples'   => \&nic_dnsexit_examples,
+	'variables'  => merge(
+			$variables{'dnsexit-common-defaults'},
+			$variables{'service-common-defaults'},
+		),
+	},
 );
 $variables{'merged'} = merge($variables{'global-defaults'},
 			     $variables{'service-common-defaults'},
@@ -4670,8 +4685,88 @@ sub nic_woima_update {
             if $state ne 'results2';
     }
 }
+######################################################################
+## nic_dnsexit_examples
+######################################################################
+sub nic_dnsexit_examples {
+    return <<EoEXAMPLE; 
+o 'dnsexit'
+                          
+The 'dnsexit' protocol is the protocol used by the dynamic hostname services
+of the 'DnsExit' dns services. This is currently used by the free
+dynamic DNS service offered by www.dnsexit.com.
+    
+Configuration variables applicable to the 'dnsexit' protocol are:
+  ssl=no                       ## turn off ssl
+  protocol=dnsexit             ## 
+  server=update.dnsexit.com    ## defaults to update.dnsexit.com
+  use=web                      ## defaults to web
+  web=update.dnsexit.com       ## defaults to update.dnsexit.com
+  script=/RemoteUpdate.sv      ## defaults to /RemoteUpdate.sv
+  login=service-userid         ## userid registered with the service
+  password=service-password    ## password registered with the service
+  fully.qualified.host         ## the host registered with the service.
 
+Example ${program}.conf file entries:
+  ## single host update
+  protocol=dnsexit             \\ 
+  login=service-userid         \\
+  password=service-password    \\
+  fully.qualified.host
+                        
+EoEXAMPLE
+}
++######################################################################
++## nic_dnsexit_update
++## modified copy of nic_dtns_update above
++## by Dan Campbell
++######################################################################
+sub nic_dnsexit_update {
+    debug("\nnic_dnsexit_update -------------------");
 
+    ## update each configured host
+    foreach my $h (@_) {
+	my $ip = delete $config{$h}{'wantip'};
+        info("setting IP address to %s for %s", $ip, $h);
+        verbose("UPDATE:","updating %s", $h);
+		
+        # Set the URL that we're going to update
+        my $url;
+        $url  = "http://$config{$h}{'server'}$config{$h}{'script'}";
+        $url .= "?login=";
+        $url .= $config{$h}{'login'};
+        $url .= "&password=";
+        $url .= $config{$h}{'password'};
+        $url .= "&host=";
+        $url .= $h;
+
+        # Try to get URL
+        my $reply = geturl(opt('proxy'), $url);
+
+        # No response, declare as failed
+        if (!defined($reply) || !$reply) {
+            failed("updating %s: Could not connect to %s.", $h, $config{$h}{'server'});
+            last;
+        }
+        last if !header_ok($h, $reply);
+
+        # Response found, just declare as success (this is ugly, we need more error checking)
+        if ($reply =~ /success/i)
+        {
+            $config{$h}{'ip'}     = $ip;
+            $config{$h}{'mtime'}  = $now;
+            $config{$h}{'status'} = 'good';
+            success("updating %s: good: IP address set to %s", $h, $ip);
+         }
+         else
+         {
+            my @reply = split /\n/, $reply;
+            my $returned = pop(@reply);
+            $config{$h}{'status'} = 'failed';
+            failed("updating %s: Server said: '$returned'", $h);
+         }
+    }
+}
 ######################################################################
 # vim: ai ts=4 sw=4 tw=78 :
 

--- a/ddclient
+++ b/ddclient
@@ -4716,11 +4716,11 @@ Example ${program}.conf file entries:
                         
 EoEXAMPLE
 }
-+######################################################################
-+## nic_dnsexit_update
-+## modified copy of nic_dtns_update above
-+## by Dan Campbell
-+######################################################################
+######################################################################
+## nic_dnsexit_update
+## modified copy of nic_dtns_update above
+## by Dan Campbell
+######################################################################
 sub nic_dnsexit_update {
     debug("\nnic_dnsexit_update -------------------");
 

--- a/ddclient
+++ b/ddclient
@@ -691,15 +691,15 @@ my %services = (
             $variables{'woima-service-common-defaults'},
         ),
     },
-	'dnsexit' => {
-	'updateable' => undef,
-	'update'     => \&nic_dnsexit_update,
-	'examples'   => \&nic_dnsexit_examples,
-	'variables'  => merge(
-			$variables{'dnsexit-common-defaults'},
-			$variables{'service-common-defaults'},
-		),
-	},
+    'dnsexit' => {
+        'updateable' => undef,
+        'update'     => \&nic_dnsexit_update,
+        'examples'   => \&nic_dnsexit_examples,
+        'variables'  => merge(
+            $variables{'dnsexit-common-defaults'},
+            $variables{'service-common-defaults'},
+        ),
+    },
 );
 $variables{'merged'} = merge($variables{'global-defaults'},
 			     $variables{'service-common-defaults'},

--- a/ddclient
+++ b/ddclient
@@ -4753,8 +4753,8 @@ sub nic_dnsexit_update {
         }
         last if !header_ok($h, $reply);
 
-        # Response found, look for 0, 4, or 11 status as success"
-        if ($reply =~ /0=|4=|1=/)
+        # Response found
+        if ($reply =~ /(\d+)=(.+)/)
         {
             $config{$h}{'ip'}     = $ip;
             $config{$h}{'mtime'}  = $now;

--- a/ddclient
+++ b/ddclient
@@ -4689,7 +4689,7 @@ sub nic_woima_update {
 ## nic_dnsexit_examples
 ######################################################################
 sub nic_dnsexit_examples {
-    return <<EoEXAMPLE; 
+    return <<"EoEXAMPLE";
 o 'dnsexit'
                           
 The 'dnsexit' protocol is the protocol used by the dynamic hostname services

--- a/ddclient
+++ b/ddclient
@@ -483,11 +483,11 @@ my %variables = (
         'warned-min-interval'       => setv(T_ANY,    0, 1, 0, 0,             undef),
         'warned-min-error-interval' => setv(T_ANY,    0, 1, 0, 0,             undef),
     },
-	'dnsexit-common-defaults'       => {
-		'ssl'                 => setv(T_BOOL,   0, 0, 0, 0,                    undef),
-		'use'                 => setv(T_USE,    0, 1, 1, 'web',                undef),
-		'server'              => setv(T_FQDNP,  0, 1, 1, 'update.dnsexit.com', undef),
-		'script'              => setv(T_STRING, 0, 1, 1, '/RemoteUpdate.sv',   undef),
+    'dnsexit-common-defaults'       => {
+        'ssl'                 => setv(T_BOOL,   0, 0, 0, 0,                    undef),
+        'use'                 => setv(T_USE,    0, 1, 1, 'web',                undef),
+        'server'              => setv(T_FQDNP,  0, 1, 1, 'update.dnsexit.com', undef),
+        'script'              => setv(T_STRING, 0, 1, 1, '/RemoteUpdate.sv',   undef),
     },
 );
 my %services = (

--- a/ddclient
+++ b/ddclient
@@ -484,7 +484,7 @@ my %variables = (
         'warned-min-error-interval' => setv(T_ANY,    0, 1, 0, 0,             undef),
     },
 	'dnsexit-common-defaults'       => {
-		'ssl'                 => setv(T_BOOL,   0, 1, 0, 0,                    undef),
+		'ssl'                 => setv(T_BOOL,   0, 0, 0, 0,                    undef),
 		'use'                 => setv(T_USE,    0, 1, 1, 'web',                undef),
 		'server'              => setv(T_FQDNP,  0, 1, 1, 'update.dnsexit.com', undef),
 		'script'              => setv(T_STRING, 0, 1, 1, '/RemoteUpdate.sv',   undef),

--- a/ddclient
+++ b/ddclient
@@ -4718,9 +4718,6 @@ EoEXAMPLE
 }
 ######################################################################
 ## nic_dnsexit_update
-## Need update URL in this format:
-##   http://update.dnsexit.com/RemoteUpdate.sv?login=yourlogin&password=your_ip_update_password&host=yourhost.yourdomain.com&myip=xxx.xx.xx.xxx
-## Successful responses are: '0=Success', '1=IP is the same as the IP on the system', '4=IP not changed. To save our system resources, please don't post updates unless the IP got changed.'
 ######################################################################
 sub nic_dnsexit_update {
     debug("\nnic_dnsexit_update -------------------");

--- a/ddclient
+++ b/ddclient
@@ -488,7 +488,7 @@ my %variables = (
 		'use'         => setv(T_USE,  0, 1, 1, 'web',undef),
 		'server'      => setv(T_FQDNP,  0, 1, 1, 'update.dnsexit.com', undef),
 		'script'      => setv(T_STRING,  0, 1, 1, '/RemoteUpdate.sv', undef),
-+    },
+    },
 );
 my %services = (
     'dyndns1' => {

--- a/ddclient
+++ b/ddclient
@@ -483,11 +483,11 @@ my %variables = (
         'warned-min-interval'       => setv(T_ANY,    0, 1, 0, 0,             undef),
         'warned-min-error-interval' => setv(T_ANY,    0, 1, 0, 0,             undef),
     },
-		'dnsexit-common-defaults'       => {
-		'ssl'         => setv(T_BOOL,    0, 1, 0, 0, undef),
-		'use'         => setv(T_USE,  0, 1, 1, 'web',undef),
-		'server'      => setv(T_FQDNP,  0, 1, 1, 'update.dnsexit.com', undef),
-		'script'      => setv(T_STRING,  0, 1, 1, '/RemoteUpdate.sv', undef),
+	'dnsexit-common-defaults'       => {
+		'ssl'                 => setv(T_BOOL,   0, 1, 0, 0,                    undef),
+		'use'                 => setv(T_USE,    0, 1, 1, 'web',                undef),
+		'server'              => setv(T_FQDNP,  0, 1, 1, 'update.dnsexit.com', undef),
+		'script'              => setv(T_STRING, 0, 1, 1, '/RemoteUpdate.sv',   undef),
     },
 );
 my %services = (

--- a/sample-etc_ddclient.conf
+++ b/sample-etc_ddclient.conf
@@ -244,7 +244,7 @@ ssl=yes					# use ssl-support.  Works with
 ##
 ## dnsexit (www.dnsexit.com)
 ##
-#protocol=dnsexit
-#login=myusername
-#password=mypassword
-#subdomain-1.domain.com,subdomain-2.domain.com,subdomain-3.domain.com
+#protocol=dnsexit,                                            \
+#login=myusername,                                            \
+#password=mypassword,                                         \
+#subdomain-1.domain.com,subdomain-2.domain.com

--- a/sample-etc_ddclient.conf
+++ b/sample-etc_ddclient.conf
@@ -240,3 +240,11 @@ ssl=yes					# use ssl-support.  Works with
 # login=your-myonlineportal-username
 # password=your-myonlineportal-password
 # domain.myonlineportal.net
+
+##
+## dnsexit (www.dnsexit.com)
+##
+#protocol=dnsexit
+#login=myusername
+#password=mypassword
+#subdomain-1.domain.com,subdomain-2.domain.com,subdomain-3.domain.com


### PR DESCRIPTION
Hi wimpunk -
I've hacked back in DNS exit support with this pull. Noticed it from https://sourceforge.net/p/ddclient/discussion/399428/thread/04e23ee6/ when I was gooling to try and make my dnsexit work. Took the patch that [Reuben Thomas](https://sourceforge.net/u/rrt/) updated from [danofsteel](https://sourceforge.net/u/danofsteel/) and did some further edits:
  - removed SSL as not supported
  - added in example to example config file
  - used the same regex that the official client uses to report update success
Hope this can make it into the master so I can easily deploy it in existing dockers with an update!
Thanks!