### PR TITLE
Support IPv6 for CloudFlare

### DIFF
--- a/ddclient
+++ b/ddclient
@@ -4287,7 +4287,11 @@ sub nic_cloudflare_update {
 
 			# Get DNS record ID
 			$url = "https://$config{$key}{'server'}/zones/$zone_id/dns_records?";
-			$url .= "type=A&name=$domain";
+			if (is_ipv6($ip)) {
+				$url .= "type=AAAA&name=$domain";
+			} else {
+				$url .= "type=A&name=$domain";
+			}
 
 			$reply = geturl(opt('proxy'), $url, undef, undef, $headers);
 			unless ($reply) {


### PR DESCRIPTION
This makes the Cloudflare support IPv6-aware.

Ideally, A and AAAA records would be updated in one shot, as CloudFlare has a 5 minute throttling limit for API calls that change records.