### PR TITLE
 Fix sample Cloudflare config

### DIFF
--- a/sample-etc_ddclient.conf
+++ b/sample-etc_ddclient.conf
@@ -200,9 +200,9 @@ ssl=yes					# use ssl-support.  Works with
 ##
 #protocol=cloudflare,        \
 #zone=domain.tld,            \
+#ttl=1,                      \
 #login=your-login-email,     \
-#password=APIKey,             \
-#ttl=1                       \
+#password=APIKey             \
 #domain.tld,my.domain.tld
 
 ##


### PR DESCRIPTION
The extra comma bleeds into the API request sent to Cloudflare and, as a
result, causes it to fail. Removing the comma fixes this problem.