### PR TITLE
Specify port number properly to 'nsupdate'

### DIFF
--- a/ddclient
+++ b/ddclient
@@ -4146,6 +4146,8 @@ sub nic_nsupdate_update {
 		my $binary = $config{$h}{'login'};
 		my $keyfile = $config{$h}{'password'};
 		my $server = $config{$h}{'server'};
+		## nsupdate requires a port number to be separated by whitepace, not colon
+		$server =~ s/:/ /;
 		my $zone = $config{$h}{'zone'};
 		my $ip = $config{$h}{'wantip'};
 		my $recordtype = '';


### PR DESCRIPTION
If a port number is included in the 'server' configuration item,
ddclient allows a port number to be specified by appending a colon
and the port number to the server's name or IPv4 address. However,
nsupdate does not support this syntax, it requires the port number
to be separated from the server name/address by whitespace.

Signed-off-by: Kevin P. Fleming <kevin@km6g.us>