### PR TITLE
Update Cloudflare zone ID query

### DIFF
--- a/ddclient
+++ b/ddclient
@@ -4262,7 +4262,7 @@ sub nic_cloudflare_update {
 			verbose("UPDATE:","updating %s", $domain);
 
 			# Get zone ID
-			my $url = "https://$config{$key}{'server'}/zones?";
+			my $url = "https://$config{$key}{'server'}/zones/?";
 			$url   .= "name=".$config{$key}{'zone'};
 
 			my $reply = geturl(opt('proxy'), $url, undef, undef, $headers);


### PR DESCRIPTION
The zone ID query was executed without a trailing slash, resulting in an un-handled 301.