### PR TITLE
Restore ability to update multiple namecheap domains

### DIFF
--- a/ddclient
+++ b/ddclient
@@ -3600,14 +3600,14 @@ Configuration variables applicable to the 'namecheap' protocol are:
   server=fqdn.of.service       ## defaults to dynamicdns.park-your-domain.com
   login=service-login          ## login name and password  registered with the service
   password=service-password    ##
-  hostname                     ## the hostname to update.
+  fully.qualified.host         ## the hostname to update.
 
 Example ${program}.conf file entries:
   ## single host update
   protocol=namecheap,                                         \\
   login=my-namecheap.com-login,                               \\
   password=my-namecheap.com-password                          \\
-  myhost
+  myhost.namecheap.com
 
 EoEXAMPLE
 }
@@ -3630,15 +3630,17 @@ sub nic_namecheap_update {
 
     ## update each configured host
     foreach my $h (@_) {
-	my $ip = delete $config{$h}{'wantip'};
+        my $ip = delete $config{$h}{'wantip'};
         info("setting IP address to %s for %s", $ip, $h);
         verbose("UPDATE:","updating %s", $h);
 
         my $url;
         $url   = "https://$config{$h}{'server'}/update";
-	my $domain = $config{$h}{'login'};
-	$url  .= "?host=$h";
-	$url  .= "&domain=$domain";
+        my $domain = $config{$h}{'login'};
+        my $host = $h;
+        $host  =~ s/(.*)\.$domain(.*)/$1$2/;
+        $url  .= "?host=$host";
+        $url  .= "&domain=$domain";
         $url  .= "&password=$config{$h}{'password'}";
         $url  .= "&ip=";
         $url  .= $ip if $ip;

--- a/ddclient
+++ b/ddclient
@@ -3604,8 +3604,8 @@ Configuration variables applicable to the 'namecheap' protocol are:
 
 Example ${program}.conf file entries:
   ## single host update
-  protocol=namecheap,                                         \\
-  login=my-namecheap.com-login,                               \\
+  protocol=namecheap                                          \\
+  login=my-namecheap.com-login                                \\
   password=my-namecheap.com-password                          \\
   myhost
 

--- a/ddclient
+++ b/ddclient
@@ -3607,7 +3607,7 @@ Example ${program}.conf file entries:
   protocol=namecheap,                                         \\
   login=my-namecheap.com-login,                               \\
   password=my-namecheap.com-password                          \\
-  myhost.namecheap.com
+  myhost
 
 EoEXAMPLE
 }

--- a/sample-etc_ddclient.conf
+++ b/sample-etc_ddclient.conf
@@ -1,5 +1,5 @@
 ######################################################################
-## 
+##
 ## Define default global variables with lines like:
 ## 	var=value [, var=value]*
 ## These values will be used for each following host unless overridden
@@ -12,7 +12,7 @@
 ## with a \
 ##
 ##
-## Warning: not all supported routers or dynamic DNS services 
+## Warning: not all supported routers or dynamic DNS services
 ##          are mentioned here.
 ##
 ######################################################################
@@ -48,7 +48,7 @@ ssl=yes					# use ssl-support.  Works with
 #use=fw, fw=192.168.1.254/status.htm, fw-skip='IP Address' # found after IP Address
 #
 ## To obtain an IP address from Web status page (using the proxy if defined)
-## by default, checkip.dyndns.org is used if you use the dyndns protocol. 
+## by default, checkip.dyndns.org is used if you use the dyndns protocol.
 ## Using use=web is enough to get it working.
 ## WARNING: set deamon at least to 600 seconds if you use checkip or you could
 ## get banned from their service.
@@ -161,7 +161,7 @@ ssl=yes					# use ssl-support.  Works with
 # server=dynamicdns.park-your-domain.com,	\
 # login=my-namecheap.com-login,			\
 # password=my-namecheap.com-password		\
-# myhost.namecheap.com 
+# fully.qualified.host
 
 ##
 ##
@@ -216,7 +216,7 @@ ssl=yes					# use ssl-support.  Works with
 ##
 ## Duckdns (http://www.duckdns.org/)
 ##
-# 
+#
 # password=my-auto-generated-password
 # protocol=duckdns hostwithoutduckdnsorg
 
@@ -230,7 +230,7 @@ ssl=yes					# use ssl-support.  Works with
 
 ##
 ## MyOnlinePortal (http://myonlineportal.net)
-## 
+##
 # protocol=dyndns2
 # ssl=yes
 # # ipv6=yes # optional

--- a/sample-etc_ddclient.conf
+++ b/sample-etc_ddclient.conf
@@ -1,5 +1,5 @@
 ######################################################################
-##
+## 
 ## Define default global variables with lines like:
 ## 	var=value [, var=value]*
 ## These values will be used for each following host unless overridden
@@ -12,7 +12,7 @@
 ## with a \
 ##
 ##
-## Warning: not all supported routers or dynamic DNS services
+## Warning: not all supported routers or dynamic DNS services 
 ##          are mentioned here.
 ##
 ######################################################################
@@ -48,7 +48,7 @@ ssl=yes					# use ssl-support.  Works with
 #use=fw, fw=192.168.1.254/status.htm, fw-skip='IP Address' # found after IP Address
 #
 ## To obtain an IP address from Web status page (using the proxy if defined)
-## by default, checkip.dyndns.org is used if you use the dyndns protocol.
+## by default, checkip.dyndns.org is used if you use the dyndns protocol. 
 ## Using use=web is enough to get it working.
 ## WARNING: set deamon at least to 600 seconds if you use checkip or you could
 ## get banned from their service.
@@ -216,7 +216,7 @@ ssl=yes					# use ssl-support.  Works with
 ##
 ## Duckdns (http://www.duckdns.org/)
 ##
-#
+# 
 # password=my-auto-generated-password
 # protocol=duckdns hostwithoutduckdnsorg
 
@@ -230,7 +230,7 @@ ssl=yes					# use ssl-support.  Works with
 
 ##
 ## MyOnlinePortal (http://myonlineportal.net)
-##
+## 
 # protocol=dyndns2
 # ssl=yes
 # # ipv6=yes # optional


### PR DESCRIPTION
This PR reverts PR #54 which removed some very useful functionality. 
This PR also resolves this [sourceforge bug report](https://sourceforge.net/p/ddclient/bugs/89/).

Upon investigating this issue, I found a rather confusing history behind it. 
You can find a full explanation of the situation [on my blog](https://blog.iancolwell.ca/updating-multiple-namecheap-domains-with-ddclient-a-history). I hope it sheds some light on the issue and saves you some time trying to sort it out.
I also intend to contact namecheap support and suggest they update their docs.

In addition to re-adding the functionality, I did a bit of formatting cleanup in the immediate area surrounding the fix. I also updated the example configuration. Let me know if you'd rather leave it as-is to shorten the diff. 