### PR TITLE
Add systemd sample and instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ INSTALLATION:
     vi /etc/ddclient/ddclient.conf
     -- and change hostnames, logins, and passwords appropriately
 
+    ## For those using systemd:
+    cp sample-etc_systemd.service /etc/systemd/system/ddclient.service
+    ## enable automatic startup when booting
+    systemctl enable ddclient.service
+    ## start the first time by hand
+    systemctl start ddclient.service
+
     ## For those using Redhat style rc files and using daemon-mode:
     cp sample-etc_rc.d_init.d_ddclient /etc/rc.d/init.d/ddclient
     ## enable automatic startup when booting

--- a/sample-etc_systemd.service
+++ b/sample-etc_systemd.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Dynamic DNS Update Client
+After=network.target
+
+[Service]
+Type=forking
+PIDFile=/var/run/ddclient.pid
+ExecStart=/usr/sbin/ddclient
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
These days many Linux distributions (both Redhat and Ubuntu) uses systemd by default. So it's good time to add a sample for systemd.