### PR TITLE
Fixed cloudflare cache not updating properly

### DIFF
--- a/ddclient
+++ b/ddclient
@@ -4651,9 +4651,9 @@ sub nic_cloudflare_update {
 			}
 
 			# Cache
-			$config{$key}{'ip'}     = $ip;
-			$config{$key}{'mtime'}  = $now;
-			$config{$key}{'status'} = 'good';
+			$config{$domain}{'ip'}     = $ip;
+			$config{$domain}{'mtime'}  = $now;
+			$config{$domain}{'status'} = 'good';
 		}
 	}
 }


### PR DESCRIPTION
Found that cloudlare wasn't updating the local cache properly after updating the IPs for all my subdomains, it would write the cache values to the first domain in the list and nothing for the rest.