### PR TITLE
Replace '-w' Perl flag with `use warnings;`

### DIFF
--- a/ddclient
+++ b/ddclient
@@ -1,5 +1,4 @@
-#!/usr/bin/perl -w
-#!/usr/local/bin/perl -w
+#!/usr/bin/perl
 ######################################################################
 #
 # DDCLIENT - a Perl client for updating DynDNS information
@@ -19,8 +18,9 @@
 #
 #
 ######################################################################
-require 5.004;
+require v5.8.0;
 use strict;
+use warnings;
 use Getopt::Long;
 use Sys::Hostname;
 use IO::Socket;


### PR DESCRIPTION
Now the shebang line conforms with Debian policy >= 4.1.2 (see https://www.debian.org/doc/debian-policy/ch-files.html#scripts).

Also delete the useless 2nd shebang line.