### PR TITLE
Add ipify ipv4 and ipv6 as ip getter

### DIFF
--- a/ddclient
+++ b/ddclient
@@ -71,8 +71,10 @@ sub T_POSTS  { 'postscript' };
 
 ## strategies for obtaining an ip address.
 my %builtinweb = (
-    'dyndns'  => { 'url' => 'http://checkip.dyndns.org/',               'skip' => 'Current IP Address:', },
-    'loopia'  => { 'url' => 'http://dns.loopia.se/checkip/checkip.php', 'skip' => 'Current IP Address:', },
+    'dyndns'    => { 'url' => 'http://checkip.dyndns.org/',               'skip' => 'Current IP Address:', },
+    'ipifyipv4' => { 'url' => 'https://api.ipify.org/', },
+    'ipifyipv6' => { 'url' => 'https://api6.ipify.org/', },
+    'loopia'    => { 'url' => 'http://dns.loopia.se/checkip/checkip.php', 'skip' => 'Current IP Address:', },
     'myonlineportal' => { 'url' => 'https://myonlineportal.net/checkip', },
 );
 my %builtinfw = (


### PR DESCRIPTION
I don't think we want to change the default provider for now cause it supports ipv4 and ipv6 on a single endpoint.

Closes #41