### PR TITLE
Delete redundant `$opt{'daemon'}` processing

### DIFF
--- a/ddclient
+++ b/ddclient
@@ -867,7 +867,7 @@ do {
     usage("invalid argument '-use %s'; possible values are:\n%s", $opt{'use'}, join("\n", ip_strategies_usage()))
         unless exists $ip_strategies{lc opt('use')};
 
-    $daemon = $opt{'daemon'};
+    $daemon = opt('daemon');
     $daemon = 0 if opt('force');
 
     update_nics();
@@ -1281,13 +1281,6 @@ sub init_config {
     $opt{'min-error-interval'} = max(interval(opt('min-error-interval')), interval(default('min-error-interval')));
 
     $opt{'timeout'} = 0 if opt('timeout') < 0;
-
-    ## only set $opt{'daemon'} if it has been explicitly passed in
-    if (define($opt{'daemon'}, $globals{'daemon'}, 0)) {
-        $opt{'daemon'} = interval(opt('daemon'));
-        $opt{'daemon'} = minimum('daemon')
-            if ($opt{'daemon'} < minimum('daemon'));
-    }
 
     ## define or modify host options specified on the command-line
     if (exists $opt{'options'} && defined $opt{'options'}) {


### PR DESCRIPTION
The stuff done in this deleted block is already done in `check_value`.