### PR TITLE
Only write the PID file if daemonized

### DIFF
--- a/ddclient
+++ b/ddclient
@@ -742,7 +742,7 @@ my @opt = (
     [ "protocol",    "=s", "-protocol type        : update protocol used" ],
     [ "file",        "=s", "-file path            : load configuration information from 'path'" ],
     [ "cache",       "=s", "-cache path           : record address used in 'path'" ],
-    [ "pid",         "=s", "-pid path             : record process id in 'path'" ],
+    [ "pid",         "=s", "-pid path             : record process id in 'path' if daemonized" ],
     "",
     [ "use",         "=s", "-use which            : how the should IP address be obtained." ],
     &ip_strategies_usage(),
@@ -839,10 +839,6 @@ if (opt('foreground')) {
     open(STDOUT, ">/dev/null");
     open(STDERR, ">/dev/null");
     open(STDIN,  "</dev/null");
-}
-
-# write out the pid file if we're daemon'ized
-if (opt('daemon')) {
     write_pid();
 }
 


### PR DESCRIPTION
There's not much point in writing a PID file if the user does not want to fork. (The process executing ddclient already knows the PID, so it can save it to a file if desired.)

This change is a prerequisite to using [Proc::Daemon](https://metacpan.org/pod/Proc::Daemon) to fix the buggy daemonization logic.