### PR TITLE
Delete do-nothing `$opt{'syslog'} = 1;` when daemonized

### DIFF
--- a/ddclient
+++ b/ddclient
@@ -845,7 +845,6 @@ if (opt('foreground') || opt('force')) {
 # write out the pid file if we're daemon'ized
 if (opt('daemon')) {
     write_pid();
-    $opt{'syslog'} = 1;
 }
 
 umask 077;


### PR DESCRIPTION
That line has no effect because of the `%opt = %saved_opt;` line a few lines later.