### PR TITLE
Remove `concont` protocol.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Dynamic DNS services currently supported include:
     Zoneedit    - See http://www.zoneedit.com for details.
     EasyDNS     - See http://www.easydns.com for details.
     NameCheap   - See http://www.namecheap.com for details
-    ConCont     - See http://www.dyndns.za.net for details
     DslReports  - See http://www.dslreports.com for details
     Sitelutions - See http://www.sitelutions.com for details
     Loopia      - See http://www.loopia.se for details

--- a/ddclient
+++ b/ddclient
@@ -522,16 +522,6 @@ my %services = (
             $variables{'noip-service-common-defaults'},
         ),
     },
-    'concont' => {
-        'updateable' => undef,
-        'update'     => \&nic_concont_update,
-        'examples'   => \&nic_concont_examples,
-        'variables'  => merge(
-            $variables{'service-common-defaults'},
-            { 'mx'       => setv(T_OFQDN, 0, 1, 1, '', undef), },
-            { 'wildcard' => setv(T_BOOL,  0, 1, 1, 0,  undef), },
-        ),
-    },
     'dslreports1' => {
         'updateable' => undef,
         'update'     => \&nic_dslreports1_update,
@@ -2971,90 +2961,6 @@ Example ${program}.conf file entries:
 
 EoEXAMPLE
 }
-
-######################################################################
-## nic_concont_examples
-######################################################################
-sub nic_concont_examples {
-    return <<"EoEXAMPLE";
-o 'concont'
-
-The 'concont' protocol is the protocol used by the content management
-system ConCont's dydns module. This is currently used by the free
-dynamic DNS service offered by Tyrmida at www.dyndns.za.net
-
-Configuration variables applicable to the 'concont' protocol are:
-  protocol=concont             ##
-  server=www.fqdn.of.service   ## for example www.dyndns.za.net (for most add a www)
-  login=service-login          ## login registered with the service
-  password=service-password    ## password registered with the service
-  mx=mail.server.fqdn          ## fqdn of the server handling domain\'s mail (leave out for none)
-  wildcard=yes|no              ## set yes for wild (*.host.domain) support
-  fully.qualified.host         ## the host registered with the service.
-
-Example ${program}.conf file entries:
-  ## single host update
-  protocol=concont,                                     \\
-  login=dyndns.za.net,                                  \\
-  password=my-dyndns.za.net-password,                   \\
-  mx=mailserver.fqdn,                                   \\
-  wildcard=yes                                          \\
-  myhost.hn.org
-
-EoEXAMPLE
-}
-######################################################################
-## nic_concont_update
-######################################################################
-sub nic_concont_update {
-    debug("\nnic_concont_update -------------------");
-
-    ## update each configured host
-    foreach my $h (@_) {
-        my $ip = delete $config{$h}{'wantip'};
-        info("setting IP address to %s for %s", $ip, $h);
-        verbose("UPDATE:", "updating %s", $h);
-
-        # Set the URL that we're going to to update
-        my $url;
-        $url  = "http://$config{$h}{'server'}/modules/dydns/update.php";
-        $url .= "?username=";
-        $url .= $config{$h}{'login'};
-        $url .= "&password=";
-        $url .= $config{$h}{'password'};
-        $url .= "&wildcard=";
-        $url .= $config{$h}{'wildcard'};
-        $url .= "&mx=";
-        $url .= $config{$h}{'mx'};
-        $url .= "&host=";
-        $url .= $h;
-        $url .= "&ip=";
-        $url .= $ip;
-
-        # Try to get URL
-        my $reply = geturl(opt('proxy'), $url);
-
-        # No response, declare as failed
-        if (!defined($reply) || !$reply) {
-            failed("updating %s: Could not connect to %s.", $h, $config{$h}{'server'});
-            last;
-        }
-        last if !header_ok($h, $reply);
-
-        # Response found, just declare as success (this is ugly, we need more error checking)
-        if ($reply =~ /SUCCESS/) {
-            $config{$h}{'ip'}     = $ip;
-            $config{$h}{'mtime'}  = $now;
-            $config{$h}{'status'} = 'good';
-            success("updating %s: good: IP address set to %s", $h, $ip);
-        } else {
-            my @reply = split /\n/, $reply;
-            my $returned = pop(@reply);
-            $config{$h}{'status'} = 'failed';
-            failed("updating %s: Server said: '$returned'", $h);
-        }
-    }
-}
 ######################################################################
 ## nic_dslreports1_examples
 ######################################################################
@@ -4054,7 +3960,7 @@ Configuration variables applicable to the 'dtdns' protocol are:
 Example ${program}.conf file entries:
   ## single host update
   protocol=dtdns,                                       \\
-  password=my-dyndns.za.net-password,                   \\
+  password=my_password,                                 \\
   client=ddclient                                       \\
   myhost.dtdns.net
 


### PR DESCRIPTION
It is unclear that this protocol is in use anywhere.  See https://sourceforge.net/p/ddclient/mailman/message/432027/ for some discussion.

If it turns out that users are still using `concont` we can revert this change.