### PR TITLE
Fix `CONF` in sample init script for Ubuntu

### DIFF
--- a/sample-etc_rc.d_init.d_ddclient.ubuntu
+++ b/sample-etc_rc.d_init.d_ddclient.ubuntu
@@ -10,7 +10,7 @@
 ### END INIT INFO
 
 DDCLIENT=/usr/sbin/ddclient
-CONF=/etc/ddclient/ddclient.conf
+CONF=/etc/ddclient.conf
 PIDFILE=/var/run/ddclient.pid
 
 test -x $DDCLIENT || exit 0


### PR DESCRIPTION
Both Ubuntu and Debian patch ddclient so that `$etc` is `/etc`, not `/etc/ddclient`.