### PR TITLE
Fix usage of printf-like functions

### DIFF
--- a/ddclient
+++ b/ddclient
@@ -2006,7 +2006,7 @@ sub geturl {
     $url    = "/" unless $url =~ m%/%;
     $url    =~ s%^[^/]*/%%;
 
-    opt('fw') && debug("opt(fw = ", opt('fw'),")");
+    opt('fw') && debug("opt(fw = ", opt('fw'), ")");
     $globals{'fw'} && debug("glo fw = $globals{'fw'}");
     ## always omit SSL for connections to local router
     if ($force_ssl || ($globals{'ssl'} and (caller(1))[3] ne 'main::get_ip')) {
@@ -2232,7 +2232,7 @@ sub get_ip {
         $queryif =~ s%\/%\\\/%g;
 
         # Protect special HTML characters (like '?')
-        $queryif =~ s/([\?&= ])/sprintf("%%%02x",ord($1))/ge;
+        $queryif =~ s/([\?&= ])/sprintf("%%%02x", ord($1))/ge;
 
         $url   = "http://" . opt('fw', $h) . "/level/1/exec/show/ip/interface/brief/${queryif}/CR";
         $reply = geturl('', $url, opt('fw-login', $h), opt('fw-password', $h)) || '';
@@ -2249,7 +2249,7 @@ sub get_ip {
         $queryif =~ s%\/%\\\/%g;
 
         # Protect special HTML characters (like '?')
-        $queryif =~ s/([\?&= ])/sprintf("%%%02x",ord($1))/ge;
+        $queryif =~ s/([\?&= ])/sprintf("%%%02x", ord($1))/ge;
 
         $url   = "https://" . opt('fw', $h) . "/exec/show%20interface%20${queryif}";
         $reply = geturl('', $url, opt('fw-login', $h), opt('fw-password', $h)) || '';
@@ -3628,8 +3628,7 @@ sub nic_nfsn_update {
             $name = '';
         } elsif ($h !~ /$zone$/) {
             $config{$h}{'status'} = 'failed';
-            failed("updating %s: %s is outside zone %s", $h, $h,
-                   $zone);
+            failed("updating %s: %s is outside zone %s", $h, $h, $zone);
             next;
         } else {
             $name = $h;

--- a/ddclient
+++ b/ddclient
@@ -994,10 +994,10 @@ sub write_pid {
     if ($file && opt('daemon')) {
         local *FD;
         if (!open(FD, "> $file")) {
-            warning("Cannot create file '%s'. ($!)", $file);
+            warning("Cannot create file '%s'. (%s)", $file, $!);
 
         } else {
-            printf FD "$$\n";
+            printf FD "%s\n", $$;
             close(FD);
         }
     }
@@ -1033,11 +1033,11 @@ sub write_cache {
         $saved_cache = undef;
         local *FD;
         if (!open(FD, "> $file")) {
-            fatal("Cannot create file '%s'. ($!)", $file);
+            fatal("Cannot create file '%s'. (%s)", $file, $!);
         }
-        printf FD "## $program-$version\n";
+        printf FD "## %s-%s\n", $program, $version;
         printf FD "## last updated at %s (%d)\n", prettytime($now), $now;
-        printf FD $cache;
+        printf FD "%s", $cache;
 
         close(FD);
     }
@@ -1165,15 +1165,15 @@ sub _read_config {
 
     local *FD;
     if (!open(FD, "< $file")) {
-        warning("Cannot open file '%s'. ($!)", $file);
+        warning("Cannot open file '%s'. (%s)", $file, $!);
     }
     # Check for only owner has any access to config file
     my ($dev, $ino, $mode, @statrest) = stat(FD);
     if ($mode & 077) {
         if (-f FD && (chmod 0600, $file)) {
-            warning("file $file must be accessible only by its owner (fixed).");
+            warning("file %s must be accessible only by its owner (fixed).", $file);
         } else {
-            warning("file $file must be accessible only by its owner.");
+            warning("file %s must be accessible only by its owner.", $file);
         }
     }
 
@@ -1483,7 +1483,7 @@ sub test_possible_ip {
         if (opt('fw') !~ m%/%) {
             foreach my $fw (sort keys %builtinfw) {
                 local $opt{'use'} = $fw;
-                printf "use=$fw address is %s\n", define(get_ip($fw), 'NOT FOUND');
+                printf "use=%s address is %s\n", $fw, define(get_ip($fw), 'NOT FOUND');
             }
         }
         local $opt{'use'} = 'fw';
@@ -1495,7 +1495,7 @@ sub test_possible_ip {
         local $opt{'use'} = 'web';
         foreach my $web (sort keys %builtinweb) {
             local $opt{'web'} = $web;
-            printf "use=web, web=$web address is %s\n", define(get_ip('web'), 'NOT FOUND');
+            printf "use=web, web=%s address is %s\n", $web, define(get_ip('web'), 'NOT FOUND');
         }
         printf "use=web, web=%s address is %s\n", opt('web'), define(get_ip('web'), 'NOT FOUND')
             if !exists $builtinweb{opt('web')};
@@ -1535,7 +1535,7 @@ sub load_file {
         close(FD);
         debug("Loaded %d bytes from %s", length($buffer), $file);
     } else {
-        debug("Load failed from %s ($!)", $file);
+        debug("Load failed from %s (%s)", $file, $!);
     }
     return $buffer
 }
@@ -1620,17 +1620,17 @@ sub pipecmd {
     ## execute the command.
     local *FD;
     if (!open(FD, $cmd)) {
-        printf STDERR "$program: cannot execute command %s.\n", $cmd;
+        printf STDERR "%s: cannot execute command %s.\n", $program, $cmd;
 
     } elsif ($stdin && (!print FD "$stdin\n")) {
-        printf STDERR "$program: failed writting to %s.\n", $cmd;
+        printf STDERR "%s: failed writting to %s.\n", $program, $cmd;
         close(FD);
 
     } elsif (!close(FD)) {
-        printf STDERR "$program: failed closing %s.($@)\n", $cmd;
+        printf STDERR "%s: failed closing %s.(%s)\n", $program, $cmd, $@;
 
     } elsif (opt('exec') && $?) {
-        printf STDERR "$program: failed %s. ($@)\n", $cmd;
+        printf STDERR "%s: failed %s. (%s)\n", $program, $cmd, $@;
 
     } else {
         $ok = 1;
@@ -1922,7 +1922,7 @@ sub encode_base64 ($;$) {
 sub load_ssl_support {
     my $ssl_loaded = eval { require IO::Socket::SSL };
     unless ($ssl_loaded) {
-        fatal(<<"EOM");
+        fatal("%s", <<"EOM");
 Error loading the Perl module IO::Socket::SSL needed for SSL connect.
 On Debian, the package libio-socket-ssl-perl must be installed.
 On Red Hat, the package perl-IO-Socket-SSL must be installed.
@@ -1939,7 +1939,7 @@ EOM
 sub load_ipv6_support {
     my $ipv6_loaded = eval { require IO::Socket::INET6 };
     unless ($ipv6_loaded) {
-        fatal(<<"EOM");
+        fatal("%s", <<"EOM");
 Error loading the Perl module IO::Socket::INET6 needed for ipv6 connect.
 On Debian, the package libio-socket-inet6-perl must be installed.
 On Red Hat, the package perl-IO-Socket-INET6 must be installed.
@@ -1958,7 +1958,7 @@ sub load_sha1_support {
     my $sha1_loaded = eval { require Digest::SHA1 };
     my $sha_loaded  = eval { require Digest::SHA };
     unless ($sha1_loaded || $sha_loaded) {
-        fatal(<<"EOM");
+        fatal("%s", <<"EOM");
 Error loading the Perl module Digest::SHA1 or Digest::SHA needed for $why update.
 On Debian, the package libdigest-sha1-perl or libdigest-sha-perl must be installed.
 EOM
@@ -1976,7 +1976,7 @@ sub load_json_support {
     my $why = shift;
     my $json_loaded = eval { require JSON::PP };
     unless ($json_loaded) {
-        fatal(<<"EOM");
+        fatal("%s", <<"EOM");
 Error loading the Perl module JSON::PP needed for $why update.
 EOM
     }
@@ -2006,8 +2006,8 @@ sub geturl {
     $url    = "/" unless $url =~ m%/%;
     $url    =~ s%^[^/]*/%%;
 
-    opt('fw') && debug("opt(fw = ", opt('fw'), ")");
-    $globals{'fw'} && debug("glo fw = $globals{'fw'}");
+    opt('fw') && debug("opt(fw = %s)", opt('fw'));
+    $globals{'fw'} && debug("glo fw = %s", $globals{'fw'});
     ## always omit SSL for connections to local router
     if ($force_ssl || ($globals{'ssl'} and (caller(1))[3] ne 'main::get_ip')) {
         $use_ssl      = 1;
@@ -2017,9 +2017,9 @@ sub geturl {
         $use_ssl      = 0;
         $default_port = 80;
     }
-    debug("proxy    = $proxy");
-    debug("protocol = " . ($use_ssl ? "https" : "http"));
-    debug("server   = $server");
+    debug("proxy    = %s", $proxy);
+    debug("protocol = %s", $use_ssl ? "https" : "http");
+    debug("server   = %s", $server);
     debug("url      = %s", $url);
 
     ## determine peer and port to use.
@@ -2069,7 +2069,7 @@ sub geturl {
             MultiHomed => 1,
             Timeout    => opt('timeout'),
         );
-        defined $sd or warning("cannot connect to $peer:$port socket: $@ " . IO::Socket::SSL::errstr());
+        defined $sd or warning("cannot connect to %s:%s socket: %s %s", $peer, $port, $@, IO::Socket::SSL::errstr());
     } elsif ($globals{'ipv6'}) {
         load_ipv6_support;
         $sd = IO::Socket::INET6->new(
@@ -2079,7 +2079,7 @@ sub geturl {
             MultiHomed => 1,
             Timeout    => opt('timeout'),
         );
-        defined $sd or warning("cannot connect to $peer:$port socket: $@");
+        defined $sd or warning("cannot connect to %s:%s socket: %s", $peer, $port, $@);
     } else {
         $sd = IO::Socket::INET->new(
             PeerAddr   => $peer,
@@ -2088,7 +2088,7 @@ sub geturl {
             MultiHomed => 1,
             Timeout    => opt('timeout'),
         );
-        defined $sd or warning("cannot connect to $peer:$port socket: $@");
+        defined $sd or warning("cannot connect to %s:%s socket: %s", $peer, $port, $@);
     }
 
     if (defined $sd) {
@@ -2099,7 +2099,7 @@ sub geturl {
         $0 = sprintf("%s - sending to %s port %s", $program, $peer, $port);
         my $result = syswrite $sd, $rq;
         if ($result != length($rq)) {
-            warning("cannot send to $peer:$port ($!).");
+            warning("cannot send to %s:%s (%s).", $peer, $port, $!);
         } else {
             $0 = sprintf("%s - reading from %s port %s", $program, $peer, $port);
             eval {
@@ -2836,10 +2836,10 @@ sub nic_dyndns2_update {
 
                     $sec = $wait * $scale;
                     $config{$h}{'wtime'} = $now + $sec;
-                    warning("updating %s: %s: wait $wait $units before further updates", $h, $status, $ip);
+                    warning("updating %s: %s: wait %s %s before further updates", $h, $status, $wait, $units);
 
                 } else {
-                    failed("updating %s: %s: unexpected status (%s)", $h, $line);
+                    failed("updating %s: unexpected status (%s)", $h, $line);
                 }
             }
         }
@@ -2936,10 +2936,10 @@ sub nic_noip_update {
 
                     $sec = $wait * $scale;
                     $config{$h}{'wtime'} = $now + $sec;
-                    warning("updating %s: %s: wait $wait $units before further updates", $h, $status, $ip);
+                    warning("updating %s: %s: wait %s %s before further updates", $h, $status, $wait, $units);
 
                 } else {
-                    failed("updating %s: %s: unexpected status (%s)", $h, $line);
+                    failed("updating %s: unexpected status (%s)", $h, $line);
                 }
             }
         }
@@ -3374,13 +3374,13 @@ sub nic_easydns_update {
                     ($scale, $units) = (60, 'minutes')  if $units eq 'm';
                     ($scale, $units) = (60*60, 'hours') if $units eq 'h';
                     $config{$h}{'wtime'} = $now + $sec;
-                    warning("updating %s: %s: wait $wait $units before further updates", $h, $status, $ip);
+                    warning("updating %s: %s: wait %d %s before further updates", $h, $status, $wait, $units);
 
                 } elsif (exists $errors{$status}) {
                     failed("updating %s: %s: %s", $h, $line, $errors{$status});
 
                 } else {
-                    failed("updating %s: %s: unexpected status (%s)", $h, $line);
+                    failed("updating %s: unexpected status (%s)", $h, $line);
                 }
                 last;
             }
@@ -3598,9 +3598,9 @@ sub nic_nfsn_handle_error {
         return;
     }
 
-    failed($json->{'error'});
+    failed("%s", $json->{'error'});
     if (defined $json->{'debug'}) {
-        failed($json->{'debug'});
+        failed("%s", $json->{'debug'});
     }
 }
 
@@ -4025,7 +4025,7 @@ sub nic_dtdns_update {
             my @reply = split /\n/, $reply;
             my $returned = pop(@reply);
             $config{$h}{'status'} = 'failed';
-            failed("updating %s: Server said: '$returned'", $h);
+            failed("updating %s: Server said: '%s'", $h, $returned);
         }
     }
 }
@@ -4321,7 +4321,7 @@ sub nic_cloudflare_update {
                 failed("updating %s: No zone ID found.", $config{$key}{'zone'});
                 next;
             }
-            info("zone ID is $zone_id");
+            info("zone ID is %s", $zone_id);
 
             # Get DNS record ID
             $url = "https://$config{$key}{'server'}/zones/$zone_id/dns_records?";
@@ -4352,7 +4352,7 @@ sub nic_cloudflare_update {
                 failed("updating %s: No DNS record ID found.", $domain);
                 next;
             }
-            info("DNS record ID is $dns_rec_id");
+            info("DNS record ID is %s", $dns_rec_id);
 
             # Set domain
             $url = "https://$config{$key}{'server'}/zones/$zone_id/dns_records/$dns_rec_id";
@@ -4568,7 +4568,7 @@ sub nic_duckdns_update {
             success("updating %s: good: IP address set to %s", $h, $ip);
         } else {
             $config{$h}{'status'} = 'failed';
-            failed("updating %s: Server said: '$returned'", $h);
+            failed("updating %s: Server said: '%s'", $h, $returned);
         }
     }
 }
@@ -4639,7 +4639,7 @@ sub nic_freemyip_update {
             success("updating %s: good: IP address set to %s", $h, $ip);
         } else {
             $config{$h}{'status'} = 'failed';
-            failed("updating %s: Server said: '$returned'", $h);
+            failed("updating %s: Server said: '%s'", $h, $returned);
         }
     }
 }
@@ -4802,10 +4802,10 @@ sub nic_woima_update {
 
                     $sec = $wait * $scale;
                     $config{$h}{'wtime'} = $now + $sec;
-                    warning("updating %s: %s: wait $wait $units before further updates", $h, $status, $ip);
+                    warning("updating %s: %s: wait %s %s before further updates", $h, $status, $wait, $units);
 
                 } else {
-                    failed("updating %s: %s: unexpected status (%s)", $h, $line);
+                    failed("updating %s: unexpected status (%s)", $h, $line);
                 }
             }
         }
@@ -4883,7 +4883,7 @@ sub nic_dondominio_update {
             success("updating %s: good: IP address set to %s", $h, $ip);
         } else {
             $config{$h}{'status'} = 'failed';
-            failed("updating %s: Server said: '$returned'", $h);
+            failed("updating %s: Server said: '%s'", $h, $returned);
         }
     }
 }
@@ -4969,7 +4969,7 @@ sub nic_dnsmadeeasy_update {
             success("Updating %s: good: IP address set to %s", $h, $ip);
         } else {
             $config{$h}{'status'} = 'failed';
-            failed("Updating %s: Server said: '$returned': $messages{$returned}", $h);
+            failed("Updating %s: Server said: '%s': %s", $h, $returned, $messages{$returned});
         }
     }
 }
@@ -5042,7 +5042,7 @@ sub nic_ovh_update {
             }
         } else {
             $config{$h}{'status'} = 'failed';
-            failed("updating %s: Server said: '$returned'", $h);
+            failed("updating %s: Server said: '%s'", $h, $returned);
         }
     }
 }


### PR DESCRIPTION
  * Remove interpolations from the format specifier (in case the variable contains a `%` character).
  * Match the number of arguments to the number of `%` substitutions in the format specifier.
