### PR TITLE
Prefer `ip` over `if` over `web` when inferring `use`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,6 +21,9 @@ repository history](https://github.com/ddclient/ddclient/commits/master).
     minute.
   * The `pid` option is now ignored when ddclient is not daemonized.
   * ddclient now gracefully exits when interrupted by Ctrl-C.
+  * The way ddclient chooses the default for the `use` option has changed.
+    Rather than rely on the default, users should explicitly set the `use`
+    option.
 
 ## 2020-01-08 v3.9.1
 

--- a/ddclient
+++ b/ddclient
@@ -1291,9 +1291,11 @@ sub init_config {
     $opt{'quiet'} = 0 if opt('verbose');
 
     ## infer the IP strategy if possible
-    $opt{'use'} = 'ip'  if !define($opt{'use'}) && defined($opt{'ip'});
-    $opt{'use'} = 'if'  if !define($opt{'use'}) && defined($opt{'if'});
-    $opt{'use'} = 'web' if !define($opt{'use'}) && defined($opt{'web'});
+    if (!defined($opt{'use'})) {
+        $opt{'use'} = 'ip'  if defined($opt{'ip'});
+        $opt{'use'} = 'if'  if defined($opt{'if'});
+        $opt{'use'} = 'web' if defined($opt{'web'});
+    }
 
     ## sanity check
     $opt{'max-interval'}       = min(interval(opt('max-interval')), interval(default('max-interval')));

--- a/ddclient
+++ b/ddclient
@@ -1292,9 +1292,9 @@ sub init_config {
 
     ## infer the IP strategy if possible
     if (!defined($opt{'use'})) {
-        $opt{'use'} = 'ip'  if defined($opt{'ip'});
-        $opt{'use'} = 'if'  if defined($opt{'if'});
         $opt{'use'} = 'web' if defined($opt{'web'});
+        $opt{'use'} = 'if'  if defined($opt{'if'});
+        $opt{'use'} = 'ip'  if defined($opt{'ip'});
     }
 
     ## sanity check


### PR DESCRIPTION
If the user passed `-ip` they almost certainly want to use it, even if they also passed `-if` and `-web`.

Similarly, if the user passed `-if` they almost certainly want to use it even if they also passed `-web`.