### PR TITLE
Fix regex searching for Content-Type header

### DIFF
--- a/ddclient
+++ b/ddclient
@@ -2046,7 +2046,7 @@ sub geturl {
     $request .= "Authorization: Basic $auth\n" if $login || $password;
     $request .= "User-Agent: ${program}/${version}\n";
     if ($data) {
-        $request .= "Content-Type: application/x-www-form-urlencoded\n" if !$headers =~ /^Content-Type: /;
+        $request .= "Content-Type: application/x-www-form-urlencoded\n" if $headers !~ /^Content-Type:/mi;
         $request .= "Content-Length: " . length($data) . "\n";
     }
     $request .= "Connection: close\n";


### PR DESCRIPTION
  * Add the `m` modifier because the `$headers` variable can contain multiple headers. If `$headers` contains a Content-Type header but it is the second or later header then the regex won't match without `m`.
  * Add the `i` modifier because RFC 7230 says that header field names are case-insensitive.
  * Don't require a space after the colon because RFC 7230 says that the space is optional.