### PR TITLE
Remove extra space at beginning of multiline log messages

### DIFF
--- a/ddclient
+++ b/ddclient
@@ -1769,7 +1769,7 @@ sub _msg {
     }
     if ($prefix) {
         $buffer = "$prefix$buffer";
-        $buffer =~ s/\n/\n$prefix /g;
+        $buffer =~ s/\n/\n$prefix/g;
     }
     $buffer .= "\n";
     print $fh $buffer;


### PR DESCRIPTION
It's unclear whether the extra space is intentional or not, but it breaks formatting of vertically-aligned multiline content.