### PR TITLE
Bump minimum required Perl to v5.10.1

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,7 +11,7 @@ repository history](https://github.com/ddclient/ddclient/commits/master).
 
 ### Compatibility changes
 
-  * Perl v5.8 or later is now required.
+  * Perl v5.10.1 or later is now required.
   * Removed the `concont` protocol. If you still use this protocol, please
     [file a bug report](https://github.com/ddclient/ddclient/issues) and we
     will restore it.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ through github.com. Please check out http://ddclient.net
 
 - one or more accounts from one of the dynamic DNS services
 
-- Perl 5.014 or later
+- Perl v5.10.1 or later
   - `Data::Validate::IP` perl library
   - `IO::Socket::SSL` perl library for ssl-support
   - `JSON::PP` perl library for JSON support

--- a/ddclient
+++ b/ddclient
@@ -18,7 +18,7 @@
 #
 #
 ######################################################################
-require v5.8.0;
+require v5.10.1;
 use strict;
 use warnings;
 use Getopt::Long;


### PR DESCRIPTION
This allows us to use the `//` and `//=` operators.

v5.10.1 was chosen because that is the oldest version of Perl among all currently supported releases of Ubuntu, CentOS, RHEL, Fedora, and Debian.