### PR TITLE
Fix global fallback when host-specific setting is undefined

### DIFF
--- a/ddclient
+++ b/ddclient
@@ -1708,7 +1708,7 @@ sub minimum {
 sub opt {
     my $v = shift;
     my $h = shift;
-    return $config{$h}{$v} if defined($h && $config{$h}{$v});
+    return $config{$h}{$v} if defined($h) && defined($config{$h}{$v});
     return $opt{$v}        if defined $opt{$v};
     return $globals{$v}    if defined $globals{$v};
     return default($v)     if defined default($v);


### PR DESCRIPTION
This commit only changes behavior if the hostname is a falsy string (`''` or `'0'`) and there is a variable that:
  * was not set globally before the host definition,
  * was not set in the host definition,
  * was set globally after the host definition, and
  * is relevant to the host.