### PR TITLE
Remove dependency on Data::Validate::IP 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@ repository history](https://github.com/ddclient/ddclient/commits/master).
 ### New features
 
   * Added support for OVH DynHost.
+  * Removed dependency on Data::Validate::IP.
 
 ### Compatibility changes
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ through github.com. Please check out http://ddclient.net
 - one or more accounts from one of the dynamic DNS services
 
 - Perl v5.10.1 or later
-  - `Data::Validate::IP` perl library
   - `IO::Socket::SSL` perl library for ssl-support
   - `JSON::PP` perl library for JSON support
   - `IO::Socket:INET6` perl library for ipv6-support

--- a/ddclient
+++ b/ddclient
@@ -24,7 +24,6 @@ use warnings;
 use Getopt::Long;
 use Sys::Hostname;
 use IO::Socket;
-use Data::Validate::IP;
 
 my $version  = "3.9.1";
 my $programd = $0;
@@ -2304,6 +2303,15 @@ sub get_ip {
 
     debug("get_ip: using %s, %s reports %s", $use, $arg, define($ip, "<undefined>"));
     return $ip;
+}
+
+######################################################################
+## is_ipv6() validates if string is valid IPv6 address
+######################################################################
+sub is_ipv6 {
+    my ($value) = @_;
+    # This little gem from http://home.deds.nl/~aeron/regex/
+    return $value =~ /^(((?=.*(::))(?!.*\3.+\3))\3?|([\dA-F]{1,4}(\3|:\b|$)|\2))(?4){5}((?4){2}|(((2[0-4]|1\d|[1-9])?\d|25[0-5])\.?\b){4})\z/ai;
 }
 
 ######################################################################


### PR DESCRIPTION
The Data::Validate::IP module is not available by default on many systems, and not available at all on lightweight embedded systems.  As all we need it for is to validate IPv6 addresses it is better that we do this in our own function and remove this dependency.  Resolves https://github.com/ddclient/ddclient/issues/177