### PR TITLE
Fix `use=ip` when `ip` is set to an IPv4 address

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,8 @@ repository history](https://github.com/ddclient/ddclient/commits/master).
 
 ### Bug fixes
 
+  * Fixed a regression introduced in v3.9.0 that caused
+    `use=ip,ip=<ipv4-address>` to fail.
   * "true" is now accepted as a boolean value.
 
 ### Compatibility and dependency changes

--- a/ddclient
+++ b/ddclient
@@ -2287,7 +2287,9 @@ sub get_ip {
         $skip  =~ s/ /\\s/is;
         $reply =~ s/^.*?${skip}//is;
     }
-    if ($reply =~ /^.*?\b(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\b.*/is) {
+    if (defined($ip)) {
+        # no need to parse $reply
+    } elsif ($reply =~ /^.*?\b(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\b.*/is) {
         $ip = $1;
         $ip = un_zero_pad($ip);
         $ip = filter_local($ip) if opt('fw-banlocal', $h);


### PR DESCRIPTION
Before, with `use=ip,ip=1.2.3.4`, `get_ip` would return `undef` and print a warning:

  WARNING:  found neither ipv4 nor ipv6 address