### PR TITLE
Fix parsing of "true" as a boolean value

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,10 @@ repository history](https://github.com/ddclient/ddclient/commits/master).
 
   * Added support for OVH DynHost.
 
+### Bug fixes
+
+  * "true" is now accepted as a boolean value.
+
 ### Compatibility and dependency changes
 
   * Perl v5.10.1 or later is now required.

--- a/ddclient
+++ b/ddclient
@@ -1864,9 +1864,9 @@ sub check_value {
         $value = $min if defined($min) && $value < $min;
 
     } elsif ($type eq T_BOOL) {
-        if ($value =~ /^y(es)?$|^t(true)?$|^1$/i) {
+        if ($value =~ /^(y(es)?|t(rue)?|1)$/i) {
             $value = 1;
-        } elsif ($value =~ /^n(o)?$|^f(alse)?$|^0$/i) {
+        } elsif ($value =~ /^(n(o)?|f(alse)?|0)$/i) {
             $value = 0;
         } else {
             return undef;


### PR DESCRIPTION
Before, "t" and "ttrue" were accepted as true, but not "true".

Also simplify the true and false regular expressions.