### PR TITLE
Fix shebang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ release
 /autom4te.cache/
 /build-aux/install-sh
 /build-aux/missing
+/build-aux/tap-driver.sh
 /config.log
 /config.status
 /configure


### PR DESCRIPTION
This is probably not the nicest method but it fixes the shebang so that you can run the script normally or with perl.
I also ignored the changed ``tap-driver.sh`` cause it is annoying when changing branches a lot.

I got inspiration from lcov https://github.com/linux-test-project/lcov/commit/74bae96e8ef724eb9dbdf126adad17505375e149#diff-2066c4d7515c02785d28a6ab3a57ace1R41 .