### PR TITLE
Recommend `VERBOSE=1` when running tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Always add tests for your changes when feasible.
 To run the ddclient test suite:
 
   1. Install GNU Autoconf and Automake
-  2. Run: `./autogen && ./configure && make check`
+  2. Run: `./autogen && ./configure && make VERBOSE=1 check`
 
 To add a new test script:
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,7 +12,7 @@ repository history](https://github.com/ddclient/ddclient/commits/master).
   * Added a build system to make it easier for distributions to package
     ddclient:
 
-        ./autogen && ./configure && make && make check && make install
+        ./autogen && ./configure && make && make VERBOSE=1 check && make install
 
   * The `freedns` protocol (for https://freedns.afraid.org) now supports IPv6
     addresses.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ See https://github.com/ddclient/ddclient/releases
          --sysconfdir=/etc/ddclient \
          --localstatedir=/var
      make
-     make check
+     make VERBOSE=1 check
      sudo make install
      ```
 


### PR DESCRIPTION
This causes Automake to output a failed test's log so that you don't have to look at the `.log` file yourself.