### PR TITLE
Explicit require version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,9 +21,12 @@ AX_PROG_PERL_VERSION([5.10.1], [],
   [AC_MSG_ERROR([Perl 5.10.1 or newer not found])])
 AC_SUBST([PERL])
 
-# Perl modules required to run ddclient. Core modules may be omitted;
-# they are assumed to always exist.
+# Perl modules required to run ddclient. Note: CentOS, RHEL, and
+# Fedora put some core modules in separate packages, and the perl
+# package doesn't depend on all of them, so their availability can't
+# be assumed.
 m4_foreach_w([_m], [
+    version=0.77
   ], [AX_PROG_PERL_MODULES([_m], [],
          [AC_MSG_ERROR([missing required Perl module _m])])])
 


### PR DESCRIPTION
because centos does not include it at all times. Right now we need to explicitly [install it for the tests to pass](https://github.com/ddclient/ddclient/blob/master/.github/workflows/ci.yml#L54). So I think it would be a good idea to also require it in automake just to be sure it is not forgotten.