### PR TITLE
Stringify default port numbers

### DIFF
--- a/ddclient.in
+++ b/ddclient.in
@@ -2009,10 +2009,10 @@ sub geturl {
     ## always omit SSL for connections to local router
     if ($force_ssl || ($globals{'ssl'} and (caller(1))[3] ne 'main::get_ip')) {
         $use_ssl      = 1;
-        $default_port = 443;
+        $default_port = '443';
     } else {
         $use_ssl      = 0;
-        $default_port = 80;
+        $default_port = '80';
     }
     debug("proxy    = %s", $proxy);
     debug("protocol = %s", $use_ssl ? "https" : "http");


### PR DESCRIPTION
The IO::Socket classes expect strings for the port number because you can pass service names from `/etc/services`. Numbers work too, but using strings everywhere makes it easier to write unit tests.