### PR TITLE
CentOS/RHEL/Fedora CI improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: install dependencies
-        run: dnf --enablerepo=PowerTools install -y automake make perl-Test-Warnings perl-core
+        run: dnf --refresh --enablerepo=PowerTools install -y automake make perl-Test-Warnings perl-core
       - name: autogen
         run: ./autogen
       - name: configure
@@ -89,7 +89,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: install dependencies
-        run: dnf install -y automake findutils make perl perl-Test-Warnings
+        run: dnf --refresh install -y automake findutils make perl perl-Test-Warnings
       - name: autogen
         run: ./autogen
       - name: configure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: install dependencies
-        run: yum install -y automake perl-Test-Simple
+        run: yum install -y automake perl-core
       - name: autogen
         run: ./autogen
       - name: configure
@@ -73,7 +73,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: install dependencies
-        run: dnf --enablerepo=PowerTools install -y perl-version automake make perl-Test-Warnings
+        run: dnf --enablerepo=PowerTools install -y automake make perl-Test-Warnings perl-core
       - name: autogen
         run: ./autogen
       - name: configure
@@ -89,7 +89,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: install dependencies
-        run: dnf install -y automake findutils make perl-Test-Warnings perl-version
+        run: dnf install -y automake findutils make perl perl-Test-Warnings
       - name: autogen
         run: ./autogen
       - name: configure
@@ -107,7 +107,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: install dependencies
-        run: yum install -y perl-version automake make perl-Test-Simple
+        run: yum install -y automake make perl-core
       - name: autogen
         run: ./autogen
       - name: configure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,9 @@ jobs:
       - name: configure
         run: ./configure
       - name: check
-        run: make VERBOSE=1 check
+        run: make VERBOSE=1 AM_COLOR_TESTS=always check
       - name: distcheck
-        run: make VERBOSE=1 distcheck
+        run: make VERBOSE=1 AM_COLOR_TESTS=always distcheck
       - name: distribution tarball is complete
         run: ./.github/workflows/scripts/dist-tarball-check
 
@@ -63,9 +63,9 @@ jobs:
       - name: configure
         run: ./configure
       - name: check
-        run: make VERBOSE=1 check
+        run: make VERBOSE=1 AM_COLOR_TESTS=always check
       - name: distcheck
-        run: make VERBOSE=1 distcheck
+        run: make VERBOSE=1 AM_COLOR_TESTS=always distcheck
 
   test-centos8:
     runs-on: ubuntu-latest
@@ -79,9 +79,9 @@ jobs:
       - name: configure
         run: ./configure
       - name: check
-        run: make VERBOSE=1 check
+        run: make VERBOSE=1 AM_COLOR_TESTS=always check
       - name: distcheck
-        run: make VERBOSE=1 distcheck
+        run: make VERBOSE=1 AM_COLOR_TESTS=always distcheck
 
   test-fedora:
     runs-on: ubuntu-latest
@@ -95,9 +95,9 @@ jobs:
       - name: configure
         run: ./configure
       - name: check
-        run: make VERBOSE=1 check
+        run: make VERBOSE=1 AM_COLOR_TESTS=always check
       - name: distcheck
-        run: make VERBOSE=1 distcheck
+        run: make VERBOSE=1 AM_COLOR_TESTS=always distcheck
 
   test-redhat-ubi7:
     runs-on: ubuntu-latest
@@ -113,6 +113,6 @@ jobs:
       - name: configure
         run: ./configure
       - name: check
-        run: make VERBOSE=1 check
+        run: make VERBOSE=1 AM_COLOR_TESTS=always check
       - name: distcheck
-        run: make VERBOSE=1 distcheck
+        run: make VERBOSE=1 AM_COLOR_TESTS=always distcheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,13 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: install dependencies
-        run: yum install -y automake perl-core
+        run: |
+          yum install -y \
+              automake \
+              perl-IO-Socket-INET6 \
+              perl-core \
+              perl-libwww-perl \
+              ;
       - name: autogen
         run: ./autogen
       - name: configure
@@ -73,7 +79,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: install dependencies
-        run: dnf --refresh --enablerepo=PowerTools install -y automake make perl-Test-Warnings perl-core
+        run: |
+          dnf --refresh --enablerepo=PowerTools install -y \
+              automake \
+              make \
+              perl-HTTP-Daemon \
+              perl-IO-Socket-INET6 \
+              perl-Test-Warnings \
+              perl-core \
+              ;
       - name: autogen
         run: ./autogen
       - name: configure
@@ -89,7 +103,19 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: install dependencies
-        run: dnf --refresh install -y automake findutils make perl perl-Test-Warnings
+        run: |
+          dnf --refresh install -y \
+              automake \
+              findutils \
+              make \
+              perl \
+              perl-HTTP-Daemon \
+              perl-HTTP-Daemon-SSL \
+              perl-IO-Socket-INET6 \
+              perl-Plack \
+              perl-Test-TCP \
+              perl-Test-Warnings \
+              ;
       - name: autogen
         run: ./autogen
       - name: configure
@@ -107,7 +133,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: install dependencies
-        run: yum install -y automake make perl-core
+        run: |
+          yum install -y \
+              automake \
+              make \
+              perl-HTTP-Daemon \
+              perl-IO-Socket-INET6 \
+              perl-core \
+              ;
       - name: autogen
         run: ./autogen
       - name: configure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
       - name: distcheck
         run: make VERBOSE=1 distcheck
 
-  test-redhat:
+  test-redhat-ubi7:
     runs-on: ubuntu-latest
     # we use redhats univeral base image which is not available on docker hub
     # https://catalog.redhat.com/software/containers/ubi7/ubi/5c3592dcd70cc534b3a37814


### PR DESCRIPTION
  * Install all core modules on CentOS/RHEL/Fedora
  * Rename `test-redhat` to `test-redhat-ubi7`
  * Pass `--refresh` to `dnf`
  * Colorize test results
  * Install modules for testing on CentOS/RHEL/Fedora