### PR TITLE
Adjust path to ddclient

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ In my case, it is named dhcpcd-eth0.exe and contains the lines:
 
 ```shell
 #!/bin/sh
-PATH=/usr/sbin:/root/bin:${PATH}
+PATH=/usr/bin:/root/bin:${PATH}
 logger -t dhcpcd IP address changed to $1
 ddclient -proxy fasthttp.sympatico.ca -wildcard -ip $1 | logger -t ddclient
 exit 0

--- a/sample-etc_cron.d_ddclient
+++ b/sample-etc_cron.d_ddclient
@@ -9,8 +9,8 @@
 ######################################################################
 ## force an update twice a month (only if you are not using daemon-mode)
 ##
-## 30 23 1,15 * *	root    /usr/sbin/ddclient -daemon=0 -syslog -quiet -force
+## 30 23 1,15 * *	root    /usr/bin/ddclient -daemon=0 -syslog -quiet -force
 ######################################################################
 ## retry failed updates every hour (only if you are not using daemon-mode)
 ##
-## 0 * * * *	root    /usr/sbin/ddclient -daemon=0 -syslog -quiet retry
+## 0 * * * *	root    /usr/bin/ddclient -daemon=0 -syslog -quiet retry

--- a/sample-etc_dhclient-exit-hooks
+++ b/sample-etc_dhclient-exit-hooks
@@ -3,7 +3,7 @@
 # The /etc/dhclient-enter-hooks script is run by the ISC DHCP client's standard
 # update script whenever dhclient obtains or renews an address. 
 
-PATH=/usr/sbin:${PATH}
+PATH=/usr/bin:${PATH}
 case "$new_ip_address" in
 10.*)   	;;
 172.1[6-9].* | 172.2[0-9].* | 172.3[0-1].*)	;;

--- a/sample-etc_dhcpc_dhcpcd-eth0.exe
+++ b/sample-etc_dhcpc_dhcpcd-eth0.exe
@@ -1,6 +1,6 @@
 #!/bin/sh
 ######################################################################
-PATH=/usr/sbin:${PATH}
+PATH=/usr/bin:${PATH}
 
 ## update the DNS server unless the IP address is a private address
 ## that may be used as an internal LAN address. This may be true if

--- a/sample-etc_ppp_ip-up.local
+++ b/sample-etc_ppp_ip-up.local
@@ -14,7 +14,7 @@
 ## in the environment as either PPP_LOCAL or IPLOCAL.
 ##
 ######################################################################
-PATH=/usr/sbin:${PATH}
+PATH=/usr/bin:${PATH}
 IP=
 IP=${IP:-$PPP_LOCAL}
 IP=${IP:-$IPLOCAL}

--- a/sample-etc_rc.d_init.d_ddclient
+++ b/sample-etc_rc.d_init.d_ddclient
@@ -28,7 +28,7 @@ else
     PID=`ps -aef | grep "$program - sleep" | grep -v grep | awk '{print $2}'`
 fi
 
-PATH=/usr/sbin:/usr/local/sbin:${PATH}
+PATH=/usr/bin:/usr/local/bin:${PATH}
 export PATH
 
 # See how we were called.

--- a/sample-etc_rc.d_init.d_ddclient.alpine
+++ b/sample-etc_rc.d_init.d_ddclient.alpine
@@ -1,6 +1,6 @@
 #!/sbin/openrc-run
 description="ddclient Daemon for Alpine"
-command="/usr/sbin/ddclient"
+command="/usr/bin/ddclient"
 config_file="/etc/ddclient/ddclient.conf"
 command_args=""
 pidfile=$(grep -v '^\s*#' "${config_file}" | grep -i -m 1 pid= | awk -F '=' '{print $2}')

--- a/sample-etc_rc.d_init.d_ddclient.lsb
+++ b/sample-etc_rc.d_init.d_ddclient.lsb
@@ -25,7 +25,7 @@
 
 [ -f /etc/ddclient/ddclient.conf ] || exit 0
 
-DDCLIENT_BIN=/usr/sbin/ddclient
+DDCLIENT_BIN=/usr/bin/ddclient
 
 #
 # LSB Standard (SuSE,RedHat,...)

--- a/sample-etc_rc.d_init.d_ddclient.ubuntu
+++ b/sample-etc_rc.d_init.d_ddclient.ubuntu
@@ -9,7 +9,7 @@
 # Description:       Start ddclient that provides support for updating dynamic DNS services.  Originally submitted by paolo martinelli, updated by joe passavanti
 ### END INIT INFO
 
-DDCLIENT=/usr/sbin/ddclient
+DDCLIENT=/usr/bin/ddclient
 CONF=/etc/ddclient/ddclient.conf
 PIDFILE=/var/run/ddclient.pid
 

--- a/sample-etc_systemd.service
+++ b/sample-etc_systemd.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=forking
 PIDFile=/var/run/ddclient.pid
-ExecStart=/usr/sbin/ddclient
+ExecStart=/usr/bin/ddclient
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Installing with `make install` automatically places the ddclient executable in "/usr/bin/ddclient"
This service file has the wrong path and that causes systemd to be unable to start ddclient.