### PR TITLE
Import IO::Socket::INET

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,7 @@ m4_foreach_w([_m], [
     File::Basename
     File::Path
     Getopt::Long
+    IO::Socket::INET
     Socket
     Sys::Hostname
     version=0.77

--- a/ddclient.in
+++ b/ddclient.in
@@ -25,6 +25,7 @@ use warnings;
 use File::Basename;
 use File::Path qw(make_path);
 use Getopt::Long;
+use IO::Socket::INET;
 use Socket qw(AF_INET AF_INET6 PF_INET PF_INET6);
 use Sys::Hostname;
 


### PR DESCRIPTION
We've always required IO::Socket::INET but never explicitly included it. For some reason that hasn't been a problem until now.

Fixes #255

cc @dkerr64 