### PR TITLE
Fix `-daemon` command-line argument parsing

### DIFF
--- a/ddclient.in
+++ b/ddclient.in
@@ -1295,6 +1295,11 @@ sub init_config {
 
     $opt{'timeout'} = 0 if opt('timeout') < 0;
 
+    ## parse an interval expression (such as '5m') into number of seconds
+    $opt{'daemon'} = interval(opt('daemon')) if defined($opt{'daemon'});
+    ## make sure the interval isn't too short
+    $opt{'daemon'} = minimum('daemon') if opt('daemon') > 0 && opt('daemon') < minimum('daemon');
+
     ## define or modify host options specified on the command-line
     if (exists $opt{'options'} && defined $opt{'options'}) {
         ## collect cmdline configuration options.


### PR DESCRIPTION
It turns out the logic removed in d10601de11d287cf8a44a043ed31d658cf219a51 had a purpose after all.