### PR TITLE
Add new device built-ins (`fw=<device>`)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,12 @@ repository history](https://github.com/ddclient/ddclient/commits/master).
     addresses.
   * New `ssl_ca_dir` and `ssl_ca_file` options to specify the location of CA
     certificates.
+  * New built-in shorthands for obtaining the IP address from the following
+    devices ([thanks to Geoff Simmons](https://bugs.debian.org/589980)):
+      - `alcatel-530`: Alcatel/Thomson SpeedTouch 530
+      - `siemens-ss4200`: Siemens SpeedStream 4200
+      - `thomson-st536v6`: Thomson SpeedTouch 536v6
+      - `thomson-tg782`: Thomson/Technicolor TG782
 
 ### Bug fixes
 

--- a/ddclient.in
+++ b/ddclient.in
@@ -123,6 +123,11 @@ my %builtinfw = (
         'url'  => '/cgi/ip/',
         'skip' => 'ppp',
     },
+    'alcatel-530' => {
+        'name' => 'Alcatel/Thomson SpeedTouch 530',
+        'url'  => '/cgi/status/',
+        'skip' => 'IP Address',
+    },
     'alcatel-stp' => {
         'name' => 'Alcatel Speed Touch Pro',
         'url'  => '/cgi/router/',
@@ -258,6 +263,11 @@ my %builtinfw = (
         'url'  => '/cgi-bin/webcm?getpage=%2Fusr%2Fwww_safe%2Fhtml%2Fstatus%2FRouter.html',
         'skip' => 'Internet.*?IP Address',
     },
+    'siemens-ss4200' => {
+        'name' => 'Siemens SpeedStream 4200',
+        'url'  => '/summary.htm',
+        'skip' => '',
+    },
     'sitecom-dc202' => {
         'name' => 'Sitecom DC-202 FW',
         'url'  => '/status.htm',
@@ -292,6 +302,16 @@ my %builtinfw = (
         'name' => 'Sveasoft WRT54G/WRT54GS',
         'url'  => '/Status_Router.asp',
         'skip' => 'var wan_ip',
+    },
+    'thomson-st536v6' => {
+        'name' => 'Thomson SpeedTouch 536v6',
+        'url'  => '/cgi/b/is/',
+        'skip' => 'IP Address',
+    },
+    'thomson-tg782' => {
+        'name' => 'Thomson/Technicolor TG782',
+        'url'  => '/cgi/b/is/',
+        'skip' => 'IP Address',
     },
     'vigor-2200usb' => {
         'name' => 'Vigor 2200 USB',


### PR DESCRIPTION
Thanks goes to Geoff Simmons, who provided the definitions in https://bugs.debian.org/589980.