### PR TITLE
Add additional builtinweb entries

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,6 +22,7 @@ repository history](https://github.com/ddclient/ddclient/commits/master).
     certificates.
   * New built-in IP discovery service shorthands:
       - `googledomains` from https://domains.google
+      - `he` from https://he.net
       - `ipify-ipv4` and `ipify-ipv6` from https://www.ipify.org
       - `myonlineportal` from https://myonlineportal.net
       - `noip-ipv4` and `noip-ipv6` from https://www.noip.com

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ repository history](https://github.com/ddclient/ddclient/commits/master).
     addresses.
   * New `ssl_ca_dir` and `ssl_ca_file` options to specify the location of CA
     certificates.
+  * New built-in IP discovery service shorthands:
+      - `ipifyipv4` and `ipifyipv6` from https://www.ipify.org
+      - `myonlineportal` from https://myonlineportal.net
   * New built-in shorthands for obtaining the IP address from the following
     devices ([thanks to Geoff Simmons](https://bugs.debian.org/589980)):
       - `alcatel-530`: Alcatel/Thomson SpeedTouch 530

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,6 +21,7 @@ repository history](https://github.com/ddclient/ddclient/commits/master).
   * New `ssl_ca_dir` and `ssl_ca_file` options to specify the location of CA
     certificates.
   * New built-in IP discovery service shorthands:
+      - `googledomains` from https://domains.google
       - `ipify-ipv4` and `ipify-ipv6` from https://www.ipify.org
       - `myonlineportal` from https://myonlineportal.net
       - `noip-ipv4` and `noip-ipv6` from https://www.noip.com

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,7 +21,7 @@ repository history](https://github.com/ddclient/ddclient/commits/master).
   * New `ssl_ca_dir` and `ssl_ca_file` options to specify the location of CA
     certificates.
   * New built-in IP discovery service shorthands:
-      - `ipifyipv4` and `ipifyipv6` from https://www.ipify.org
+      - `ipify-ipv4` and `ipify-ipv6` from https://www.ipify.org
       - `myonlineportal` from https://myonlineportal.net
   * New built-in shorthands for obtaining the IP address from the following
     devices ([thanks to Geoff Simmons](https://bugs.debian.org/589980)):

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -27,6 +27,8 @@ repository history](https://github.com/ddclient/ddclient/commits/master).
       - `ipify-ipv4` and `ipify-ipv6` from https://www.ipify.org
       - `myonlineportal` from https://myonlineportal.net
       - `noip-ipv4` and `noip-ipv6` from https://www.noip.com
+      - `nsupdate.info-ipv4` and `nsupdate.info-ipv6` from
+        https://www.nsupdate.info
       - `zoneedit` from https://www.zoneedit.com
   * New built-in shorthands for obtaining the IP address from the following
     devices ([thanks to Geoff Simmons](https://bugs.debian.org/589980)):

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,7 @@ repository history](https://github.com/ddclient/ddclient/commits/master).
   * New built-in IP discovery service shorthands:
       - `ipify-ipv4` and `ipify-ipv6` from https://www.ipify.org
       - `myonlineportal` from https://myonlineportal.net
+      - `noip-ipv4` and `noip-ipv6` from https://www.noip.com
   * New built-in shorthands for obtaining the IP address from the following
     devices ([thanks to Geoff Simmons](https://bugs.debian.org/589980)):
       - `alcatel-530`: Alcatel/Thomson SpeedTouch 530

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,7 @@ repository history](https://github.com/ddclient/ddclient/commits/master).
   * New built-in IP discovery service shorthands:
       - `googledomains` from https://domains.google
       - `he` from https://he.net
+      - `ip4only.me`, `ip6only.me` from http://whatismyv6.com
       - `ipify-ipv4` and `ipify-ipv6` from https://www.ipify.org
       - `myonlineportal` from https://myonlineportal.net
       - `noip-ipv4` and `noip-ipv6` from https://www.noip.com

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -25,6 +25,7 @@ repository history](https://github.com/ddclient/ddclient/commits/master).
       - `ipify-ipv4` and `ipify-ipv6` from https://www.ipify.org
       - `myonlineportal` from https://myonlineportal.net
       - `noip-ipv4` and `noip-ipv6` from https://www.noip.com
+      - `zoneedit` from https://www.zoneedit.com
   * New built-in shorthands for obtaining the IP address from the following
     devices ([thanks to Geoff Simmons](https://bugs.debian.org/589980)):
       - `alcatel-530`: Alcatel/Thomson SpeedTouch 530

--- a/ddclient.in
+++ b/ddclient.in
@@ -96,11 +96,11 @@ sub T_POSTS  { 'postscript' }
 
 ## strategies for obtaining an ip address.
 my %builtinweb = (
-    'dyndns'    => { 'url' => 'http://checkip.dyndns.org/',               'skip' => 'Current IP Address:', },
-    'ipifyipv4' => { 'url' => 'https://api.ipify.org/', },
-    'ipifyipv6' => { 'url' => 'https://api6.ipify.org/', },
-    'loopia'    => { 'url' => 'http://dns.loopia.se/checkip/checkip.php', 'skip' => 'Current IP Address:', },
-    'myonlineportal' => { 'url' => 'https://myonlineportal.net/checkip', },
+    'dyndns' => {'url' => 'http://checkip.dyndns.org/', 'skip' => 'Current IP Address:',},
+    'ipifyipv4' => {'url' => 'https://api.ipify.org/',},
+    'ipifyipv6' => {'url' => 'https://api6.ipify.org/',},
+    'loopia' => {'url' => 'http://dns.loopia.se/checkip/checkip.php', 'skip' => 'Current IP Address:',},
+    'myonlineportal' => {'url' => 'https://myonlineportal.net/checkip',},
 );
 my %builtinfw = (
     '2wire' => {

--- a/ddclient.in
+++ b/ddclient.in
@@ -105,6 +105,7 @@ my %builtinweb = (
     'myonlineportal' => {'url' => 'https://myonlineportal.net/checkip'},
     'noip-ipv4' => {'url' => 'http://ip1.dynupdate.no-ip.com/'},
     'noip-ipv6' => {'url' => 'http://ip1.dynupdate6.no-ip.com/'},
+    'zoneedit' => {'url' => 'http://dynamic.zoneedit.com/checkip.html'},
 );
 my %builtinfw = (
     '2wire' => {

--- a/ddclient.in
+++ b/ddclient.in
@@ -101,6 +101,8 @@ my %builtinweb = (
     'ipify-ipv6' => {'url' => 'https://api6.ipify.org/'},
     'loopia' => {'url' => 'http://dns.loopia.se/checkip/checkip.php', 'skip' => 'Current IP Address:'},
     'myonlineportal' => {'url' => 'https://myonlineportal.net/checkip'},
+    'noip-ipv4' => {'url' => 'http://ip1.dynupdate.no-ip.com/'},
+    'noip-ipv6' => {'url' => 'http://ip1.dynupdate6.no-ip.com/'},
 );
 my %builtinfw = (
     '2wire' => {

--- a/ddclient.in
+++ b/ddclient.in
@@ -97,6 +97,7 @@ sub T_POSTS  { 'postscript' }
 ## strategies for obtaining an ip address.
 my %builtinweb = (
     'dyndns' => {'url' => 'http://checkip.dyndns.org/', 'skip' => 'Current IP Address:'},
+    'freedns' => {'url' => 'https://freedns.afraid.org/dynamic/check.php'},
     'googledomains' => {'url' => 'https://domains.google.com/checkip'},
     'ipify-ipv4' => {'url' => 'https://api.ipify.org/'},
     'ipify-ipv6' => {'url' => 'https://api6.ipify.org/'},

--- a/ddclient.in
+++ b/ddclient.in
@@ -108,6 +108,8 @@ my %builtinweb = (
     'myonlineportal' => {'url' => 'https://myonlineportal.net/checkip'},
     'noip-ipv4' => {'url' => 'http://ip1.dynupdate.no-ip.com/'},
     'noip-ipv6' => {'url' => 'http://ip1.dynupdate6.no-ip.com/'},
+    'nsupdate.info-ipv4' => {'url' => 'http://ipv4.nsupdate.info/myip'},
+    'nsupdate.info-ipv6' => {'url' => 'http://ipv6.nsupdate.info/myip'},
     'zoneedit' => {'url' => 'http://dynamic.zoneedit.com/checkip.html'},
 );
 my %builtinfw = (

--- a/ddclient.in
+++ b/ddclient.in
@@ -99,6 +99,7 @@ my %builtinweb = (
     'dyndns' => {'url' => 'http://checkip.dyndns.org/', 'skip' => 'Current IP Address:'},
     'freedns' => {'url' => 'https://freedns.afraid.org/dynamic/check.php'},
     'googledomains' => {'url' => 'https://domains.google.com/checkip'},
+    'he' => {'url' => 'http://checkip.dns.he.net/'},
     'ipify-ipv4' => {'url' => 'https://api.ipify.org/'},
     'ipify-ipv6' => {'url' => 'https://api6.ipify.org/'},
     'loopia' => {'url' => 'http://dns.loopia.se/checkip/checkip.php', 'skip' => 'Current IP Address:'},

--- a/ddclient.in
+++ b/ddclient.in
@@ -97,8 +97,8 @@ sub T_POSTS  { 'postscript' }
 ## strategies for obtaining an ip address.
 my %builtinweb = (
     'dyndns' => {'url' => 'http://checkip.dyndns.org/', 'skip' => 'Current IP Address:'},
-    'ipifyipv4' => {'url' => 'https://api.ipify.org/'},
-    'ipifyipv6' => {'url' => 'https://api6.ipify.org/'},
+    'ipify-ipv4' => {'url' => 'https://api.ipify.org/'},
+    'ipify-ipv6' => {'url' => 'https://api6.ipify.org/'},
     'loopia' => {'url' => 'http://dns.loopia.se/checkip/checkip.php', 'skip' => 'Current IP Address:'},
     'myonlineportal' => {'url' => 'https://myonlineportal.net/checkip'},
 );

--- a/ddclient.in
+++ b/ddclient.in
@@ -100,6 +100,8 @@ my %builtinweb = (
     'freedns' => {'url' => 'https://freedns.afraid.org/dynamic/check.php'},
     'googledomains' => {'url' => 'https://domains.google.com/checkip'},
     'he' => {'url' => 'http://checkip.dns.he.net/'},
+    'ip4only.me' => {'url' => 'http://ip4only.me/api/'},
+    'ip6only.me' => {'url' => 'http://ip6only.me/api/'},
     'ipify-ipv4' => {'url' => 'https://api.ipify.org/'},
     'ipify-ipv6' => {'url' => 'https://api6.ipify.org/'},
     'loopia' => {'url' => 'http://dns.loopia.se/checkip/checkip.php', 'skip' => 'Current IP Address:'},

--- a/ddclient.in
+++ b/ddclient.in
@@ -97,6 +97,7 @@ sub T_POSTS  { 'postscript' }
 ## strategies for obtaining an ip address.
 my %builtinweb = (
     'dyndns' => {'url' => 'http://checkip.dyndns.org/', 'skip' => 'Current IP Address:'},
+    'googledomains' => {'url' => 'https://domains.google.com/checkip'},
     'ipify-ipv4' => {'url' => 'https://api.ipify.org/'},
     'ipify-ipv6' => {'url' => 'https://api6.ipify.org/'},
     'loopia' => {'url' => 'http://dns.loopia.se/checkip/checkip.php', 'skip' => 'Current IP Address:'},

--- a/ddclient.in
+++ b/ddclient.in
@@ -96,11 +96,11 @@ sub T_POSTS  { 'postscript' }
 
 ## strategies for obtaining an ip address.
 my %builtinweb = (
-    'dyndns' => {'url' => 'http://checkip.dyndns.org/', 'skip' => 'Current IP Address:',},
-    'ipifyipv4' => {'url' => 'https://api.ipify.org/',},
-    'ipifyipv6' => {'url' => 'https://api6.ipify.org/',},
-    'loopia' => {'url' => 'http://dns.loopia.se/checkip/checkip.php', 'skip' => 'Current IP Address:',},
-    'myonlineportal' => {'url' => 'https://myonlineportal.net/checkip',},
+    'dyndns' => {'url' => 'http://checkip.dyndns.org/', 'skip' => 'Current IP Address:'},
+    'ipifyipv4' => {'url' => 'https://api.ipify.org/'},
+    'ipifyipv6' => {'url' => 'https://api6.ipify.org/'},
+    'loopia' => {'url' => 'http://dns.loopia.se/checkip/checkip.php', 'skip' => 'Current IP Address:'},
+    'myonlineportal' => {'url' => 'https://myonlineportal.net/checkip'},
 );
 my %builtinfw = (
     '2wire' => {


### PR DESCRIPTION
Note that this PR also renames `ipifyipv4` and `ipifyipv6` to `ipify-ipv4` and `ipify-ipv6` to make them easier to read.