### PR TITLE
Fix Gandi LiveDNS update process.

### DIFF
--- a/ddclient.in
+++ b/ddclient.in
@@ -5743,13 +5743,13 @@ sub nic_gandi_update {
         $url  = "https://$config{$h}{'server'}$config{$h}{'script'}";
         $url .= "/livedns/domains/$config{$h}{'zone'}/records/$hostname/$rrset_type";
 
-        my $reply = geturl({
+        my $reply = geturl(
             proxy   => opt('proxy'),
             url     => $url,
             headers => $headers,
             method  => 'PUT',
             data    => $data,
-        });
+        );
         unless ($reply) {
             failed("%s -- Could not connect to %s.", $h, $config{$h}{'server'});
             next;

--- a/ddclient.in
+++ b/ddclient.in
@@ -5744,11 +5744,12 @@ sub nic_gandi_update {
         $url .= "/livedns/domains/$config{$h}{'zone'}/records/$hostname/$rrset_type";
 
         my $reply = geturl(
-            proxy   => opt('proxy'),
-            url     => $url,
-            headers => $headers,
-            method  => 'PUT',
-            data    => $data,
+            proxy        => opt('proxy'),
+            url          => $url,
+            headers      => $headers,
+            method       => 'PUT',
+            data         => $data,
+            ssl_validate => 0,
         );
         unless ($reply) {
             failed("%s -- Could not connect to %s.", $h, $config{$h}{'server'});


### PR DESCRIPTION
I was trying to automatic dynamic DNS updates working with Gandi LiveDNS on my EdgeOS router, and encountered two separate issues:

1. There was a bug in the geturl() call inside the nic_gandi_update() routine, causing the update to fail because a hash reference was being passed into geturl(), which actually requires a list of key-value pairs instead.  This was a simple fix, just remove the braces from the geturl() call.

2. At least on my EdgeOS router, I was getting SSL certificate validation errors for "api.gandi.net", so I added a parameter to the geturl() call to disable the SSL hostname validation.  This isn't ideal, but it works around the problem successfully.

Since the magic EdgeOS commands to configure this are not obvious, here's how to configure Gandi LiveDNS on EdgeOS, if the WAN interface (to the Internet) is on eth0:
```
configure
delete service dns dynamic interface eth0
set service dns dynamic interface eth0 service custom-gandi protocol gandi
set service dns dynamic interface eth0 service custom-gandi login dummy
set service dns dynamic interface eth0 service custom-gandi password GANDI_API_KEY
set service dns dynamic interface eth0 service custom-gandi options zone=DOMAIN_NAME,ttl=5m
set service dns dynamic interface eth0 service custom-gandi host-name HOSTNAME
commit; save; exit
update dns dynamic interface eth0
show dns dynamic status
```
For the `host-name` parameter, a comma-separated list can be used to update multiple hostnames to the dynamic IP address, and `@` can be used as a hostname to update the IP address associated with the domain itself (which must be specified in the `zone=DOMAIN_NAME` parameter).  If the `ttl` option is not specified, it will default to 3 hours;
Gandi's minimum TTL supported is 5 minutes.