### PR TITLE
Add Keysystems protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Dynamic DNS services currently supported include:
     ClouDNS     - See https://www.cloudns.net
     dinahosting - See https://dinahosting.com
     Gandi       - See https://gandi.net
+    Keysystems  - See https://www.domaindiscount24.com/faq/en/dynamic-dns
 
 DDclient now supports many of cable/dsl broadband routers.
 

--- a/ddclient.in
+++ b/ddclient.in
@@ -5845,12 +5845,9 @@ sub nic_keysystems_update {
        # Set the URL that we're going to to update
        my $url;
        $url  = "http://$config{$h}{'server'}/update.php";
-       $url .= "?hostname=";
-       $url .= $h;
-       $url .= "&password=";
-       $url .= $config{$h}{'password'};
-       $url .= "&ip=";
-       $url .= $ip;
+       $url .= "?hostname=$h";
+       $url .= "&password=$config{$h}{'password'}";
+       $url .= "&ip=$ip";
        
        # Try to get URL
        my $reply = geturl(opt('proxy'), $url);

--- a/ddclient.in
+++ b/ddclient.in
@@ -462,8 +462,8 @@ my %variables = (
         'wildcard'            => setv(T_BOOL,  0, 1, 0,                    undef),
     },
     'keysystems-common-defaults'       => {
-                       'server'              => setv(T_FQDNP,  1, 0, 1, 'dynamicdns.key-systems.net', undef),
-                       'login'               => setv(T_LOGIN,  0, 0, 0, 'unused',            undef),
+        'server'              => setv(T_FQDNP,  1, 0, 1, 'dynamicdns.key-systems.net', undef),
+        'login'               => setv(T_LOGIN,  0, 0, 0, 'unused',            undef),
     },
 );
 my %services = (

--- a/ddclient.in
+++ b/ddclient.in
@@ -5868,9 +5868,7 @@ sub nic_keysystems_update {
                $config{$h}{'mtime'}  = $now;
                $config{$h}{'status'} = 'good';
                success("updating %s: good: IP address set to %s", $h, $ip);
-        }
-        else
-        {
+        } else {
                $config{$h}{'status'} = 'failed';
                failed("updating %s: Server said: '$reply'", $h);
         }

--- a/ddclient.in
+++ b/ddclient.in
@@ -461,6 +461,10 @@ my %variables = (
         'static'              => setv(T_BOOL,  0, 1, 0,                    undef),
         'wildcard'            => setv(T_BOOL,  0, 1, 0,                    undef),
     },
+    'keysystems-common-defaults'       => {
+                       'server'              => setv(T_FQDNP,  1, 0, 1, 'dynamicdns.key-systems.net', undef),
+                       'login'               => setv(T_LOGIN,  0, 0, 0, 'unused',            undef),
+    },
 );
 my %services = (
     'changeip' => {
@@ -758,6 +762,15 @@ my %services = (
             'zone'         => setv(T_OFQDN, 0, 0, undef,                  undef),
         },
     },
+    'keysystems' => {
+       'updateable' => undef,
+       'update'     => \&nic_keysystems_update,
+       'examples'   => \&nic_keysystems_examples,
+       'variables'  => merge(
+                         $variables{'keysystems-common-defaults'},
+                         $variables{'service-common-defaults'},
+                       ),
+   },
 );
 $variables{'merged'} = {
     map({ %{$services{$_}{'variables'}} } keys(%services)),
@@ -5786,6 +5799,83 @@ sub nic_gandi_update {
         }
     }
 }
+
+######################################################################
+## nic_keysystems_examples
+######################################################################
+sub nic_keysystems_examples {
+   return <<EoEXAMPLE;
+o 'keysystems'
+
+The 'keysystems' protocol is used by some non-free dynamic DNS services
+such as www.domaindiscount24.com, www.moniker.com or www.rrpproxy.net.
+Check https://www.domaindiscount24.com/faq/en/dynamic-dns for API.
+
+Configuration variables applicable to the 'keysystems' protocol are:
+ protocol=keysystems               ##
+ server=www.fqdn.of.service   ## defaults to dynamicdns.key-systems.net
+ password=service-password    ## password (token) registered with the service
+ non-fully.qualified.host         ## the host registered with the service.
+
+Example ${program}.conf file entries:
+ ## single host update
+ protocol=keysystems,                                       \\
+ password=prettypassword                    \\
+ myhost
+
+EoEXAMPLE
+}
+
+######################################################################
+## nic_keysystems_update
+## By JMCC
+## Based on the work by Tom Bosmans - https://bit.ly/2SZI2zD
+## response contains "code 200" on succesfull completion
+######################################################################
+sub nic_keysystems_update {
+   debug("\nnic_keysystems_update -------------------");
+
+   ## update each configured host
+   ## should improve to update in one pass
+   foreach my $h (@_) {
+       my $ip = delete $config{$h}{'wantip'};
+       info("KEYSYSTEMS setting IP address to %s for %s", $ip, $h);
+       verbose("UPDATE:","updating %s", $h);
+
+       # Set the URL that we're going to to update
+       my $url;
+       $url  = "http://$config{$h}{'server'}/update.php";
+       $url .= "?hostname=";
+       $url .= $h;
+       $url .= "&password=";
+       $url .= $config{$h}{'password'};
+       $url .= "&ip=";
+       $url .= $ip;
+       
+       # Try to get URL
+       my $reply = geturl(opt('proxy'), $url);
+
+       # No response, declare as failed
+       if (!defined($reply) || !$reply) {
+           failed("KEYSYSTEMS updating %s: Could not connect to %s.", $h, $config{$h}{'server'});
+           last;
+       }
+       last if !header_ok($h, $reply);
+
+       if ($reply =~ /code = 200/)
+       {
+               $config{$h}{'ip'}     = $ip;
+               $config{$h}{'mtime'}  = $now;
+               $config{$h}{'status'} = 'good';
+               success("updating %s: good: IP address set to %s", $h, $ip);
+        }
+        else
+        {
+               $config{$h}{'status'} = 'failed';
+               failed("updating %s: Server said: '$reply'", $h);
+        }
+   }
+} 
 
 # Execute main() if this file is run as a script or run via PAR (https://metacpan.org/pod/PAR),
 # otherwise do nothing. This "modulino" pattern makes it possible to import this file as a module

--- a/ddclient.in
+++ b/ddclient.in
@@ -5813,8 +5813,8 @@ Check https://www.domaindiscount24.com/faq/en/dynamic-dns for API.
 
 Configuration variables applicable to the 'keysystems' protocol are:
  protocol=keysystems               ##
- server=www.fqdn.of.service   ## defaults to dynamicdns.key-systems.net
- password=service-password    ## password (token) registered with the service
+ server=www.example.com            ## defaults to dynamicdns.key-systems.net
+ password=service-password         ## password (token) registered with the service
  non-fully.qualified.host         ## the host registered with the service.
 
 Example ${program}.conf file entries:

--- a/ddclient.in
+++ b/ddclient.in
@@ -5819,7 +5819,7 @@ Configuration variables applicable to the 'keysystems' protocol are:
 
 Example ${program}.conf file entries:
  ## single host update
- protocol=keysystems,                                       \\
+ protocol=keysystems,                       \\
  password=prettypassword                    \\
  myhost
 


### PR DESCRIPTION
The 'keysystems' protocol is used by some non-free dynamic DNS services such as www.domaindiscount24.com, www.moniker.com or www.rrpproxy.net.

Based on the work by Tom Bosmans (see https://www.gwbasics.be/blog.nsf/dx/custom-dynamic-dns-on-ubiquity-router-with-domaindiscount24.com.htm)