### PR TITLE
Fix sample duckdns.org config

### DIFF
--- a/ddclient.conf.in
+++ b/ddclient.conf.in
@@ -218,8 +218,9 @@ ssl=yes					# use ssl-support.  Works with
 ## Duckdns (http://www.duckdns.org/)
 ##
 #
-# password=my-auto-generated-password
-# protocol=duckdns hostwithoutduckdnsorg
+# protocol=duckdns, \
+# password=my-auto-generated-password \
+# hostwithoutduckdnsorg
 
 ##
 ## Freemyip (http://freemyip.com/)


### PR DESCRIPTION
The included configuration for duckdns.org is incorrect and does not
match the protocol sample in the wiki[1].

[1] https://sourceforge.net/p/ddclient/wiki/protocols/#duckdns