### PR TITLE
modify Cloudflare documentation

### DIFF
--- a/ddclient.conf.in
+++ b/ddclient.conf.in
@@ -192,7 +192,7 @@ ssl=yes					# use ssl-support.  Works with
 #protocol=cloudflare,        \
 #zone=domain.tld,            \
 #ttl=1,                      \
-#login=your-login-email,     \ # Only needed if you are using your global API key.
+#login=your-login-email,     \ # Only needed if you are using your global API key. If you are using an API token, set it to "token" (wihtout double quotes).
 #password=APIKey             \ # This is either your global API key, or an API token. If you are using an API token, it must have the permissions "Zone - DNS - Edit" and "Zone - Zone - Read". The Zone resources must be "Include - All zones".
 #domain.tld,my.domain.tld
 

--- a/ddclient.in
+++ b/ddclient.in
@@ -4733,6 +4733,7 @@ Example ${program}.conf file entries:
   ## single host update using an API token
   protocol=cloudflare,                                         \\
   zone=dns.zone,                                               \\
+  login=token,                                                 \\
   password=cloudflare-api-token                                \\
   myhost.com
 


### PR DESCRIPTION
It seems that ddclient check if the login field is equal to "token" to use the correct header for the API token.

https://github.com/ddclient/ddclient/blob/11a583b003920f8e15591813598b70061d1a4654/ddclient.in#L4764