### PR TITLE
Trim non JSON part of payload from Cloudflare response to client

### DIFF
--- a/ddclient.in
+++ b/ddclient.in
@@ -5561,7 +5561,8 @@ sub nic_cloudflare_update {
             }
 
             # Strip header
-            $reply =~ s/^.*?\n\n//s;
+            $reply =~ s/[^{]*//s;
+            $reply =~ s/[^}]*$//s;
             my $response = eval {decode_json($reply)};
             unless ($response && $response->{result}) {
                 failed("updating %s: invalid json or result.", $domain);
@@ -5598,7 +5599,8 @@ sub nic_cloudflare_update {
                     next;
                 }
                 # Strip header
-                $reply =~ s/^.*?\n\n//s;
+                $reply =~ s/[^{]*//s;
+                $reply =~ s/[^}]*$//s;
                 $response = eval {decode_json($reply)};
                 unless ($response && $response->{result}) {
                     failed("updating %s: invalid json or result.", $domain);
@@ -5625,7 +5627,8 @@ sub nic_cloudflare_update {
                     next;
                 }
                 # Strip header
-                $reply =~ s/^.*?\n\n//s;
+                $reply =~ s/[^{]*//s;
+                $reply =~ s/[^}]*$//s;
                 $response = eval {decode_json($reply)};
                 if ($response && $response->{result}) {
                     success("updating %s: IPv$ipv address set to %s", $domain, $ip);


### PR DESCRIPTION
I have noticed that the Cloudflare support does not work (for me) at the moment due to spurious HTTP data being returned before and after the wanted JSON data. This fix solved the problem for me, however I am not a Perl developer so somebody else should review it.