### PR TITLE
Updated example service file to use network-online.target

### DIFF
--- a/sample-etc_systemd.service
+++ b/sample-etc_systemd.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Dynamic DNS Update Client
-After=network.target
+After=network.target network-online.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
I finally took the time to determine why I received a connection error every morning when I first started my computer. In my opinion, this proposed change is a more correct way to control the ddclient service.