### PR TITLE
Update pid file path from /run/var/ to /run

### DIFF
--- a/sample-etc_systemd.service
+++ b/sample-etc_systemd.service
@@ -4,7 +4,7 @@ After=network.target network-online.target
 
 [Service]
 Type=forking
-PIDFile=/var/run/ddclient.pid
+PIDFile=/run/ddclient.pid
 ExecStart=/usr/bin/ddclient
 
 [Install]


### PR DESCRIPTION
Was getting the following error while using the default systemd ddclient service:
```bash
PIDFile= references a path below legacy directory /var/run/, updating /var/run/ddclient.pid → /run/ddclient.pid;
```
Updating the path on the service file to `/run/ddclient.pid` fixes it.