### PR TITLE
Gandi: Fix "Reference found where even-sized list expected"

### DIFF
--- a/ddclient.in
+++ b/ddclient.in
@@ -5743,13 +5743,13 @@ sub nic_gandi_update {
         $url  = "https://$config{$h}{'server'}$config{$h}{'script'}";
         $url .= "/livedns/domains/$config{$h}{'zone'}/records/$hostname/$rrset_type";
 
-        my $reply = geturl({
+        my $reply = geturl(
             proxy   => opt('proxy'),
             url     => $url,
             headers => $headers,
             method  => 'PUT',
             data    => $data,
-        });
+        );
         unless ($reply) {
             failed("%s -- Could not connect to %s.", $h, $config{$h}{'server'});
             next;


### PR DESCRIPTION
## Symptom:

The Gandi code fails with the "Reference found where even-sized list expected" Perl error and all of the options end up undefined:

```
Reference found where even-sized list expected at /usr/sbin/ddclient line 2056.                                                                                
Use of uninitialized value $url in pattern match (m//) at /usr/sbin/ddclient line 2070.
Use of uninitialized value $url in substitution (s///) at /usr/sbin/ddclient line 2072.
Use of uninitialized value $server in substitution (s///) at /usr/sbin/ddclient line 2074.
Use of uninitialized value $url in substitution (s///) at /usr/sbin/ddclient line 2075.
Use of uninitialized value $url in substitution (s///) at /usr/sbin/ddclient line 2075.
DEBUG:    proxy    = <undefined>                                                                                                                               
DEBUG:    protocol = https                                                                                                                                     
Use of uninitialized value $_[0] in sprintf at /usr/sbin/ddclient line 1821.   
DEBUG:    server   =                                                                                                                                                                                                                                                                                                          
DEBUG:    url      =                                    
DEBUG:    ip ver   =                                               
Use of uninitialized value $peer in substitution (s///) at /usr/sbin/ddclient line 2093.
Use of uninitialized value $peer in pattern match (m//) at /usr/sbin/ddclient line 2094.
Use of uninitialized value $peer in pattern match (m//) at /usr/sbin/ddclient line 2094.
Use of uninitialized value $_[0] in sprintf at /usr/sbin/ddclient line 1821.
FAILED:   unable to extract host and port from                         
FAILED:   <host> -- Could not connect to api.gandi.net.
```

## Reason

`geturl()` expects a list/hash but the Gandi code is calling with a reference: `geturl({ ... })`.

## Fix

Remove the curly braces.
This is now in line with all other calls to `geturl` which use a list too, not a reference.

## Test

My Gandi protocol now succeeds with this config line:
`protocol=gandi, zone=<zone>,  ttl=900, password=<secret> <host>`
