### PR TITLE
cloudflare: Remove unused $hostname variable

### DIFF
--- a/ddclient.in
+++ b/ddclient.in
@@ -5821,7 +5821,6 @@ sub nic_cloudflare_update {
 
         # FQDNs
         for my $domain (@hosts) {
-            (my $hostname = $domain) =~ s/\.$config{$key}{zone}$//;
             my $ipv4  = delete $config{$domain}{'wantipv4'};
             my $ipv6  = delete $config{$domain}{'wantipv6'};
 


### PR DESCRIPTION
This is no longer used since commit 6c951a039543 ("Add files via upload"), which updated to the Cloudflare API v4. The new API does not require any preprocessing of the domain name.