### PR TITLE
Cut 3.10.1 release

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,12 @@
 This document describes notable changes. For details, see the [source code
 repository history](https://github.com/ddclient/ddclient/commits/master).
 
+## 2022-10-24 v3.10.1
+
+### Bug fixes
+
+  * Fix t/version.pl test failure
+
 ## 2022-10-20 v3.10.0
 ### New features
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DDCLIENT v3.10.0
+# DDCLIENT v3.10.1
 
 `ddclient` is a Perl client used to update dynamic DNS entries for accounts 
 on many dynamic DNS services.
@@ -78,8 +78,8 @@ ddclient package.
      the directory:
 
      ```shell
-     tar xvfa ddclient-3.10.0.tar.gz
-     cd ddclient-3.10.0
+     tar xvfa ddclient-3.10.1.tar.gz
+     cd ddclient-3.10.1
      ```
 
      (If you are installing from a clone of the Git repository, you

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.63])
-AC_INIT([ddclient], [3.10.0_2])
+AC_INIT([ddclient], [3.10.1])
 AC_CONFIG_SRCDIR([ddclient.in])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([m4])

--- a/ddclient.in
+++ b/ddclient.in
@@ -30,7 +30,7 @@ use IO::Socket::INET;
 use Socket qw(AF_INET AF_INET6 PF_INET PF_INET6);
 use Sys::Hostname;
 
-use version 0.77; our $VERSION = version->declare('v3.10.0');
+use version 0.77; our $VERSION = version->declare('v3.10.1');
 (my $version = $VERSION->stringify()) =~ s/^v//;
 my $programd = $0;
 $programd =~ s%^.*/%%;


### PR DESCRIPTION
In the 3.10.0 release, the `make check` tests fail because the version was not updated in configure.ac. Update both to v3.10.1 so that a new release can be made which passes the tests.