### PR TITLE
fix hetzner zone problem

### DIFF
--- a/ddclient.in
+++ b/ddclient.in
@@ -6127,7 +6127,7 @@ sub nic_hetzner_update {
                 $config{$domain}{"status-ipv$ipv"} = 'failed';
 
                 # Get DNS 'A' or 'AAAA' record ID
-                $url = "https://$config{$key}{'server'}/records?$zone_id";
+                $url = "https://$config{$key}{'server'}/records";
                 $reply = geturl(proxy => opt('proxy'),
                                 url => $url,
                                 headers => $headers
@@ -6144,7 +6144,7 @@ sub nic_hetzner_update {
                     next;
                 }
                 # Pull the ID out of the json, messy
-                my ($dns_rec_id) = map { ($_->{name} eq $hostname && $_->{type} eq $type) ? $_->{id} : ()} @{$response->{records}};
+                my ($dns_rec_id) = map { ($_->{name} eq $hostname && $_->{type} eq $type && &zone_id eq $_{zone_id}) ? $_->{id} : ()} @{$response->{records}};
 
                 # Set domain
                 my $http_method="";


### PR DESCRIPTION
The query for zone_id cannot be done at /api/v1/records. Therefore, I put the query in dns_rec_id.