### PR TITLE
fix: nic_ovh_update not ignoring extra data

### DIFF
--- a/ddclient.in
+++ b/ddclient.in
@@ -6850,8 +6850,8 @@ sub nic_ovh_update {
         }
 
         my @reply = split /\n/, $reply;
-        my $returned = pop(@reply);
-        if ($returned =~ /good/ || $returned =~ /nochg/) {
+        my $returned = List::Util::first { $_ =~ /good/ || $_ =~ /nochg/ } @reply;
+        if ($returned) {
             $config{$h}{'ip'}     = $ip;
             $config{$h}{'mtime'}  = $now;
             $config{$h}{'status'} = 'good';
@@ -6862,7 +6862,7 @@ sub nic_ovh_update {
             }
         } else {
             $config{$h}{'status'} = 'failed';
-            failed("updating %s: Server said: '%s'", $h, $returned);
+            failed("updating %s: Server said: '%s'", $h, $reply);
         }
     }
 }


### PR DESCRIPTION
Example bodies I've seen:

```
0013
good 127.0.0.1

0
```

```
0013
nochg 127.0.0.1
0
```

```
007
nohost

0
```

Seems like the trailing zero was not there before as the code relied on `pop`. Instead, we find the first line that matches `good`/`nochg`.

This provider could probably be replaced with dyndns2 if it were a bit more flexible, but I have no experience with Perl so went for the easiest fix.