### PR TITLE
add IPV6 support to duckdns protocol

### DIFF
--- a/ddclient.in
+++ b/ddclient.in
@@ -6445,7 +6445,11 @@ sub nic_duckdns_update {
         $url .= $h;
         $url .= "&token=";
         $url .= $config{$h}{'password'};
-        $url .= "&ip=";
+        if (is_ipv6($ip)) {
+            $url .= "&ipv6=";
+        } else {
+            $url .= "&ip=";
+        }
         $url .= $ip;
 
 


### PR DESCRIPTION
I have no idea how to test this thoroughly, but I did just modify these lines in my existing copy of ddclient and it works fine.  It's a really simple change as the duckdns protocol is pretty straightforward anyway.  

Basically it just uses the standard test to see if the passed IP address is IPV6 or not and just updates the url accordingly.