### PR TITLE
fix: CloudFlare configuration example

### DIFF
--- a/ddclient.conf.in
+++ b/ddclient.conf.in
@@ -184,14 +184,14 @@ ssl=yes					# use ssl-support.  Works with
 # myhost.changeip.org
 
 ##
-## CloudFlare (www.cloudflare.com)
+## CloudFlare (cloudflare.com)
 ##
-#protocol=cloudflare,        \
-#zone=domain.tld,            \
-#ttl=1,                      \
-#login=your-login-email,     \ # Only needed if you are using your global API key. If you are using an API token, set it to "token" (wihtout double quotes).
-#password=APIKey             \ # This is either your global API key, or an API token. If you are using an API token, it must have the permissions "Zone - DNS - Edit" and "Zone - Zone - Read". The Zone resources must be "Include - All zones".
-#domain.tld,my.domain.tld
+#protocol=cloudflare 
+#zone=domain.tld 
+#ttl=1 
+#login=your-login-email # Only needed if you are using your global API key. If you are using an API token, set it to "token" (wihtout double quotes).
+#password=APIKey # This is either your global API key, or an API token. If you are using an API token, it must have the permissions "Zone - DNS - Edit" and "Zone - Zone - Read". The Zone resources must be "Include - All zones".
+#domain.tld, my.domain.tld
 
 ##
 ## Gandi (gandi.net)


### PR DESCRIPTION
Current CloudFlare configuration makes it buggy. By removing useless backslashes and commas, it avoids weird errors