### PR TITLE
set use to disable if usev4 or usev6 is set

### DIFF
--- a/ddclient.in
+++ b/ddclient.in
@@ -1191,6 +1191,7 @@ sub update_nics {
             my $usev6     = opt('usev6', $h) // 'disabled';
             $use          = 'disabled' if ($use eq 'no'); # backward compatibility
             $usev6        = 'disabled' if ($usev6 eq 'no'); # backward compatibility
+            $use          = 'disabled' if ($usev4 ne 'disabled') || ($usev6 ne 'disabled');
             my $arg_ip    = opt('ip',    $h) // '';
             my $arg_ipv4  = opt('ipv4',  $h) // '';
             my $arg_ipv6  = opt('ipv6',  $h) // '';
@@ -3620,6 +3621,7 @@ sub nic_updateable {
     my $usev6  = opt('usev6', $host) // 'disabled';
     $use       = 'disabled' if ($use eq 'no');   # backward compatibility
     $usev6     = 'disabled' if ($usev6 eq 'no'); # backward compatibility
+    $use       = 'disabled' if ($usev4 ne 'disabled') || ($usev6 ne 'disabled');
 
     # If we have a valid IP address and we have previously warned that it was invalid.
     # reset the warning count back to zero.


### PR DESCRIPTION
Hi,
Is it defined everywhere that `use` is deprecated and we need to use `usev4` and `usev6` options.
But, `use` have default value to `ip` https://github.com/ddclient/ddclient/blob/master/ddclient.in#L434

So, if we dont set `use` option to `no` and set `usev4` to something, the `sub update_nics` will try to define ip address with the IP module. it causes unwanted checks, maybe unwanted behavior, but mostly just unwanted warning on the log.

I suggest to disable `use` option if `usev4` or `usev6` is set.

Another option is to set `use` to `disabled` as default, but I think it could impact more people.
