### PR TITLE
Do not use @localstatedir@ for $cachedir.

### DIFF
--- a/ddclient.in
+++ b/ddclient.in
@@ -49,7 +49,7 @@ sub subst_var {
 }
 
 my $etc = subst_var('@sysconfdir@', '/etc/ddclient');
-my $cachedir = subst_var('@localstatedir@', '/var') . '/cache/ddclient';
+my $cachedir = '/var/cache/ddclient';
 my $savedir = '/tmp';
 if ($program =~ /test/i) {
     $etc = '.';


### PR DESCRIPTION
From <https://www.gnu.org/prep/standards/html_node/Directory-Variables.html>, it states that:
```
$(localstatedir) should normally be /usr/local/var, but write it as $(prefix)/var. (If you are using Autoconf, write it as ‘@localstatedir@’.) 
```

@localstatedir@ is usually /usr/local/var which unless explicitly overriden, will depend on @​prefix@.
This usage is problematic when the prefix is immutable (distributions such as Guix, NixOS and Fedora Silverblue) as the default value results in:
```
WARNING:  Failed to create cache file /gnu/store/k4nqw1g3qac7g6nj4xw036xw16n6zyp3-ddclient-3.10.0/var/cache/ddclient/.ddclient-real.cache: Read-only file system
```