### PR TITLE
Add environment variable to override FRITZ!Box hostname

### DIFF
--- a/sample-get-ip-from-fritzbox
+++ b/sample-get-ip-from-fritzbox
@@ -9,12 +9,13 @@
 #
 # All credits for this one liner go to the author of this blog:
 # http://scytale.name/blog/2010/01/fritzbox-wan-ip
-# As the author explains its not required to tamper with the provided IP for the FritzBox
-# as it always binds to that address for UPnP.
 # Disclaimer: It might be necessary to make the script executable
+
+# Set default hostname to connect to the FritzBox
+: ${FRITZ_BOX_HOSTNAME:=fritz.box}
 
 curl -s -H 'Content-Type: text/xml; charset="utf-8"' \
   -H 'SOAPAction: urn:schemas-upnp-org:service:WANIPConnection:1#GetExternalIPAddress' \
   -d '<?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"> <s:Body> <u:GetExternalIPAddress xmlns:u="urn:schemas-upnp-org:service:WANIPConnection:1" /></s:Body></s:Envelope>' \
-  'http://fritz.box:49000/igdupnp/control/WANIPConn1' | \
+  "http://$FRITZ_BOX_HOSTNAME:49000/igdupnp/control/WANIPConn1" | \
   grep -Eo '\<[[:digit:]]{1,3}(\.[[:digit:]]{1,3}){3}\>'


### PR DESCRIPTION
The sample-get-ip-from-fritzbox.sh script currently assumes that the FRITZ!Box is reachable via the hostname `fritz.box`.
The FRITZ!Box does by default provide this hostname, but any other DNS setup must have this entry manually added.

This pull request adds the alternative option of changing the hostname queried via an environment variable.