### PR TITLE
Add configuration option to keep secrets out of config

### DIFF
--- a/ddclient.in
+++ b/ddclient.in
@@ -1585,7 +1585,7 @@ sub _read_config {
         $content .= "$_\n" unless /^#/;
 
         ## parsing passwords is special
-        if (/^([^#]*\s)?([^#]*?password\S*?)\s*=\s*('.*'|[^']\S*)(.*)/) {
+        if (/^([^#]*\s)?([^#]*?password)\s*=\s*('.*'|[^']\S*)(.*)/) {
             my ($head, $key, $value, $tail) = ($1 // '', $2, $3, $4);
             $value = $1 if $value =~ /^'(.*)'$/;
             $passwords{$key} = $value;

--- a/ddclient.in
+++ b/ddclient.in
@@ -1616,6 +1616,25 @@ sub _read_config {
 
         ## verify that keywords are valid...and check the value
         foreach my $k (keys %locals) {
+            # Handle '_env' keyword suffix
+            if ($k =~ /(.*)_env$/)
+            {
+                debug("Loading value for $1 from environment variable $locals{$k}.");
+                if (exists($ENV{$locals{$k}}))
+                {
+                    # Set the value to the value of the environment variable
+                    $locals{$1} = $ENV{$locals{$k}};
+                    # Remove the '_env' suffix from the key
+                    $k = $1;
+                }
+                else
+                {
+                    warning("Environment variable '$locals{$k}' not set for keyword '$k' (ignored)");
+                    delete $locals{$k};
+                    next;
+                }
+            }
+
             $locals{$k} = $passwords{$k} if defined $passwords{$k};
             if (!exists $variables{'merged'}{$k}) {
                 warning("unrecognized keyword '%s' (ignored)", $k);


### PR DESCRIPTION
Hi,

This pull request tackles issue #485.
I'm sending this in as an early first draft and to request comments.

EDIT: Updated revision is [in the comments](https://github.com/ddclient/ddclient/pull/522#issuecomment-1478677037), the rest of this initial comment is just kept for reference
---
My open points:
- Correct error handling when file is not found (instead of `open() or die`)
- Add tests for config parsing - I'm changing the password regex and want to be cautious.
- Either:
    - Mark password and password_file as needing either one or the other
    - Define placeholder value for password. If password_file is found and that placeholder value is not set, emit a warning.
- Make the password file less whitespace-sensitive (trailling newline)

This draft used the following config (domain references changed to example.com):
```
######################################################################
## Example configuration for password_file argument
######################################################################
daemon=300				# check every 300 seconds
syslog=yes				# log update msgs to syslog
#verbose=yes                            # Enable verbose logging
#mail=root				# mail all msgs to root
#mail-failure=root			# mail failed update msgs to root
pid=/var/run/ddclient/ddclient.pid	# record PID in file.
ssl=yes 				# use ssl-support.  Works with

# IP via fritzbox query script (local modified copy of sample-get-ip-from-fritzbox )
use=cmd, cmd=./get-ip-from-fritzbox-fixed

##
## NameCheap (namecheap.com)
##
protocol=namecheap,                       \
server=dynamicdns.park-your-domain.com,   \
login=example.com,                        \
password=iamnotused                       \
password_file=pw.secret                   \
@,subdomain.example.com
```
The file pw.secret contains the password without any extra whitespace (no trailing newlines)