### PR TITLE
Allow postscript to take args

### DIFF
--- a/ddclient.in
+++ b/ddclient.in
@@ -1209,9 +1209,10 @@ sub main {
 
 sub runpostscript {
     my ($ip) = @_;
+    my @postscript = split(/\s+/, $globals{postscript});
 
     if (defined $globals{postscript}) {
-        if (-x $globals{postscript}) {
+        if (-x $postscript[0]) {
             system("$globals{postscript} $ip &");
         } else {
             warning("Can not execute post script: %s", $globals{postscript});


### PR DESCRIPTION
$globals{postscript} can now contain a full command string including arguments. In order to facilitate this, the file executability check (-x) has been modified such that the first substring up to the first space (if it exists) is what is checked, rather than the whole string.