### PR TITLE
sample-etc_systemd.service: order after nss-lookup.target

### DIFF
--- a/sample-etc_systemd.service
+++ b/sample-etc_systemd.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Dynamic DNS Update Client
-After=network.target network-online.target
+Wants=network-online.target
+After=network-online.target nss-lookup.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
This improves the chances that the local DNS resolver (e.g. dnsmasq, systemd-resolved, Unbound) is up before the service runs and avoids DNS related failures.

Pull in network-online.target via Wants= to comply with its description in the systemd.special(7) man page and remove the redundant "After=network.target" since network-online.target already orders itself after network.target.