### PR TITLE
Add DigitalOcean to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Dynamic DNS services currently supported include:
 * [ChangeIP](https://www.changeip.com)
 * [CloudFlare](https://www.cloudflare.com)
 * [ClouDNS](https://www.cloudns.net)
+* [DigitalOcean](https://www.digitalocean.com/)
 * [dinahosting](https://dinahosting.com)
 * [DonDominio](https://www.dondominio.com)
 * [DNS Made Easy](https://dnsmadeeasy.com)


### PR DESCRIPTION
I forgot to document the new service in  #520. The changelog has since been updated to mention it, but it's still missing from the README.