### PR TITLE
If present, give URL protocol precedence over other SSL settings

### DIFF
--- a/ddclient.in
+++ b/ddclient.in
@@ -2578,21 +2578,27 @@ sub geturl {
     my $reply;
     my $server;
     my $use_ssl = 0;
-    my $force_ssl = 0;
     my $protocol;
     my $timeout  = opt('timeout');
     my @curlopt = ();
     my @header_lines = ();
 
-    ## canonify proxy and url
-    $force_ssl = 1 if ($url =~ /^https:/);
+    ## canonify use_ssl, proxy and url
+    if ($url =~ /^https:/) {
+        $use_ssl = 1;
+    } elsif ($url =~ /^http:/) {
+        $use_ssl = 0;
+    } elsif ($globals{'ssl'} && !($params{ignore_ssl_option} // 0)) {
+        $use_ssl = 1;
+    } else {
+        $use_ssl = 0;
+    }
+
     $proxy  =~ s%^https?://%%i if defined($proxy);
     $url    =~ s%^https?://%%i;
     $server = $url;
     $server =~ s%[?/].*%%;
     $url    =~ s%^[^?/]*/?%%;
-
-    $use_ssl = 1 if ($force_ssl || ($globals{'ssl'} && !($params{ignore_ssl_option} // 0)));
 
     $protocol = ($use_ssl ? "https" : "http");
 


### PR DESCRIPTION
This is basically a minor adjustment to https://github.com/ddclient/ddclient/pull/482 , updated for the new 3.11 curl-based geturl().  The original PR objections seemed to be focused on lack of time to properly understand the nuances of the old behavior rather than any realistic objection to the only-slightly-different new behavior.

My setup broke for the 3.10 update, with no easy config-only fix (see below).  Now Gentoo just updated to 3.11.1, and the 3.10 version of my fix/patch can't be applied, hence this newer patch.  This patch doesn't directly restore 3.9, but it is now possible to make a trivial configuration change for situations like this, by just including the protocol as part of each individual broken URL.

Key points:
  - I think it is basic good citizenship to prefer to extract your IP address from your local router, rather than asking a third party service unnecessarily.  Especially when querying it on a regular basis.
  - Many (most?) routers probably don't try to support an SSL web interface (https), probably because handling server certificates for a private service like this is not trivial (expiration, private URL/IP address changes, etc).  At least mine doesn't.
  - Best to use SSL wherever possible, though.  Especially for the actual update to the external ddns service you are using.
  - However, as near as I could tell (at least for 3.10), there was no way to enable SSL for the update without also forcing SSL for the "get IP address".  (It was somehow working in 3.9, although I'm not sure if it was using SSL at all.  3.10 forced SSL more widely (by default), and broke by setup.)
  - Related: At least a few other bugs mention difficulties using plain http for getting IP address...
  - The existing separate SSL setting is still used when the "URL" is incomplete and lacks a protocol, so the behavior change is minimal.

FUTURE ideas:
 - Perhaps this should be documented somehow.  (Although the documentation isn't great in general.)
 - Are there more code paths where similar "give precedence to URL protocol" should be changed?
 - Maybe some of the commented URL's in the default configuration file should include the protocol (http or https), especially if it is known that only one actually works.
 - Relatively few default config (commented) URLs currently specifies a protocol directly, but maybe "lack of explicit protocol in URL" should be deprecated because it leaves the nuances of configuring things more confusing...  (Protocol appears to be included in several embedded URLs now, though, based on a quick grep of the main script.)