### PR TITLE
Fix for getting url for keysystems

### DIFF
--- a/ddclient.in
+++ b/ddclient.in
@@ -7609,7 +7609,7 @@ sub nic_keysystems_update {
    my $url = "http://$config{$h}{'server'}/update.php?hostname=$h&password=$config{$h}{'password'}&ip=$ip";
 
    # Try to get URL
-   my $reply = geturl(opt('proxy'), $url);
+   my $reply = geturl(proxy => opt('proxy'), url => $url) // '';
 
    # No response, declare as failed
    if (!defined($reply) || !$reply) {


### PR DESCRIPTION
Updating keysystems won't work without this fix as described here: https://github.com/ddclient/ddclient/issues/501#issuecomment-1895708060