### PR TITLE
docs: Remove fork notice in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 `ddclient` is a Perl client used to update dynamic DNS entries for accounts
 on many dynamic DNS services. It uses `curl` for internet access.
 
-This is a friendly fork/continuation of https://github.com/ddclient/ddclient
-
 ## Alternatives
 
 You might also want to consider using one of the following, if they support


### PR DESCRIPTION
This no longer makes sense, given this fork then became the upstream repo.