### PR TITLE
Tell make that the tests depend on `ddclient`

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -72,6 +72,7 @@ generated_tests = \
 	t/geturl_connectivity.pl \
 	t/version.pl
 TESTS = $(handwritten_tests) $(generated_tests)
+$(TESTS): ddclient
 EXTRA_DIST += $(handwritten_tests) \
 	t/lib/Devel/Autoflush.pm \
 	t/lib/Test/Builder.pm \


### PR DESCRIPTION
This ensures that `ddclient` is rebuilt before running tests if `ddclient.in` changes.