### PR TITLE
Fix DonDominio service response treatment

### DIFF
--- a/ddclient.in
+++ b/ddclient.in
@@ -6935,7 +6935,7 @@ sub nic_dondominio_update {
 
         my @reply = split /\n/, $reply;
         my $returned = pop(@reply);
-        if ($returned =~ /OK/) {
+        if ($returned =~ /OK/ || $returned =~ /IP:$ip/) {
             $config{$h}{'ip'}     = $ip;
             $config{$h}{'mtime'}  = $now;
             $config{$h}{'status'} = 'good';


### PR DESCRIPTION
This PR fixes a bug in handling the response from DonDominio service.

According to [DonDominio documentation](https://dondominio.dev/es/dondns/docs/api/#respuesta-plaintext) when the DNS update has succeeded the service returns "OK" and, if the IP has changed, it returns an additional line with "IP:x.x.x.x.x". Also, in practice, the service always returns this line with IP as the last line, which causes ddclient to report the update as a failure because the last line is not the string "OK".

This PR corrects this behaviour.