### PR TITLE
Fix misspelled `*-ssl-validate` option names

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -68,6 +68,7 @@ handwritten_tests = \
 	t/is-and-extract-ipv6.pl \
 	t/is-and-extract-ipv6-global.pl \
 	t/parse_assignments.pl \
+	t/ssl-validate.pl \
 	t/write_cache.pl
 generated_tests = \
 	t/version.pl

--- a/ddclient.in
+++ b/ddclient.in
@@ -62,7 +62,8 @@ local $lineno = '';
 $ENV{'PATH'} = (exists($ENV{PATH}) ? "$ENV{PATH}:" : "") . "/sbin:/usr/sbin:/bin:/usr/bin:/etc:/usr/lib:";
 
 our %globals;
-my ($result, %config, %cache);
+our %config;
+my ($result, %cache);
 my $saved_cache;
 my %saved_opt;
 my $daemon;
@@ -3191,7 +3192,7 @@ sub get_ipv4 {
             $reply = geturl( proxy => opt('proxy', $h),
                 url => $url,
                 ipversion => 4, # when using a URL to find IPv4 address we should force use of IPv4
-                ssl_validate => opt('ssl-validate', $h),
+                ssl_validate => opt('web-ssl-validate', $h),
             ) // '';
         }
 
@@ -3223,7 +3224,7 @@ sub get_ipv4 {
             password => opt('fw-password', $h),
             ipversion => 4, # when using a URL to find IPv4 address we should force use of IPv4
             ignore_ssl_option => 1,
-            ssl_validate => opt('ssl-validate', $h),
+            ssl_validate => opt('fw-ssl-validate', $h),
         ) // '';
 
     } elsif ($usev4 eq 'disabled') {
@@ -3251,7 +3252,7 @@ sub get_ipv4 {
                 password => opt('fw-password', $h),
                 ipversion => 4, # when using a URL to find IPv4 address we should force use of IPv4
                 ignore_ssl_option => 1,
-                ssl_validate => opt('ssl-validate', $h),
+                ssl_validate => opt('fw-ssl-validate', $h),
             ) // '';
         }
     }
@@ -3340,7 +3341,7 @@ sub get_ipv6 {
                 proxy => opt('proxy'),
                 url => $url,
                 ipversion => 6, # when using a URL to find IPv6 address we should force use of IPv6
-                ssl_validate => opt('ssl-validate', $h),
+                ssl_validate => opt('web-ssl-validate', $h),
             ) // '';
         }
 

--- a/t/ssl-validate.pl
+++ b/t/ssl-validate.pl
@@ -1,0 +1,118 @@
+use Test::More;
+eval {
+    require ddclient::Test::Fake::HTTPD;
+    require HTTP::Daemon::SSL;
+} or plan(skip_all => $@);
+SKIP: { eval { require Test::Warnings; } or skip($@, 1); }
+eval { require 'ddclient'; } or BAIL_OUT($@);
+my $ipv6_supported = eval {
+    require IO::Socket::IP;
+    my $ipv6_socket = IO::Socket::IP->new(
+        Domain => 'PF_INET6',
+        LocalHost => '::1',
+        Listen => 1,
+    );
+    defined($ipv6_socket);
+};
+my $http_daemon_supports_ipv6 = eval {
+    require HTTP::Daemon;
+    HTTP::Daemon->VERSION(6.12);
+};
+
+# Note: $ddclient::globals{'ssl_ca_file'} is intentionally NOT set to "$certdir/dummy-ca-cert.pem"
+# so that we can test what happens when certificate validation fails.
+my $certdir = "$ENV{abs_top_srcdir}/t/lib/ddclient/Test/Fake/HTTPD";
+
+sub run_httpd {
+    my ($ipv6) = @_;
+    return undef if $ipv6 && (!$ipv6_supported || !$http_daemon_supports_ipv6);
+    my $addr = $ipv6 ? '::1' : '127.0.0.1';
+    my $httpd = ddclient::Test::Fake::HTTPD->new(
+        host => $addr,
+        scheme => 'https',
+        daemon_args => {
+            SSL_cert_file => "$certdir/dummy-server-cert.pem",
+            SSL_key_file => "$certdir/dummy-server-key.pem",
+            V6Only => 1,
+        },
+    );
+    $httpd->run(sub {
+        return [200, ['Content-Type' => 'text/plain'], [$addr]];
+    });
+    diag(sprintf("started IPv%s SSL server running at %s", $ipv6 ? '6' : '4', $httpd->endpoint()));
+    return $httpd;
+}
+my $h = 't/ssl-validate.pl';
+my %httpd = (
+    '4' => run_httpd(0),
+    '6' => run_httpd(1),
+);
+my %ep = (
+    '4' => $httpd{'4'}->endpoint(),
+    '6' => $httpd{'6'} ? $httpd{'6'}->endpoint() : undef,
+);
+
+my @test_cases = (
+    {
+        desc => 'usev4=webv4 web-ssl-validate=no',
+        cfg => {'usev4' => 'webv4', 'web-ssl-validate' => 0, 'webv4' => $ep{'4'}},
+        want => '127.0.0.1',
+    },
+    {
+        desc => 'usev4=webv4 web-ssl-validate=yes',
+        cfg => {'usev4' => 'webv4', 'web-ssl-validate' => 1, 'webv4' => $ep{'4'}},
+        want => undef,
+    },
+    {
+        desc => 'usev6=webv6 web-ssl-validate=no',
+        cfg => {'usev6' => 'webv6', 'web-ssl-validate' => 0, 'webv6' => $ep{'6'}},
+        ipv6 => 1,
+        want => '::1',
+    },
+    {
+        desc => 'usev6=webv6 web-ssl-validate=yes',
+        cfg => {'usev6' => 'webv6', 'web-ssl-validate' => 1, 'webv6' => $ep{'6'}},
+        ipv6 => 1,
+        want => undef,
+    },
+    {
+        desc => 'usev4=cisco-asa fw-ssl-validate=no',
+        cfg => {'usev4' => 'cisco-asa', 'fw-ssl-validate' => 0,
+                # cisco-asa adds https:// to the URL.  :-/
+                'fwv4' => substr($ep{'4'}, length('https://'))},
+        want => '127.0.0.1',
+    },
+    {
+        desc => 'usev4=cisco-asa fw-ssl-validate=yes',
+        cfg => {'usev4' => 'cisco-asa', 'fw-ssl-validate' => 1,
+                # cisco-asa adds https:// to the URL.  :-/
+                'fwv4' => substr($ep{'4'}, length('https://'))},
+        want => undef,
+    },
+    {
+        desc => 'usev4=fwv4 fw-ssl-validate=no',
+        cfg => {'usev4' => 'fwv4', 'fw-ssl-validate' => 0, 'fwv4' => $ep{'4'}},
+        want => '127.0.0.1',
+    },
+    {
+        desc => 'usev4=fwv4 fw-ssl-validate=yes',
+        cfg => {'usev4' => 'fwv4', 'fw-ssl-validate' => 1, 'fwv4' => $ep{'4'}},
+        want => undef,
+    },
+);
+
+for my $tc (@test_cases) {
+    SKIP: {
+        skip("IPv6 not supported on this system", 1) if $tc->{ipv6} && !$ipv6_supported;
+        skip("HTTP::Daemon too old for IPv6 support", 1)
+            if $tc->{ipv6} && !$http_daemon_supports_ipv6;
+        $ddclient::config{$h} = $tc->{cfg};
+        %ddclient::config if 0;  # suppress spurious warning "Name used only once: possible typo"
+        is(ddclient::get_ipv4($tc->{cfg}{usev4}, $h), $tc->{want}, $tc->{desc})
+            if ($tc->{cfg}{usev4});
+        is(ddclient::get_ipv6($tc->{cfg}{usev6}, $h), $tc->{want}, $tc->{desc})
+            if ($tc->{cfg}{usev6});
+    }
+}
+
+done_testing();


### PR DESCRIPTION
There is no `ssl-validate` option, and there never has been.