### PR TITLE
he.net: Add support for Hurricane Electric provider

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -29,6 +29,9 @@ repository history](https://github.com/ddclient/ddclient/commits/master).
     protocol.  The old name is still accepted but is deprecated and will be
     removed in a future version of ddclient.
     [#682](https://github.com/ddclient/ddclient/pull/682)
+  * Deprecated built-in web IP discovery services are not listed in the output
+    of `--list-web-services`.
+    [#682](https://github.com/ddclient/ddclient/pull/682)
 
 ### New features
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,6 +19,11 @@ repository history](https://github.com/ddclient/ddclient/commits/master).
     `Digest::SHA` is now required.  Previously, `Digest::SHA1` was used (if
     available) as an alternative to `Digest::SHA`.
     [#685](https://github.com/ddclient/ddclient/pull/685)
+  * The `he` built-in web IP discovery service (`--webv4=he`, `--webv6=he`, and
+    `--web=he`) was renamed to `he.net` for consistency with the new `he.net`
+    protocol.  The old name is still accepted but is deprecated and will be
+    removed in a future version of ddclient.
+    [#682](https://github.com/ddclient/ddclient/pull/682)
 
 ### New features
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,11 @@ repository history](https://github.com/ddclient/ddclient/commits/master).
   * Unencrypted (plain) HTTP is now used instead of encrypted (TLS) HTTP if the
     URL uses `http://` instead of `https://`, even if the `--ssl` option is
     enabled.  [#608](https://github.com/ddclient/ddclient/pull/608)
+  * The `googledomains` built-in web IP discovery service
+    (`--webv4=googledomains`, `--webv6=googledomains`, and
+    `--web=googledomains`) is deprecated due to the service shutting down.  It
+    will be removed in a future version of ddclient.
+    [5b104ad1](https://github.com/ddclient/ddclient/commit/5b104ad116c023c3760129cab6e141f04f72b406)
   * The default web service for `--webv4` and `--webv6` has changed from Google
     Domains (which is shutting down) to ipify.
     [5b104ad1](https://github.com/ddclient/ddclient/commit/5b104ad116c023c3760129cab6e141f04f72b406)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -47,6 +47,8 @@ repository history](https://github.com/ddclient/ddclient/commits/master).
     [#676](https://github.com/ddclient/ddclient/pull/676)
   * `emailonly`: New `protocol` option that simply emails you when your IP
     address changes.  [#654](https://github.com/ddclient/ddclient/pull/654)
+  * `he.net`: Added support for updating Hurricane Electric records.
+    [#682](https://github.com/ddclient/ddclient/pull/682)
 
 ### Bug fixes
 
@@ -150,7 +152,7 @@ Refer to [v3.11 release plan discussions](https://github.com/ddclient/ddclient/i
 
   * Added support for domaindiscount24.com
   * Added support for njal.la
- 
+
 ## 2022-05-15 v3.10.0_2
 
 ### Bug fixes

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Dynamic DNS services currently supported include:
 * [Gandi](https://gandi.net)
 * [GoDaddy](https://www.godaddy.com)
 * [Google](https://domains.google)
+* [Hurricane Electric](https://dns.he.net)
 * [Infomaniak](https://faq.infomaniak.com/2376)
 * [Loopia](https://www.loopia.se)
 * [Mythic Beasts](https://www.mythic-beasts.com/support/api/dnsv2/dynamic-dns)

--- a/ddclient.conf.in
+++ b/ddclient.conf.in
@@ -223,6 +223,13 @@ ssl=yes					# use ssl-support.  Works with
 # my.domain.tld, otherhost.domain.tld
 
 ##
+## Hurricane Electric (dns.he.net)
+##
+# protocol=he.net,                      \
+# password=my-genereated-password       \
+# myhost.example.com
+
+##
 ## Duckdns (http://www.duckdns.org/)
 ##
 #

--- a/ddclient.in
+++ b/ddclient.in
@@ -915,6 +915,17 @@ our %protocols = (
             'server'       => setv(T_FQDNP, 0, 0, 'domains.google.com', undef),
         },
     },
+    'he.net' => {
+        'updateable' => undef,
+        'update' => \&nic_henet_update,
+        'examples' => \&nic_henet_examples,
+        'variables' => {
+            %{$variables{'protocol-common-defaults'}},
+            'login' => undef,
+            'min-interval' => setv(T_DELAY, 0, 0, interval('5m'), 0),
+            'server' => setv(T_FQDNP, 0, 0, 'dyn.dns.he.net', undef),
+        },
+    },
     'hetzner' => {
         'force_update' => undef,
         'update'     => \&nic_hetzner_update,
@@ -5859,6 +5870,84 @@ sub nic_googledomains_update {
         $config{$host}{'ip'} = $ip;
         $config{$host}{'mtime'} = $now;
         $config{$host}{'status'} = 'good';
+    }
+}
+
+######################################################################
+## nic_henet_examples
+##
+## written by Indrajit Raychaudhuri
+##
+######################################################################
+sub nic_henet_examples {
+    return <<"EoEXAMPLE";
+o 'he.net'
+
+The 'he.net' protocol is used by DNS service offered by dns.he.net.
+
+Configuration variables applicable to the 'he.net' protocol are:
+  protocol=he.net              ##
+  password=service-password    ## the password provided by the admin interface
+  fully.qualified.host         ## the host registered with the service.
+
+Example ${program}.conf file entries:
+  ## single host update
+  protocol=he.net,                                             \\
+  password=my-genereated-password                              \\
+  myhost.example.com
+EoEXAMPLE
+}
+
+######################################################################
+## nic_henet_update
+######################################################################
+sub nic_henet_update {
+    debug("\nnic_henet_update -------------------");
+
+    my %errors = (
+       'badauth' => 'Bad authorization (username or password)',
+       'badsys' => 'The system parameter given was not valid',
+       'nohost' => 'The hostname specified does not exist in the database',
+       'abuse' => 'The hostname specified is blocked for abuse',
+       'nochg' => 'No update required; unnecessary attempts to change to the current address are considered abusive',
+    );
+
+    for my $h (@_) {
+        # The IPv4 and IPv6 addresses must be updated in separate API call.
+        for my $ipv ('4', '6') {
+            my $ip = delete($config{$h}{"wantipv$ipv"}) or next;
+            info("Setting IPv%s address to %s for %s", $ipv, $ip, $h);
+            verbose("UPDATE:", "updating %s", $h);
+            my $reply = geturl(
+                proxy => opt('proxy'),
+                url => "https://$config{$h}{'server'}/nic/update?hostname=$h&myip=$ip",
+                login => $h,
+                password => $config{$h}{'password'},
+            ) // '';
+            if ($reply eq '') {
+                failed("updating %s: Could not connect to %s.", $h, $config{$h}{'server'});
+                next;
+            }
+            next if !header_ok($h, $reply);
+            # dyn.dns.he.net can return 200 OK even if there is an error (e.g., bad authentication,
+            # updates too frequent) so the body of the response must also be checked.
+            (my $body = $reply) =~ s/^.*?\n\n//s;
+            my ($line) = split(/\n/, $body, 2);
+            my ($status, $returnedip) = split(/ /, lc($line));
+            $status = 'good' if $status eq 'nochg';
+            $config{$h}{"status-ipv$ipv"} = $status;
+            if ($status ne 'good') {
+                if (exists($errors{$status})) {
+                    failed("updating %s: %s: %s", $h, $status, $errors{$status});
+                } else {
+                    failed("updating %s: unexpected status: %s", $h, $line);
+                }
+                next;
+            }
+            success("updating %s: %s: IPv%s address set to %s", $h, $status, $ipv, $returnedip);
+            $config{$h}{"ipv$ipv"} = $returnedip;
+            $config{$h}{'mtime'} = $now;
+        }
     }
 }
 

--- a/ddclient.in
+++ b/ddclient.in
@@ -193,8 +193,14 @@ sub T_POSTS  { 'postscript' }
 our %builtinweb = (
     'dyndns' => {'url' => 'http://checkip.dyndns.org/', 'skip' => 'Current IP Address:'},
     'freedns' => {'url' => 'https://freedns.afraid.org/dynamic/check.php'},
-    'googledomains' => {'url' => 'https://domains.google.com/checkip'}, #  Deprecated! See https://github.com/ddclient/ddclient/issues/622 for more details
-    'he' => {'url' => 'https://checkip.dns.he.net/'},
+    'googledomains' => {
+        url => 'https://domains.google.com/checkip',
+        deprecated => 'See https://github.com/ddclient/ddclient/issues/622 for more info.',
+    },
+    'he' => {
+        url => 'https://checkip.dns.he.net/',
+        deprecated => "Use 'he.net' instead.",
+    },
     'he.net' => {'url' => 'https://checkip.dns.he.net/'},
     'ip4only.me' => {'url' => 'https://ip4only.me/api/'},
     'ip6only.me' => {'url' => 'https://ip6only.me/api/'},
@@ -1166,7 +1172,11 @@ $opt{'list-protocols'} = sub {
     exit(0);
 };
 $opt{'list-web-services'} = sub {
-    printf("%s %s\n", $_, $builtinweb{$_}{url}) for sort(keys(%builtinweb));
+    # This intentionally does not list deprecated services, although they are still accepted.
+    # Excluding deprecated services from the output discourages their selection by configuration
+    # wizards (e.g., Debian's debconf) that present this list to users.
+    printf("%s %s\n", $_, $builtinweb{$_}{url})
+        for sort(grep(!$builtinweb{$_}{deprecated}, keys(%builtinweb)));
     exit(0);
 };
 $opt{'version'} = sub {
@@ -2912,11 +2922,10 @@ sub get_ip {
     } elsif ($use eq 'web') {
         $url = opt('web', $h) // '';
         $skip = opt('web-skip', $h);
-        if (exists $builtinweb{$url}) {
-            warning("googledomains is deprecated! See https://github.com/ddclient/ddclient/issues/622 for more info.") if ($url eq 'googledomains');
-            warning("'he' is deprecated; use 'he.net' instead.") if ($url eq 'he');
-            $skip //= $builtinweb{$url}->{'skip'};
-            $url = $builtinweb{$url}->{'url'};
+        if (my $biw = $builtinweb{$url}) {
+            warning("'--web=$url' is deprecated!  $biw->{deprecated}") if $biw->{deprecated};
+            $skip //= $biw->{skip};
+            $url = $biw->{url};
         }
         $arg = $url;
         if ($url) {
@@ -3308,11 +3317,10 @@ sub get_ipv4 {
         ## Obtain IPv4 address by accessing website at url in "webv4=<url>"
         $url = $arg;
         $skip = opt('webv4-skip', $h);
-        if (exists $builtinweb{$url}) {
-            warning("googledomains is deprecated! See https://github.com/ddclient/ddclient/issues/622 for more info.") if ($url eq 'googledomains');
-            warning("'he' is deprecated; use 'he.net' instead.") if ($url eq 'he');
-            $skip //= $builtinweb{$url}->{'skip'};
-            $url = $builtinweb{$url}->{'url'};
+        if (my $biw = $builtinweb{$url}) {
+            warning("'--webv4=$url' is deprecated!  $biw->{deprecated}") if $biw->{deprecated};
+            $skip //= $biw->{skip};
+            $url = $biw->{url};
             $arg  = $url;
         }
         if ($url) {
@@ -3426,11 +3434,10 @@ sub get_ipv6 {
             if (!defined(opt('webv6-skip', $h)) && defined(opt('web-skip', $h)));
         $url = $arg;
         $skip = opt('webv6-skip', $h);
-        if (exists $builtinweb{$url}) {
-            warning("googledomains is deprecated! See https://github.com/ddclient/ddclient/issues/622 for more info.") if ($url eq 'googledomains');
-            warning("'he' is deprecated; use 'he.net' instead.") if ($url eq 'he');
-            $skip //= $builtinweb{$url}->{'skip'};
-            $url = $builtinweb{$url}->{'url'};
+        if (my $biw = $builtinweb{$url}) {
+            warning("'--webv6=$url' is deprecated!  $biw->{deprecated}") if $biw->{deprecated};
+            $skip //= $biw->{skip};
+            $url = $biw->{url};
             $arg  = $url;
         }
         if ($url) {

--- a/ddclient.in
+++ b/ddclient.in
@@ -195,6 +195,7 @@ our %builtinweb = (
     'freedns' => {'url' => 'https://freedns.afraid.org/dynamic/check.php'},
     'googledomains' => {'url' => 'https://domains.google.com/checkip'}, #  Deprecated! See https://github.com/ddclient/ddclient/issues/622 for more details
     'he' => {'url' => 'https://checkip.dns.he.net/'},
+    'he.net' => {'url' => 'https://checkip.dns.he.net/'},
     'ip4only.me' => {'url' => 'https://ip4only.me/api/'},
     'ip6only.me' => {'url' => 'https://ip6only.me/api/'},
     'ipify-ipv4' => {'url' => 'https://api.ipify.org/'},
@@ -2913,6 +2914,7 @@ sub get_ip {
         $skip = opt('web-skip', $h);
         if (exists $builtinweb{$url}) {
             warning("googledomains is deprecated! See https://github.com/ddclient/ddclient/issues/622 for more info.") if ($url eq 'googledomains');
+            warning("'he' is deprecated; use 'he.net' instead.") if ($url eq 'he');
             $skip //= $builtinweb{$url}->{'skip'};
             $url = $builtinweb{$url}->{'url'};
         }
@@ -3308,6 +3310,7 @@ sub get_ipv4 {
         $skip = opt('webv4-skip', $h);
         if (exists $builtinweb{$url}) {
             warning("googledomains is deprecated! See https://github.com/ddclient/ddclient/issues/622 for more info.") if ($url eq 'googledomains');
+            warning("'he' is deprecated; use 'he.net' instead.") if ($url eq 'he');
             $skip //= $builtinweb{$url}->{'skip'};
             $url = $builtinweb{$url}->{'url'};
             $arg  = $url;
@@ -3425,6 +3428,7 @@ sub get_ipv6 {
         $skip = opt('webv6-skip', $h);
         if (exists $builtinweb{$url}) {
             warning("googledomains is deprecated! See https://github.com/ddclient/ddclient/issues/622 for more info.") if ($url eq 'googledomains');
+            warning("'he' is deprecated; use 'he.net' instead.") if ($url eq 'he');
             $skip //= $builtinweb{$url}->{'skip'};
             $url = $builtinweb{$url}->{'url'};
             $arg  = $url;


### PR DESCRIPTION
Add support for the Hurricane Electric provider.

The implementation is based on the existing dyndns2 protocol with a few differences:
- The IPv4 and IPv6 addresses must be updated in separate calls. This is different from most of the other providers where both IPv4 and IPv6 addresses can be updated in a single call. Thus the existing dyndns2 protocol implementation cannot be reused for dns.he.net.
- Multiple hosts are not supported by the provider.

See: https://dns.he.net/docs.html