### PR TITLE
infomaniak: Fix response status processing

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -126,6 +126,8 @@ repository history](https://github.com/ddclient/ddclient/commits/master).
     [#691](https://github.com/ddclient/ddclient/pull/691)
   * `infomaniak`: Fixed incorrect parsing of server response.
     [#692](https://github.com/ddclient/ddclient/pull/692)
+  * `infomaniak`: Fixed incorrect handling of `nochg` responses.
+    [#723](https://github.com/ddclient/ddclient/pull/723)
   * `regfishde`: Fixed IPv6 support.
     [#691](https://github.com/ddclient/ddclient/pull/691)
   * `easydns`: IPv4 and IPv6 addresses are now updated separately to be

--- a/ddclient.in
+++ b/ddclient.in
@@ -7331,9 +7331,9 @@ sub nic_infomaniak_update {
             # IP changed => good <xxxx::yyyy>
             # No domain name => Validation failed
             my %statuses = (
-                'good'    => (1, sprintf("IP set to %s for %s", $ip, $h)),
-                'nochg'   => (1, sprintf("IP already set to %s for %s", $ip, $h)),
-                'nohost'  => (0, sprintf("Bad domain name %s or bad IP %s", $h, $ip)),
+                'good' => (1, sprintf("IP set to %s for %s", $ip, $h)),
+                'nochg' => (1, sprintf("IP already set to %s for %s", $ip, $h)),
+                'nohost' => (0, sprintf("Bad domain name %s or bad IP %s", $h, $ip)),
                 'badauth' => (0, sprintf("Bad authentication for %s", $h)),
             );
             my $reply = geturl(

--- a/ddclient.in
+++ b/ddclient.in
@@ -7331,10 +7331,10 @@ sub nic_infomaniak_update {
             # IP changed => good <xxxx::yyyy>
             # No domain name => Validation failed
             my %statuses = (
-                'good' => (1, "IP set to $ip for $h"),
-                'nochg' => (1, "IP already set to $ip for $h"),
-                'nohost' => (0, "Bad domain name $h or bad IP $ip"),
-                'badauth' => (0, "Bad authentication for $h"),
+                'good' => [1, "IP set to $ip for $h"],
+                'nochg' => [1, "IP already set to $ip for $h"],
+                'nohost' => [0, "Bad domain name $h or bad IP $ip"],
+                'badauth' => [0, "Bad authentication for $h"],
             );
             my $reply = geturl(
                 proxy => opt('proxy'),
@@ -7346,7 +7346,7 @@ sub nic_infomaniak_update {
             (my $body = $reply) =~ s/^.*?\n\n//s;
             my ($status) = split(/ /, $body, 2);
             my ($ok, $msg) =
-                $statuses{$status} // (0, "Unknown reply from Infomaniak: $body");
+                @{$statuses{$status} // [0, "Unknown reply from Infomaniak: $body"]};
             if (!$ok) {
                 failed($msg);
                 next;

--- a/ddclient.in
+++ b/ddclient.in
@@ -7320,7 +7320,7 @@ sub nic_infomaniak_update {
         for my $v (4, 6) {
             my $ip = delete $config{$h}{"wantipv$v"};
             if (!defined $ip) {
-                debug("ipv%d not wanted, skipping", $v);
+                debug("IPv$v not wanted, skipping");
                 next;
             }
             info("setting IP address to %s for %s", $ip, $h);
@@ -7331,10 +7331,10 @@ sub nic_infomaniak_update {
             # IP changed => good <xxxx::yyyy>
             # No domain name => Validation failed
             my %statuses = (
-                'good' => (1, sprintf("IP set to %s for %s", $ip, $h)),
-                'nochg' => (1, sprintf("IP already set to %s for %s", $ip, $h)),
-                'nohost' => (0, sprintf("Bad domain name %s or bad IP %s", $h, $ip)),
-                'badauth' => (0, sprintf("Bad authentication for %s", $h)),
+                'good' => (1, "IP set to $ip for $h"),
+                'nochg' => (1, "IP already set to $ip for $h"),
+                'nohost' => (0, "Bad domain name $h or bad IP $ip"),
+                'badauth' => (0, "Bad authentication for $h"),
             );
             my $reply = geturl(
                 proxy => opt('proxy'),
@@ -7346,7 +7346,7 @@ sub nic_infomaniak_update {
             (my $body = $reply) =~ s/^.*?\n\n//s;
             my ($status) = split(/ /, $body, 2);
             my ($ok, $msg) =
-                $statuses{$status} // (0, sprintf("Unknown reply from Infomaniak: %s", $body));
+                $statuses{$status} // (0, "Unknown reply from Infomaniak: $body");
             if (!$ok) {
                 failed($msg);
                 next;


### PR DESCRIPTION
Previously, `nochg` responses were treated as failures and the logged message for all responses was incorrect (either `undef` or "Unknown reply from Infomaniak").

Background: Hash values are always scalars, so lists of values can only be stored in hashes in arrayref form.

The following is legal but does not do what one might expect:

```perl
my %h = (
    a => (1, 2),
    b => (3, 4),
);
```

The `=>` operator is just a variant of the comma operator, and lists in list context are flattened, so the above is equivalent to:

```perl
my %h = ('a', 1, 2, 'b', 3, 4);
```

which is equivalent to:

```perl
my %h = (
    a => 1,
    2 => 'b',
    3 => 4,
);
```

which is obviously not what was intended.
