### PR TITLE
Removed 5m min-interval from changeip protocol

### DIFF
--- a/ddclient.in
+++ b/ddclient.in
@@ -723,7 +723,6 @@ our %protocols = (
         'examples'   => \&nic_changeip_examples,
         'variables' => {
             %{$variables{'protocol-common-defaults'}},
-            'min-interval' => setv(T_DELAY, 0, 0, interval('5m'), interval('5m')),
             'server'       => setv(T_FQDNP, 0, 0, 'nic.changeip.com', undef),
         },
     },


### PR DESCRIPTION
Removed the min-interval that was set to 5 minutes in changeip, because in some usecases it is needed to be able to change the IP and change it back quickly. According to my tests, changeip has no problem updating every 30 seconds, which is the default min-interval value in ddclient, and would be applied after this change.