### PR TITLE
Don't write undefined recap values to the cache file

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -127,6 +127,8 @@ repository history](https://github.com/ddclient/ddclient/commits/master).
     [#664](https://github.com/ddclient/ddclient/pull/664)
   * Fixed "Scalar value better written as" Perl warning.
     [#667](https://github.com/ddclient/ddclient/pull/667)
+  * Fixed "Invalid Value for keyword 'wtime' = ''" warning.
+    [#734](https://github.com/ddclient/ddclient/pull/734)
   * Fixed unnecessary repeated updates for some services.
     [#670](https://github.com/ddclient/ddclient/pull/670)
   * Fixed DNSExit provider when configured with a zone and non-identical

--- a/ddclient.in
+++ b/ddclient.in
@@ -1535,11 +1535,16 @@ sub write_recap {
                 $recap{$h}{$v} = opt($v, $h);
             }
         }
+        # Clear out entries with `undef` values to avoid needing to figure out how to represent
+        # `undef` in the cache file and to simplify testing.
+        for my $v (keys(%{$recap{$h}})) {
+            delete($recap{$h}{$v}) if !defined($recap{$h}{$v});
+        }
     }
 
     my $recap = "";
     for my $h (sort keys %recap) {
-        my $opt = join(',', map { "$_=" . ($recap{$h}{$_} // '') } sort keys %{$recap{$h}});
+        my $opt = join(',', map("$_=$recap{$h}{$_}", sort(keys(%{$recap{$h}}))));
 
         $recap .= sprintf "%s%s%s\n", $opt, ($opt ? ' ' : ''), $h;
     }


### PR DESCRIPTION
There might be a semantic difference between `undef` and the empty string, so it is incorrect to write an empty string when the value is `undef`.

fixes #706