### PR TITLE
build: disable automake treating warnings as error

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,7 @@ AC_REQUIRE_AUX_FILE([tap-driver.sh])
 # tap-driver.sh, so build-aux/tap-driver.sh is checked in to keep the
 # above AC_REQUIRE_AUX_FILE line from causing configure to complain
 # about a mising file if the user has Automake 1.11.)
-AM_INIT_AUTOMAKE([1.11 -Wall -Werror foreign subdir-objects parallel-tests])
+AM_INIT_AUTOMAKE([1.11 -Wall foreign subdir-objects parallel-tests])
 AM_SILENT_RULES
 
 AC_PROG_MKDIR_P


### PR DESCRIPTION
dont see any usefulness with automake treating warnings as errors. this is the same patch suggested in https://github.com/chimera-linux/cports/commit/ee4dc57b4316a390760b9bb3f0211917c0baf324

fixes https://github.com/ddclient/ddclient/issues/745