### PR TITLE
Correct NearlyFreeSpeech.NET example

### DIFF
--- a/ddclient.conf.in
+++ b/ddclient.conf.in
@@ -134,9 +134,9 @@ pid=@runstatedir@/ddclient.pid  # record PID in file.
 ## NearlyFreeSpeech.NET (nearlyfreespeech.net)
 ##
 # protocol=nfsn,                        \
+# zone=example.com,                     \
 # login=member-login,                   \
 # password=api-key                      \
-# zone=example.com                      \
 # example.com,subdomain.example.com
 
 ##

--- a/ddclient.conf.in
+++ b/ddclient.conf.in
@@ -133,9 +133,9 @@ pid=@runstatedir@/ddclient.pid  # record PID in file.
 ##
 ## NearlyFreeSpeech.NET (nearlyfreespeech.net)
 ##
-# protocol = nfsn,                      \
+# protocol=nfsn,                        \
 # login=member-login,                   \
-# password=api-key,                     \
+# password=api-key                      \
 # zone=example.com                      \
 # example.com,subdomain.example.com
 


### PR DESCRIPTION
extra spaces in the protocol and a trailing comma caused connection issues if not corrected.