### PR TITLE
Enable arguments on cmdv4 and cmdv6

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,17 @@ repository history](https://github.com/ddclient/ddclient/commits/main).
 
 ## v4.0.0-rc.3 (unreleased work-in-progress)
 
+### Breaking changes
+
+  * The string argument to `--cmdv4` or `--cmdv6` is now executed as-is by the
+    system's shell, matching the behavior of the deprecated `--cmd` option.
+    This makes it possible to pass command-line arguments, which reduces the
+    need for a custom wrapper script.  Beware that the string is also subject to
+    the shell's command substitution, quote handling, variable expansion, field
+    splitting, etc., so you may need to add extra escaping to ensure that any
+    special characters are preserved literally.
+    [#766](https://github.com/ddclient/ddclient/pull/766)
+
 ## 2025-01-07 v4.0.0-rc.2
 
 ### Breaking changes

--- a/Makefile.am
+++ b/Makefile.am
@@ -77,6 +77,7 @@ handwritten_tests = \
 	t/skip.pl \
 	t/ssl-validate.pl \
 	t/update_nics.pl \
+	t/use_cmd.pl \
 	t/use_web.pl \
 	t/variable_defaults.pl \
 	t/write_recap.pl

--- a/ddclient.in
+++ b/ddclient.in
@@ -3343,8 +3343,7 @@ sub get_ipv4 {
         warning("'--cmd-skip' ignored for '--usev4=$p{'usev4'}'")
             if opt('verbose') && defined($p{'cmd-skip'});
         if ($arg) {
-            my $sys_cmd = quotemeta($arg);
-            $reply = qx{$sys_cmd};
+            $reply = qx{$arg};
             $reply = '' if $?;
         }
     } elsif ($p{'usev4'} eq 'webv4') {
@@ -3457,8 +3456,7 @@ sub get_ipv6 {
         warning("'--cmd-skip' ignored for '--usev6=$p{'usev6'}'")
             if opt('verbose') && defined($p{'cmd-skip'});
         if ($arg) {
-            my $sys_cmd = quotemeta($arg);
-            $reply = qx{$sys_cmd};
+            $reply = qx{$arg};
             $reply = '' if $?;
         }
     } elsif ($p{'usev6'} eq 'webv6' || $p{'usev6'} eq 'web') {

--- a/t/use_cmd.pl
+++ b/t/use_cmd.pl
@@ -1,0 +1,41 @@
+use Test::More;
+BEGIN { SKIP: { eval { require Test::Warnings; 1; } or skip($@, 1); } }
+BEGIN { eval { require 'ddclient'; } or BAIL_OUT($@); }
+
+local $ddclient::globals{debug} = 1;
+local $ddclient::globals{verbose} = 1;
+
+my @test_cases;
+for my $ipv ('4', '6') {
+    my $ip = $ipv eq '4' ? '192.0.2.1' : '2001:db8::1';
+    for my $use ('use', "usev$ipv") {
+        my @cmds = ();
+        push(@cmds, 'cmd') if $use eq 'use' || $ipv eq '6';
+        push(@cmds, "cmdv$ipv") if $use ne 'use';
+        for my $cmd (@cmds) {
+            my $cmdarg = "echo '$ip'";
+            push(
+                @test_cases,
+                {
+                    desc => "$use=$cmd $cmd=\"$cmdarg\"",
+                    cfg => {$use => $cmd, $cmd => $cmdarg},
+                    want => $ip,
+                },
+            );
+        }
+    }
+}
+
+for my $tc (@test_cases) {
+    local $ddclient::_l = ddclient::pushlogctx($tc->{desc});
+    my $h = 'test-host';
+    local $ddclient::config{$h} = $tc->{cfg};
+    is(ddclient::get_ip(ddclient::strategy_inputs('use', $h)), $tc->{want}, $tc->{desc})
+        if $tc->{cfg}{use};
+    is(ddclient::get_ipv4(ddclient::strategy_inputs('usev4', $h)), $tc->{want}, $tc->{desc})
+        if $tc->{cfg}{usev4};
+    is(ddclient::get_ipv6(ddclient::strategy_inputs('usev6', $h)), $tc->{want}, $tc->{desc})
+        if $tc->{cfg}{usev6};
+}
+
+done_testing();


### PR DESCRIPTION
Do not call `quotemeta` on `cmdv4` and `cmdv6` arguments as it prevents executing commands with arguments.  eg. it is now possible to get an IP address with:

```
usev4=cmdv4
cmdv4="dig +short myip.opendns.com @resolver1.opendns.com"
```

Fixes #736 