### PR TITLE
systemd: Add systemd service settings for better security

### DIFF
--- a/sample-etc_systemd.service
+++ b/sample-etc_systemd.service
@@ -9,5 +9,31 @@ Environment=daemon_interval=5m
 ExecStart=/usr/bin/ddclient --daemon ${daemon_interval} --foreground
 Restart=on-failure
 
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~ @privileged @resources
+
+CapabilityBoundingSet=
+NoNewPrivileges=yes
+
+ProtectControlGroups=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectProc=invisible
+ProtectClock=yes
+ProtectHostname=yes
+
+ProtectSystem=yes
+ProtectHome=yes
+PrivateTmp=yes
+PrivateDevices=yes
+MemoryDenyWriteExecute=true
+
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+RestrictNamespaces=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This adds additional settings to improve the security of 'ddclient.service'. 

The settings are based on basic [systemd guidelines][1] and other security-related [guide][2] and [roadmap][3].

[1]: https://www.freedesktop.org/software/systemd/man/systemd.exec.html
[2]: https://www.redhat.com/sysadmin/systemd-secure-services
[3]: https://wiki.debian.org/ReleaseGoals/SystemdAnalyzeSecurity