### PR TITLE
Make 'cmd-skip' warning message consistent for IPv4 and IPv6

### DIFF
--- a/ddclient.in
+++ b/ddclient.in
@@ -3454,7 +3454,7 @@ sub get_ipv6 {
         $ipv6 = get_ip_from_interface($arg, 6);
     }  elsif ($p{'usev6'} eq 'cmdv6' || $p{'usev6'} eq 'cmd') {
         ## Obtain IPv6 address by executing the command in "cmdv6=<command>"
-        warning("'--cmd-skip' ignored") if opt('verbose') && p{'cmd-skip'};
+        warning("'--cmd-skip' ignored") if opt('verbose') && $p{'cmd-skip'};
         if ($arg) {
             my $sys_cmd = quotemeta($arg);
             $reply = qx{$sys_cmd};

--- a/ddclient.in
+++ b/ddclient.in
@@ -3341,7 +3341,7 @@ sub get_ipv4 {
     } elsif ($p{'usev4'} eq 'cmdv4') {
         ## Obtain IPv4 address by executing the command in "cmdv4=<command>"
         warning("'--cmd-skip' ignored for '--usev4=$p{'usev4'}'")
-            if (opt('verbose') && $p{'cmd-skip'});
+            if opt('verbose') && defined($p{'cmd-skip'});
         if ($arg) {
             my $sys_cmd = quotemeta($arg);
             $reply = qx{$sys_cmd};
@@ -3454,7 +3454,8 @@ sub get_ipv6 {
         $ipv6 = get_ip_from_interface($arg, 6);
     }  elsif ($p{'usev6'} eq 'cmdv6' || $p{'usev6'} eq 'cmd') {
         ## Obtain IPv6 address by executing the command in "cmdv6=<command>"
-        warning("'--cmd-skip' ignored") if opt('verbose') && $p{'cmd-skip'};
+        warning("'--cmd-skip' ignored for '--usev6=$p{'usev6'}'")
+            if opt('verbose') && defined($p{'cmd-skip'});
         if ($arg) {
             my $sys_cmd = quotemeta($arg);
             $reply = qx{$sys_cmd};


### PR DESCRIPTION
Making warning messages for ignoring 'cmd-skip' consistent for IPv4 and IPv6 flows.

Also, cherry-pick a commit for #763 (for the committer's attribution).