### PR TITLE
Don't silence curl errors/warnings, only the progress bar

### DIFF
--- a/ddclient.in
+++ b/ddclient.in
@@ -2889,7 +2889,7 @@ sub geturl {
     if (!opt('exec')) {
         info("would request: ${protocol}://${server}/${url}");
     } else {
-        push(@curlopt, "silent");
+        push(@curlopt, "no-progress-meter");
         push(@curlopt, "include"); ## Include HTTP response for compatibility
         push(@curlopt, "insecure") if ($use_ssl && !($params{ssl_validate} // 1));
         push(@curlopt, "cacert=\"".escape_curl_param(opt('ssl_ca_file')).'"') if defined(opt('ssl_ca_file'));


### PR DESCRIPTION
I don't know when this option was added to curl, so I think it's safer to wait until after v4.0.0 is released to merge this.  It's low importance anyway.