### PR TITLE
tests: Delete vestigial code

### DIFF
--- a/t/protocol_dyndns2.pl
+++ b/t/protocol_dyndns2.pl
@@ -1,7 +1,6 @@
 use Test::More;
 BEGIN { SKIP: { eval { require Test::Warnings; 1; } or skip($@, 1); } }
 use MIME::Base64;
-use Scalar::Util qw(blessed);
 BEGIN { eval { require 'ddclient'; } or BAIL_OUT($@); }
 BEGIN {
     eval { require ddclient::t::HTTPD; 1; } or plan(skip_all => $@);

--- a/t/use_web.pl
+++ b/t/use_web.pl
@@ -1,6 +1,5 @@
 use Test::More;
 BEGIN { SKIP: { eval { require Test::Warnings; 1; } or skip($@, 1); } }
-use Scalar::Util qw(blessed);
 BEGIN { eval { require 'ddclient'; } or BAIL_OUT($@); }
 BEGIN {
     eval { require ddclient::t::HTTPD; 1; } or plan(skip_all => $@);
@@ -70,16 +69,6 @@ for my $ipv ('4', '6') {
 }
 
 for my $tc (@test_cases) {
-    my $subst = sub {
-        return map({
-            my $class = blessed($_);
-            (defined($class) && $class->isa('EndpointPlaceholder')) ? do {
-                my $uri = ${$_}->clone();
-                $uri->query_param(tc => $tc->{desc});
-                $uri;
-            } : $_;
-        } @_);
-    };
     local $ddclient::builtinweb{$builtinweb} = $tc->{biw};
     $ddclient::builtinweb if 0;
     local $ddclient::config{$h} = $tc->{cfg};


### PR DESCRIPTION
This deleted code came from a previous unpublished prior draft of the tests and was accidentally not deleted when the approach changed.