### PR TITLE
Update ddclient.in to determine perl path using env call

### DIFF
--- a/ddclient.in
+++ b/ddclient.in
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 ######################################################################
 #
 # DDCLIENT - a Perl client for updating DynDNS information


### PR DESCRIPTION
Using env to determine perl path as it is not usually in /usr/bin for all systems. For FreeBSD for example it is under /usr/bin/local