### PR TITLE
Zero index sh args in t/geturl_respones.pl

### DIFF
--- a/t/geturl_response.pl
+++ b/t/geturl_response.pl
@@ -5,7 +5,10 @@ eval { require 'ddclient'; } or BAIL_OUT($@);
 # Fake curl.  Use the printf utility, which can process escapes.  This allows Perl to drive the fake
 # curl with plain ASCII and get arbitrary bytes back, avoiding problems caused by any encoding that
 # might be done by Perl (e.g., "use open ':encoding(UTF-8)';").
-my @fakecurl = ('sh', '-c', 'printf %b "$1"', '--');
+#
+# Use $0 rather than $1 to avoid relying on -- being treated as argv[0],
+# which some sh variants do not handle correctly.
+my @fakecurl = ('sh', '-c', 'printf %b "$0"');
 
 my @test_cases = (
     {


### PR DESCRIPTION
This test currently breaks for me because the version of `sh` I use (a fork of FreeBSD's `sh`) does not treat `--` as an argument (rather than treating it as $0). Removing the `--` and using `$0` seems to be more portable. In addition to my default `sh` I have tried this with bash, dash, and zsh which all seem to work. 