### PR TITLE
Correct and enhance duckdns.org example

### DIFF
--- a/ddclient.conf.in
+++ b/ddclient.conf.in
@@ -217,7 +217,7 @@ pid=@runstatedir@/ddclient.pid  # record PID in file.
 #
 # protocol=duckdns, \
 # password=my-auto-generated-password \
-# hostwithoutduckdnsorg
+# hostwithoutduckdnsorg,host2withoutduckdnsorg
 
 ##
 ## Freemyip (http://freemyip.com/)

--- a/ddclient.in
+++ b/ddclient.in
@@ -6457,16 +6457,21 @@ dynamic DNS service offered by www.duckdns.org.
 Check https://www.duckdns.org/install.jsp?tab=linux-cron for API
 
 Configuration variables applicable to the 'duckdns' protocol are:
-  protocol=duckdns               ##
+  protocol=duckdns             ##
   server=www.fqdn.of.service   ## defaults to www.duckdns.org
   password=service-password    ## password (token) registered with the service
-  non-fully.qualified.host         ## the host registered with the service.
+  non-fully.qualified.host     ## the host registered with the service.
 
 Example ${program}.conf file entries:
   ## single host update
   protocol=duckdns,        \\
-  password=your_password,  \\
+  password=your_password   \\
   myhost
+
+  ## multiple host update
+  protocol=duckdns,        \\
+  password=your_password   \\
+  myhost,myhost2
 
 EoEXAMPLE
 }


### PR DESCRIPTION
* The trailing comma (after password) caused connection issues
* Updated the examples with multiple hosts