### PR TITLE
doc(cfg): cf API token only needs 'Zone - DNS - Edit' perm

### DIFF
--- a/ddclient.in
+++ b/ddclient.in
@@ -5860,7 +5860,7 @@ Configuration variables applicable to the 'cloudflare' protocol are:
   protocol=cloudflare          ##
   server=fqdn.of.service       ## defaults to api.cloudflare.com/client/v4
   login=service-login          ## login email when using a global API key
-  password=service-password    ## Global API key, or an API token. If using an API token, it must have the permissions "Zone - DNS - Edit" and "Zone - Zone - Read". The Zone resources must be "Include - All zones".
+  password=service-password    ## Global API key, or an API token. If using an API token, it must have the permissions "Zone - DNS - Edit".
   fully.qualified.host         ## the host registered with the service.
 
 Example ${program}.conf file entries:


### PR DESCRIPTION
For cloudflare, when using API token,

as I test, only such one perm is added and the update succeeds.

Also, the Zone resources doesn't have to be "Include - All zones";
I just use "Include - Specific zone - ..."

