### PR TITLE
docs: Fixed build options to match the official documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ operating system. See the image to the right for a list of distributions with a 
      ```shell
      ./configure \
          --prefix=/usr \
-         --sysconfdir=/etc \
+         --sysconfdir=/etc/ddclient \
          --localstatedir=/var
      make
      make VERBOSE=1 check


### PR DESCRIPTION
I have fixed a discrepancy in the reference path for `ddclient.conf` between the **official documentation** and the README.md build default.

Specifically:

- The **README.md** / build-time default expects the config at `/etc/ddclient.conf`.
- The **official documentation** (https://ddclient.net/#configuration) describes the default config file as `/etc/ddclient/ddclient.conf`.

I have submitted a patch to align these and ensure consistency across both usages.

**Related Issue:**

- [#756](https://github.com/ddclient/ddclient/issues/756): Where is the config file on debian 12
- [#788](https://github.com/ddclient/ddclient/issues/788): Look for ddclient.conf in ddclient subdirectory by default

