### PR TITLE
Fix %recap tag for ip.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,11 @@ repository history](https://github.com/ddclient/ddclient/commits/main).
 
 ## v4.0.1-alpha (unreleased work-in-progress)
 
+### Bug fixes
+
+  * `gandi`: Fix %recap tag for ip
+    [#841](https://github.com/ddclient/ddclient/pull/841)
+
 ## 2025-01-19 v4.0.0
 
 ### Breaking changes

--- a/ddclient.in
+++ b/ddclient.in
@@ -7201,7 +7201,7 @@ sub nic_gandi_update {
             }
             if ($response->{'rrset_values'}->[0] eq $ip && (!defined(opt('ttl', $h)) ||
                 $response->{'rrset_ttl'} eq opt('ttl', $h))) {
-                $recap{$h}{'ip'} = $ip;
+                $recap{$h}{$ipv} = $ip;
                 $recap{$h}{'mtime'} = $now;
                 $recap{$h}{"status-$ipv"} = "good";
                 success("skipped: address was already set to $ip");


### PR DESCRIPTION
gandi incorrectly writes 'ip' key to %recap, which later yields:

> WARNING: [file /var/cache/ddclient/ddclient.cache, line 3][@][ip]> ignoring unrecognized recap variable for host '@' with protocol 'gandi': ip