### PR TITLE
Update Cloudflare configuration example with API token details

### DIFF
--- a/ddclient.conf.in
+++ b/ddclient.conf.in
@@ -178,22 +178,19 @@ pid=@runstatedir@/ddclient.pid  # record PID in file.
 ## CloudFlare (www.cloudflare.com)
 ##
 ## API Token authentication (recommended)
-# use=web, web=https://1.1.1.1/cdn-cgi/trace, web-skip='ip='
 # protocol=cloudflare,                  \
-# zone=domain.tld,                      \
-# ttl=1,                                \
-# login=token,                          \ # Use 'token' for API token auth
+# zone=domain.tld,                      \ # Cloudflare DNS zone
+# ttl=300,                              \ # Optional
 # password='your-api-token',            \ # API token with Zone:DNS:Edit and Zone:Zone:Read permissions
-# zone-id=your-zone-id                  \ # Optional zone ID from dashboard
-# domain.tld
+# domain.tld,sub.domain.tld
 #
-## Global API Key authentication
+## Global API Key authentication (legacy)
 # protocol=cloudflare,                  \
-# zone=domain.tld,                      \
-# ttl=1,                                \
-# login=your-login-email,               \
+# zone=domain.tld,                      \ # Cloudflare DNS zone
+# ttl=300,                              \ # Optional
+# login=your-login-email,               \ # Cloudflare DNS zone
 # password=your-global-key              \
-# domain.tld
+# domain.tld,sub.domain.tld
 
 ##
 ## Gandi (gandi.net)

--- a/ddclient.conf.in
+++ b/ddclient.conf.in
@@ -177,12 +177,23 @@ pid=@runstatedir@/ddclient.pid  # record PID in file.
 ##
 ## CloudFlare (www.cloudflare.com)
 ##
-# protocol=cloudflare,        \
-# zone=domain.tld,            \
-# ttl=1,                      \
-# login=your-login-email,     \ # Only needed if you are using your global API key. If you are using an API token, set it to "token" (without double quotes).
-# password=APIKey             \ # This is either your global API key, or an API token. If you are using an API token, it must have the permissions "Zone - DNS - Edit" and "Zone - Zone - Read". The Zone resources must be "Include - All zones".
-# domain.tld,my.domain.tld
+## API Token authentication (recommended)
+# use=web, web=https://1.1.1.1/cdn-cgi/trace, web-skip='ip='
+# protocol=cloudflare,                  \
+# zone=domain.tld,                      \
+# ttl=1,                                \
+# login=token,                          \ # Use 'token' for API token auth
+# password='your-api-token',            \ # API token with Zone:DNS:Edit and Zone:Zone:Read permissions
+# zone-id=your-zone-id                  \ # Optional zone ID from dashboard
+# domain.tld
+#
+## Global API Key authentication
+# protocol=cloudflare,                  \
+# zone=domain.tld,                      \
+# ttl=1,                                \
+# login=your-login-email,               \
+# password=your-global-key              \
+# domain.tld
 
 ##
 ## Gandi (gandi.net)

--- a/ddclient.conf.in
+++ b/ddclient.conf.in
@@ -176,12 +176,23 @@ pid=@runstatedir@/ddclient.pid  # record PID in file.
 ##
 ## CloudFlare (www.cloudflare.com)
 ##
-# protocol=cloudflare,        \
-# zone=domain.tld,            \
-# ttl=1,                      \
-# login=your-login-email,     \ # Only needed if you are using your global API key. If you are using an API token, set it to "token" (without double quotes).
-# password=APIKey             \ # This is either your global API key, or an API token. If you are using an API token, it must have the permissions "Zone - DNS - Edit" and "Zone - Zone - Read". The Zone resources must be "Include - All zones".
-# domain.tld,my.domain.tld
+## API Token authentication (recommended)
+# use=web, web=https://1.1.1.1/cdn-cgi/trace, web-skip='ip='
+# protocol=cloudflare,                  \
+# zone=domain.tld,                      \
+# ttl=1,                                \
+# login=token,                          \ # Use 'token' for API token auth
+# password='your-api-token',            \ # API token with Zone:DNS:Edit and Zone:Zone:Read permissions
+# zone-id=your-zone-id                  \ # Optional zone ID from dashboard
+# domain.tld
+#
+## Global API Key authentication
+# protocol=cloudflare,                  \
+# zone=domain.tld,                      \
+# ttl=1,                                \
+# login=your-login-email,               \
+# password=your-global-key              \
+# domain.tld
 
 ##
 ## Gandi (gandi.net)

--- a/ddclient.in
+++ b/ddclient.in
@@ -5885,11 +5885,22 @@ o 'cloudflare'
 
 The 'cloudflare' protocol is used by DNS service offered by www.cloudflare.com.
 
-Configuration variables applicable to the 'cloudflare' protocol are:
+The protocol can be configured in two ways, either using API Token authentication
+(recommended) or using Global API Key authentication (legacy). Depending on the
+chosen authentication method, the configuration variables applicable to the
+'cloudflare' protocol are:
+
+  API Token authentication (recommended):
   protocol=cloudflare          ##
   server=fqdn.of.service       ## defaults to api.cloudflare.com/client/v4
-  login=service-login          ## login email when using a global API key
-  password=service-password    ## Global API key, or an API token. If using an API token, it must have the permissions "Zone - DNS - Edit" and "Zone - Zone - Read". The Zone resources must be "Include - All zones".
+  password=your-api-token      ## API token with Zone:DNS:Edit and Zone:Zone:Read permissions for the zone
+  fully.qualified.host         ## the host registered with the service.
+
+  Global API Key authentication (legacy)
+  protocol=cloudflare          ##
+  server=fqdn.of.service       ## defaults to api.cloudflare.com/client/v4
+  login=service-login          ## Cloudflare login email
+  password=your-global-key     ## Global API key
   fully.qualified.host         ## the host registered with the service.
 
 Example ${program}.conf file entries:


### PR DESCRIPTION
Add detailed API token configuration example and document required formatting.
Include Cloudflare's IP detection service and zone-id parameter.
Maintain consistent style with other provider examples.

The changes help users avoid common configuration issues, particularly
the requirement for single quotes around API tokens which can cause
authentication failures.