### PR TITLE
Add IONOS Zones support for A- and AAAA-records

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -180,6 +180,8 @@ repository history](https://github.com/ddclient/ddclient/commits/main).
     option.  [#752](https://github.com/ddclient/ddclient/pull/752)
   * `dnsexit2`: Multiple hosts are updated in a single API call when possible.
     [#684](https://github.com/ddclient/ddclient/pull/684)
+  * `ionos`: Add IONOS Zones support for A- and AAAA-records.
+    [#863](https://github.com/ddclient/ddclient/pull/863)
 
 ### Bug fixes
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -76,6 +76,7 @@ handwritten_tests = \
 	t/protocol_dnsexit2.pl \
 	t/protocol_dyndns2.pl \
 	t/protocol_hetzner.pl \
+	t/protocol_ionos.pl \
 	t/protocol_ns1.pl \
 	t/protocol_simplycom.pl \
 	t/protocol_spaceship.pl \

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Dynamic DNS services currently supported include:
   * [Hurricane Electric](https://dns.he.net)
   * [Infomaniak](https://faq.infomaniak.com/2376)
   * [INWX](https://www.inwx.com/)
+  * [IONOS](https://ionos.com)
   * [Loopia](https://www.loopia.se)
   * [Mythic Beasts](https://www.mythic-beasts.com/support/api/dnsv2/dynamic-dns)
   * [NameCheap](https://www.namecheap.com)

--- a/ddclient.conf.in
+++ b/ddclient.conf.in
@@ -439,6 +439,13 @@ pid=@runstatedir@/ddclient.pid  # record PID in file.
 # myhost.example.org
 
 ##
+## IONOS (https://ionos.com)
+##
+# protocol=ionos,               \
+# password=prefix.secret,       \
+# myhost.example.com
+
+##
 ## Hetzner
 ##
 # protocol=hetzner                          \

--- a/ddclient.in
+++ b/ddclient.in
@@ -1364,6 +1364,16 @@ our %protocols = (
             'max-interval' => setv(T_DELAY, 0, 'inf', 0),
         },
     ),
+    'ionos' => ddclient::Protocol->new(
+        'update'   => \&nic_ionos_update,
+        'examples' => \&nic_ionos_examples,
+        'cfgvars'  => {
+            %{$cfgvars{'protocol-common-defaults'}},
+            'login'  => undef,
+            'server' => setv(T_FQDNP,  0, 'api.hosting.ionos.com', undef),
+            'ttl'    => setv(T_NUMBER, 0, 300,                      300),
+        },
+    ),
 );
 $cfgvars{'merged'} = {
     map({ %{$protocols{$_}{'cfgvars'}} } keys(%protocols)),
@@ -2186,7 +2196,7 @@ sub init_config {
     load_sha1_support(join(', ', @needs_sha1)) if @needs_sha1;
     my @needs_json = grep({ my $p = $_; grep($_ eq $p, @protos); }
                           qw(1984 cloudflare digitalocean directnic dnsexit2 gandi godaddy hetzner
-                             nfsn njalla ns1 porkbun spaceship yandex));
+                             ionos nfsn njalla ns1 porkbun spaceship yandex));
     load_json_support(join(', ', @needs_json)) if @needs_json;
 }
 
@@ -8281,6 +8291,137 @@ Example ${program}.conf file entries:
   host.example.com
 EoEXAMPLE
 }
+
+######################################################################
+## nic_ionos_update
+######################################################################
+sub nic_ionos_update {
+    my $self = shift;
+    for my $h (@_) {
+        local $_l = pushlogctx($h);
+        my $ipv4 = delete $config{$h}{'wantipv4'};
+        my $ipv6 = delete $config{$h}{'wantipv6'};
+        next unless $ipv4 || $ipv6;
+
+        my $headers =
+            "Content-Type: application/json\n" .
+            "accept: application/json\n" .
+            "X-API-Key: " . opt('password', $h) . "\n";
+
+        ## Step 1: Get zone list and find the zone for this host.
+        my $reply = geturl(
+            proxy   => opt('proxy'),
+            url     => opt('server', $h) . "/dns/v1/zones",
+            headers => $headers,
+        );
+        next unless header_ok($reply);
+        (my $body = $reply) =~ s/^.*?\n\n//s;
+        my $zones = eval { decode_json($body) };
+        if ($@ || ref($zones) ne 'ARRAY') {
+            failed("failed to parse IONOS zone list");
+            next;
+        }
+        my ($zone) = grep { $h =~ /(?:^|\.)\Q$_->{name}\E$/ } @$zones;
+        unless ($zone) {
+            failed("no IONOS zone found for $h");
+            next;
+        }
+        my $zone_id = $zone->{id};
+
+        ## Step 2: Get existing records for this host.
+        $reply = geturl(
+            proxy   => opt('proxy'),
+            url     => opt('server', $h)
+                     . "/dns/v1/zones/$zone_id?suffix=$h&recordType=A%2CAAAA",
+            headers => $headers,
+        );
+        next unless header_ok($reply);
+        ($body = $reply) =~ s/^.*?\n\n//s;
+        my $zone_data = eval { decode_json($body) };
+        if ($@ || ref($zone_data) ne 'HASH') {
+            failed("failed to parse IONOS zone records");
+            next;
+        }
+        my $records = $zone_data->{records} // [];
+
+        ## Step 3: Update A and AAAA records.
+        for my $ip ($ipv4, $ipv6) {
+            next unless defined($ip);
+            my $ipv  = ($ip eq ($ipv6 // '')) ? '6' : '4';
+            my $type = $ipv eq '6' ? 'AAAA' : 'A';
+            $recap{$h}{"status-ipv$ipv"} = 'failed';
+
+            my ($rec) = grep {
+                $_->{type} eq $type &&
+                (lc($_->{name}) eq lc($h) || lc($_->{name}) eq lc("$h."))
+            } @$records;
+            my $ttl = opt('ttl', $h) // 300;
+
+            my ($method, $url, $data);
+            if ($rec) {
+                $method = 'PUT';
+                $url    = opt('server', $h) . "/dns/v1/zones/$zone_id/records/$rec->{id}";
+                $data   = encode_json({
+                    content  => $ip,
+                    ttl      => $ttl,
+                    prio     => 0,
+                    disabled => \0,
+                });
+            } else {
+                $method = 'POST';
+                $url    = opt('server', $h) . "/dns/v1/zones/$zone_id/records";
+                $data   = encode_json([{
+                    name     => $h,
+                    type     => $type,
+                    content  => $ip,
+                    ttl      => $ttl,
+                    prio     => 0,
+                    disabled => \0,
+                }]);
+            }
+
+            $reply = geturl(
+                method  => $method,
+                proxy   => opt('proxy'),
+                url     => $url,
+                headers => $headers,
+                data    => $data,
+            );
+            next unless header_ok($reply);
+
+            success("IPv$ipv address set to $ip");
+            $recap{$h}{"ipv$ipv"} = $ip;
+            $recap{$h}{'mtime'}   = $now;
+            $recap{$h}{"status-ipv$ipv"} = 'good';
+        }
+    }
+}
+
+######################################################################
+## nic_ionos_examples
+######################################################################
+sub nic_ionos_examples {
+    my $self = shift;
+    return <<"EoEXAMPLE";
+o 'ionos'
+
+The 'ionos' protocol updates DNS records via the IONOS DNS REST API
+<https://developer.hosting.ionos.com/docs/dns>.
+
+Configuration variables applicable to the 'ionos' protocol are:
+  protocol=ionos             ##
+  password=prefix.secret     ## IONOS DNS API key (prefix.secret format)
+  server=fqdn.of.service     ## can be omitted, defaults to api.hosting.ionos.com
+  ttl=300                    ## record TTL in seconds (optional, default 300)
+  host.example.com           ## the host to update
+
+Example ${program}.conf file entries:
+  protocol=ionos,             \\
+  password=my-api-key-prefix.my-api-key-secret \\
+  host.example.com
+EoEXAMPLE
+}
+
 
 # Execute main() if this file is run as a script or run via PAR (https://metacpan.org/pod/PAR),
 # otherwise do nothing. This "modulino" pattern makes it possible to import this file as a module

--- a/t/protocol_ionos.pl
+++ b/t/protocol_ionos.pl
@@ -1,0 +1,245 @@
+use Test::More;
+BEGIN { SKIP: { eval { require Test::Warnings; 1; } or skip($@, 1); } }
+BEGIN { eval { require JSON::PP; 1; } or plan(skip_all => $@); JSON::PP->import(); }
+BEGIN { eval { require 'ddclient'; } or BAIL_OUT($@); }
+use ddclient::t::HTTPD;
+use ddclient::t::Logger;
+
+httpd_required();
+
+local $ddclient::globals{debug}   = 1;
+local $ddclient::globals{verbose} = 1;
+
+ddclient::load_json_support('ionos');
+
+# Use scripted responses: httpd()->reset(r1, r2, ...) loads the response script
+# for the next test, and returns logged requests from the previous test.
+httpd()->run(sub { return undef; });  # let all requests fall through to scripted responses
+
+my $a_rec   = {id => 'rec-a',    name => 'host.example.com', type => 'A',
+               content => '203.0.113.1', ttl => 300, prio => 0, disabled => \0};
+my $aaaa_rec = {id => 'rec-aaaa', name => 'host.example.com', type => 'AAAA',
+                content => '2001:db8::1', ttl => 300, prio => 0, disabled => \0};
+
+sub zones_ok  { [200, ['Content-Type', 'application/json'],
+                 [encode_json([{id => 'zone-1', name => 'example.com', type => 'NATIVE'}])]] }
+sub zones_err { [500, ['Content-Type', 'text/plain'], ['server error']] }
+sub records_ok {
+    my (@recs) = @_;
+    [200, ['Content-Type', 'application/json'],
+     [encode_json({id => 'zone-1', name => 'example.com', records => \@recs})]];
+}
+sub records_err { [500, ['Content-Type', 'text/plain'], ['server error']] }
+sub update_ok   { [200, ['Content-Type', 'application/json'], [encode_json({id => 'rec-a'})]] }
+sub update_err  { [500, ['Content-Type', 'text/plain'], ['server error']] }
+
+my $hostname = httpd()->endpoint();
+
+my @test_cases = (
+    {
+        desc => 'IPv4 update, record exists (PUT)',
+        responses => [zones_ok(), records_ok($a_rec), update_ok()],
+        cfg => {'host.example.com' => {wantipv4 => '192.0.2.1'}},
+        wantrecap => {
+            'host.example.com' => {
+                'status-ipv4' => 'good', 'ipv4' => '192.0.2.1', 'mtime' => $ddclient::now,
+            },
+        },
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv4.*192\.0\.2\.1/},
+        ],
+        wantreqs => sub {
+            my (@reqs) = @_;
+            is(scalar(@reqs), 3, 'three requests: zone list, records, PUT');
+            return if @reqs < 3;
+            is($reqs[0]->method(), 'GET',  'first request is GET (zones)');
+            is($reqs[1]->method(), 'GET',  'second request is GET (records)');
+            is($reqs[2]->method(), 'PUT',  'third request is PUT (update)');
+            like($reqs[2]->uri()->path(), qr{/dns/v1/zones/zone-1/records/rec-a},
+                 'PUT targets correct record ID');
+            my $body = eval { decode_json($reqs[2]->content()) };
+            is(ref($body), 'HASH',      'PUT body is a JSON object');
+            is($body->{content}, '192.0.2.1', 'PUT body has correct IP');
+            ok(!defined($body->{name}), 'PUT body has no name field');
+            ok(!defined($body->{type}), 'PUT body has no type field');
+        },
+    },
+    {
+        desc => 'IPv6 update, record exists (PUT)',
+        responses => [zones_ok(), records_ok($aaaa_rec), update_ok()],
+        cfg => {'host.example.com' => {wantipv6 => '2001:db8::2'}},
+        wantrecap => {
+            'host.example.com' => {
+                'status-ipv6' => 'good', 'ipv6' => '2001:db8::2', 'mtime' => $ddclient::now,
+            },
+        },
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv6.*2001:db8::2/},
+        ],
+        wantreqs => sub {
+            my (@reqs) = @_;
+            is(scalar(@reqs), 3, 'three requests');
+            return if @reqs < 3;
+            is($reqs[2]->method(), 'PUT', 'third request is PUT');
+            like($reqs[2]->uri()->path(), qr{/records/rec-aaaa}, 'PUT targets AAAA record');
+            my $body = eval { decode_json($reqs[2]->content()) };
+            is($body->{content}, '2001:db8::2', 'PUT body has correct IPv6');
+        },
+    },
+    {
+        desc => 'IPv4 update, no existing record (POST)',
+        responses => [zones_ok(), records_ok(), update_ok()],
+        cfg => {'host.example.com' => {wantipv4 => '192.0.2.1'}},
+        wantrecap => {
+            'host.example.com' => {
+                'status-ipv4' => 'good', 'ipv4' => '192.0.2.1', 'mtime' => $ddclient::now,
+            },
+        },
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv4.*192\.0\.2\.1/},
+        ],
+        wantreqs => sub {
+            my (@reqs) = @_;
+            is(scalar(@reqs), 3, 'three requests');
+            return if @reqs < 3;
+            is($reqs[2]->method(), 'POST', 'third request is POST (create)');
+            like($reqs[2]->uri()->path(), qr{/dns/v1/zones/zone-1/records$},
+                 'POST targets zone records endpoint');
+            my $body = eval { decode_json($reqs[2]->content()) };
+            is(ref($body), 'ARRAY', 'POST body is a JSON array');
+            return unless ref($body) eq 'ARRAY' && @$body;
+            is($body->[0]{name},    'host.example.com', 'POST body has correct name');
+            is($body->[0]{type},    'A',                'POST body has type A');
+            is($body->[0]{content}, '192.0.2.1',        'POST body has correct IP');
+        },
+    },
+    {
+        desc => 'both IPv4 and IPv6 updated (dual-stack)',
+        responses => [zones_ok(), records_ok($a_rec, $aaaa_rec), update_ok(), update_ok()],
+        cfg => {'host.example.com' => {wantipv4 => '192.0.2.1', wantipv6 => '2001:db8::2'}},
+        wantrecap => {
+            'host.example.com' => {
+                'status-ipv4' => 'good', 'ipv4' => '192.0.2.1',
+                'status-ipv6' => 'good', 'ipv6' => '2001:db8::2',
+                'mtime' => $ddclient::now,
+            },
+        },
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv4/},
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv6/},
+        ],
+        wantreqs => sub {
+            my (@reqs) = @_;
+            is(scalar(@reqs), 4, 'four requests: zone list, records, PUT x2');
+        },
+    },
+    {
+        desc => 'zone not found',
+        responses => [[200, ['Content-Type', 'application/json'], [encode_json([])]]],
+        cfg => {'host.example.com' => {wantipv4 => '192.0.2.1'}},
+        wantrecap => {},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['host.example.com'], msg => qr/no IONOS zone found/},
+        ],
+        wantreqs => sub {
+            my (@reqs) = @_;
+            is(scalar(@reqs), 1, 'only one request (zone list)');
+        },
+    },
+    {
+        desc => 'zone list API error',
+        responses => [zones_err()],
+        cfg => {'host.example.com' => {wantipv4 => '192.0.2.1'}},
+        wantrecap => {},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['host.example.com'], msg => qr/500/},
+        ],
+        wantreqs => sub {
+            my (@reqs) = @_;
+            is(scalar(@reqs), 1, 'only one request (zone list)');
+        },
+    },
+    {
+        desc => 'records API error',
+        responses => [zones_ok(), records_err()],
+        cfg => {'host.example.com' => {wantipv4 => '192.0.2.1'}},
+        wantrecap => {},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['host.example.com'], msg => qr/500/},
+        ],
+        wantreqs => sub {
+            my (@reqs) = @_;
+            is(scalar(@reqs), 2, 'two requests: zone list, records');
+        },
+    },
+    {
+        desc => 'update API error sets status-ipv4 to failed',
+        responses => [zones_ok(), records_ok(), update_err()],
+        cfg => {'host.example.com' => {wantipv4 => '192.0.2.1'}},
+        wantrecap => {
+            'host.example.com' => {'status-ipv4' => 'failed'},
+        },
+        wantlogs => [
+            {label => 'FAILED', ctx => ['host.example.com'], msg => qr/500/},
+        ],
+        wantreqs => sub {
+            my (@reqs) = @_;
+            is(scalar(@reqs), 3, 'three requests: zone list, records, POST');
+        },
+    },
+);
+
+httpd()->reset();  # clear initial state
+
+for my $tc (@test_cases) {
+    diag('==============================================================================');
+    diag("Starting test: $tc->{desc}");
+    diag('==============================================================================');
+    subtest($tc->{desc} => sub {
+        # Load responses for this test; discard any stale requests from the last reset.
+        httpd()->reset(@{$tc->{responses}});
+        my @hosts = keys(%{$tc->{cfg}});
+        my $l = ddclient::t::Logger->new($ddclient::_l, qr/^(?:WARNING|FATAL|SUCCESS|FAILED)$/);
+        local %ddclient::config = ();
+        for my $h (@hosts) {
+            $ddclient::config{$h} = {
+                password => 'test-prefix.test-secret',
+                server   => $hostname,
+                ssl      => 0,
+                %{$tc->{cfg}{$h}},
+            };
+        }
+        local %ddclient::recap;
+        {
+            local $ddclient::_l = $l;
+            ddclient::nic_ionos_update(undef, sort(@hosts));
+        }
+        my @reqs = httpd()->reset();
+        is_deeply(\%ddclient::recap, $tc->{wantrecap}, "recap")
+            or diag(ddclient::repr(Values => [\%ddclient::recap, $tc->{wantrecap}],
+                                   Names => ['*got', '*want']));
+        subtest('logs' => sub {
+            my @got  = @{$l->{logs}};
+            my @want = @{$tc->{wantlogs} // []};
+            for my $i (0..$#want) {
+                last if $i >= @got;
+                my $got  = $got[$i];
+                my $want = $want[$i];
+                subtest("log $i" => sub {
+                    is($got->{label}, $want->{label}, 'label');
+                    is_deeply($got->{ctx}, $want->{ctx}, 'context');
+                    like($got->{msg}, $want->{msg}, 'message');
+                }) or diag(ddclient::repr(Values => [$got, $want], Names => ['*got', '*want']));
+            }
+            my @unexpected = @got[@want..$#got];
+            ok(!@unexpected, 'no unexpected logs')
+                or diag(ddclient::repr(\@unexpected, Names => ['*unexpected']));
+            my @missing = @want[@got..$#want];
+            ok(!@missing, 'no missing logs')
+                or diag(ddclient::repr(\@missing, Names => ['*missing']));
+        });
+        subtest('requests' => sub { $tc->{wantreqs}->(@reqs) }) if $tc->{wantreqs};
+    });
+}
+
+done_testing();


### PR DESCRIPTION
Adds support to update A and AAAA records. The old records are stored in as recap, searched in the list of records and substituted if they exist.

Happy about suggestions on how to improve things!