### PR TITLE
Fix `configure.ac` to prevent error while trying to find `curl`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -59,7 +59,7 @@ AS_CASE([${with_curl}],
     AC_MSG_CHECKING([for curl])
     CURL=${with_curl}
     AC_MSG_RESULT([${CURL}])
-  ]);
+  ])
 AS_IF([test -z "${CURL}"], [AC_MSG_ERROR([curl not found])])
 
 AX_WITH_PROG([PERL], perl)


### PR DESCRIPTION
This removes an errant semicolon from `configure.ac` which causes `configure` to fail while trying to detect curl.

Confirmed fix with automake 1.12 & autoconf 2.63 under OpenBSD/amd64-current.

If/when merged, this should allow us to remove the one remaining patch for the OpenBSD port. OpenBSD's net/ddclient port & package is currently at 3.9.1, but I have [4.0.0 update pending review](https://marc.info/?l=openbsd-ports&m=176774235202182&w=2).