### PR TITLE
digitalocean: Save IPs to correct variables

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,8 +7,10 @@ repository history](https://github.com/ddclient/ddclient/commits/main).
 
 ### Bug fixes
 
-  * `gandi`: Fix %recap tag for ip
+  * `gandi`: Fix %recap tag for ip.
     [#841](https://github.com/ddclient/ddclient/pull/841)
+  * `digitalocean`: Save IPs to correct variables.
+    [#870](https://github.com/ddclient/ddclient/pull/870)
 
 ## 2025-01-19 v4.0.0
 

--- a/ddclient.in
+++ b/ddclient.in
@@ -7514,7 +7514,7 @@ sub nic_digitalocean_update_one {
     }
 
     $recap{$h}{"status-$ipv"} = 'good';
-    $recap{$h}{"ip-$ipv"} = $ip;
+    $recap{$h}{$ipv} = $ip;
     $recap{$h}{"mtime"} = $now;
 }
 


### PR DESCRIPTION
This provider has been using the wrong variable names (`ip-ipv4`/`ip-ipv6` instead of just `ipv4`/`ipv6`) since the beginning, but it was a silent error until v4.0.0, which logs an "ignoring unrecognized recap variable" message thanks to the refactoring from #740. Fix the issue.