### PR TITLE
fix: add proportional jitter to reduce synchronized API calls

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -65,6 +65,7 @@ handwritten_tests = \
 	t/group_hosts_by.pl \
 	t/header_ok.pl \
 	t/interval_expired.pl \
+	t/jitter.pl \
 	t/is-and-extract-ipv4.pl \
 	t/is-and-extract-ipv6.pl \
 	t/is-and-extract-ipv6-global.pl \

--- a/ddclient.in
+++ b/ddclient.in
@@ -1493,6 +1493,14 @@ sub main {
         print_info() if opt('debug') && opt('verbose');
         $daemon = opt('daemon');
 
+        # Add proportional jitter to spread API calls across clients and reduce
+        # synchronized traffic spikes at DNS providers. Jitter is [0, 20%) of
+        # the daemon interval, applied once per cycle before the update check.
+        if ($daemon) {
+            my $jitter = int(rand($daemon * 0.2));
+            sleep($jitter) if $jitter > 0;
+        }
+
         update_nics();
 
         if ($daemon) {

--- a/t/jitter.pl
+++ b/t/jitter.pl
@@ -1,0 +1,55 @@
+use strict;
+use warnings;
+use Test::More;
+SKIP: { eval { require Test::Warnings; } or skip($@, 1); }
+eval { require 'ddclient'; } or BAIL_OUT($@);
+
+# Stub sleep() in the ddclient namespace to capture calls without blocking.
+my @sleep_calls;
+{
+    no warnings 'redefine';
+    *ddclient::sleep = sub { push @sleep_calls, $_[0] };
+}
+
+# Compute jitter the same way ddclient does: int(rand($daemon * 0.2))
+sub compute_jitter {
+    my ($interval) = @_;
+    return int(rand($interval * 0.2));
+}
+
+# For a 5-minute (300s) interval, jitter must be in [0, 60).
+# Run several trials to ensure we never produce a value outside the range.
+{
+    my $interval = 300;
+    my $max_jitter = int($interval * 0.2);  # 60
+    my $out_of_range = 0;
+    for (1..200) {
+        my $j = compute_jitter($interval);
+        $out_of_range++ if $j < 0 || $j >= $max_jitter;
+        @sleep_calls = ();
+        ddclient::sleep($j) if $j > 0;
+        if ($j > 0) {
+            is($sleep_calls[0], $j, "sleep called with jitter value $j");
+        }
+    }
+    is($out_of_range, 0, "jitter always in [0, 60) for 300s interval");
+}
+
+# For a 1-second interval, int(rand(0.2)) is always 0 — sleep must not be called.
+{
+    my $interval = 1;
+    @sleep_calls = ();
+    my $jitter = compute_jitter($interval);
+    is($jitter, 0, "jitter is 0 for 1s interval");
+    ddclient::sleep($jitter) if $jitter > 0;
+    is(scalar @sleep_calls, 0, "sleep not called when jitter is 0");
+}
+
+# For a 0-second interval (daemon disabled), jitter must be 0.
+{
+    my $interval = 0;
+    my $jitter = compute_jitter($interval);
+    is($jitter, 0, "jitter is 0 for 0s interval");
+}
+
+done_testing();


### PR DESCRIPTION
Hello, I'm a product manager at @Cloudflare who oversees our API platform. Our logs show that we get millions of clients calling our DDNS endpoints every 5 minutes. This is a noticeable increase over our typical baseline, and contributes to performance degradation. We would like to smooth out the API traffic so that the spikes aren't so prominent, and we have identified your project as one to reach out to. 

I added some code that introduces proportional jitter to the DDNS update interval, which should help reduce synchronized API calls and improve performance for us and all the other services that you're using. 

Let me know if you have any questions on this, happy to take your suggestions on this as well! 