### PR TITLE
Add automated packaging for RPM and DEB

### DIFF
--- a/.github/workflows/package-deb.yml
+++ b/.github/workflows/package-deb.yml
@@ -1,0 +1,212 @@
+name: Package DEB
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-debian:
+    name: Build DEB (Debian ${{ matrix.debian_version }})
+    runs-on: ubuntu-latest
+    container:
+      image: debian:${{ matrix.debian_version }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        debian_version:
+          - "12"
+          - "13"
+
+    env:
+      DEBIAN_FRONTEND: noninteractive
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install build dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+              automake \
+              build-essential \
+              curl \
+              debhelper \
+              dpkg-dev \
+              libhttp-daemon-perl \
+              libhttp-daemon-ssl-perl \
+              libhttp-message-perl \
+              libplack-perl \
+              libtest-mockmodule-perl \
+              libtest-tcp-perl \
+              libtest-warnings-perl \
+              liburi-perl \
+              make \
+              perl \
+              ;
+
+      - name: Build distribution tarball from source
+        run: |
+          ./autogen
+          ./configure
+          make dist
+
+      - name: Build DEBs
+        id: build
+        run: |
+          TARBALL=$(ls ddclient-*.tar.gz)
+          UPSTREAM="${TARBALL#ddclient-}"
+          UPSTREAM="${UPSTREAM%.tar.gz}"
+
+          # Translate semver suffix to Debian version.
+          # '-' suffix (pre-release): replace '-' with '~' (tilde sorts before in Debian)
+          # '+' suffix (post-release): keep '+' as-is (sorts after in Debian)
+          # No suffix is a final release
+          # Get the distro codename from the container (e.g. bookworm, jammy)
+          CODENAME=$(. /etc/os-release && echo "${VERSION_CODENAME}")
+
+          # Translate semver suffix to Debian version and append ~CODENAMEn
+          # so each distro produces a unique filename that sorts correctly.
+          case "$UPSTREAM" in
+            *-*)
+              BASE="${UPSTREAM%%-*}"
+              LABEL="${UPSTREAM#*-}"
+              DEB_VERSION="${BASE}~${LABEL}-1+${CODENAME}1" ;;
+            *)
+              DEB_VERSION="${UPSTREAM}-1+${CODENAME}1" ;;
+          esac
+
+          SRCDIR="ddclient-${UPSTREAM}"
+          tar xzf "$TARBALL"
+          cp -r packaging/debian "${SRCDIR}/debian"
+
+          # Generate debian/changelog with the correct version and codename
+          printf 'ddclient (%s) %s; urgency=low\n\n  * Automated build of upstream version %s.\n\n -- ddclient packaging <ddclient@ddclient.net>  %s\n' \
+              "${DEB_VERSION}" "${CODENAME}" "${UPSTREAM}" "$(date -R)" \
+              > "${SRCDIR}/debian/changelog"
+
+          cd "${SRCDIR}"
+          dpkg-buildpackage -b --no-sign
+
+          echo "upstream=${UPSTREAM}" >> "$GITHUB_OUTPUT"
+
+      - name: Collect DEBs
+        run: |
+          mkdir -p artifacts
+          find . -maxdepth 1 -name '*.deb' -exec cp {} artifacts/ \;
+          ls -lh artifacts/
+
+      - name: Upload DEB artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: ddclient-deb-${{ steps.build.outputs.upstream }}-debian${{ matrix.debian_version }}
+          path: artifacts/*.deb
+
+      - name: Attach DEBs to GitHub release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v3
+        with:
+          files: artifacts/*.deb
+
+  build-ubuntu:
+    name: Build DEB (Ubuntu ${{ matrix.ubuntu_version }})
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:${{ matrix.ubuntu_version }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ubuntu_version:
+          - "22.04"
+          - "24.04"
+
+    env:
+      DEBIAN_FRONTEND: noninteractive
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install build dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+              automake \
+              build-essential \
+              curl \
+              debhelper \
+              dpkg-dev \
+              libhttp-daemon-perl \
+              libhttp-daemon-ssl-perl \
+              libhttp-message-perl \
+              libplack-perl \
+              libtest-mockmodule-perl \
+              libtest-tcp-perl \
+              libtest-warnings-perl \
+              liburi-perl \
+              make \
+              perl \
+              ;
+
+      - name: Build distribution tarball from source
+        run: |
+          ./autogen
+          ./configure
+          make dist
+
+      - name: Build DEBs
+        id: build
+        run: |
+          TARBALL=$(ls ddclient-*.tar.gz)
+          UPSTREAM="${TARBALL#ddclient-}"
+          UPSTREAM="${UPSTREAM%.tar.gz}"
+
+          # Get the distro codename from the container (e.g. bookworm, jammy)
+          CODENAME=$(. /etc/os-release && echo "${VERSION_CODENAME}")
+
+          # Translate semver suffix to Debian version and append ~CODENAMEn
+          # so each distro produces a unique filename that sorts correctly.
+          case "$UPSTREAM" in
+            *-*)
+              BASE="${UPSTREAM%%-*}"
+              LABEL="${UPSTREAM#*-}"
+              DEB_VERSION="${BASE}~${LABEL}-1+${CODENAME}1" ;;
+            *)
+              DEB_VERSION="${UPSTREAM}-1+${CODENAME}1" ;;
+          esac
+
+          SRCDIR="ddclient-${UPSTREAM}"
+          tar xzf "$TARBALL"
+          cp -r packaging/debian "${SRCDIR}/debian"
+
+          # Generate debian/changelog with the correct version and codename
+          printf 'ddclient (%s) %s; urgency=low\n\n  * Automated build of upstream version %s.\n\n -- ddclient packaging <ddclient@ddclient.net>  %s\n' \
+              "${DEB_VERSION}" "${CODENAME}" "${UPSTREAM}" "$(date -R)" \
+              > "${SRCDIR}/debian/changelog"
+
+          cd "${SRCDIR}"
+          dpkg-buildpackage -b --no-sign
+
+          echo "upstream=${UPSTREAM}" >> "$GITHUB_OUTPUT"
+
+      - name: Collect DEBs
+        run: |
+          mkdir -p artifacts
+          find . -maxdepth 1 -name '*.deb' -exec cp {} artifacts/ \;
+          ls -lh artifacts/
+
+      - name: Upload DEB artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: ddclient-deb-${{ steps.build.outputs.upstream }}-ubuntu${{ matrix.ubuntu_version }}
+          path: artifacts/*.deb
+
+      - name: Attach DEBs to GitHub release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v3
+        with:
+          files: artifacts/*.deb

--- a/.github/workflows/package-rpm.yml
+++ b/.github/workflows/package-rpm.yml
@@ -1,0 +1,213 @@
+name: Package RPM
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-fedora:
+    name: Build RPM (Fedora ${{ matrix.fedora_version }})
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:${{ matrix.fedora_version }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        fedora_version:
+          - 42
+          - 43
+          - 44
+          - rawhide
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install build dependencies
+        run: |
+          dnf --refresh install -y \
+              automake \
+              curl \
+              findutils \
+              make \
+              rpm-build \
+              systemd-rpm-macros \
+              perl-interpreter \
+              perl-Data-Dumper \
+              perl-File-Path \
+              perl-Getopt-Long \
+              perl-Socket \
+              perl-Sys-Hostname \
+              perl-version \
+              ;
+
+      - name: Build distribution tarball from source
+        run: |
+          ./autogen
+          ./configure
+          make dist
+
+      - name: Build RPMs
+        id: build
+        run: |
+          TARBALL=$(ls ddclient-*.tar.gz)
+          UPSTREAM="${TARBALL#ddclient-}"
+          UPSTREAM="${UPSTREAM%.tar.gz}"
+
+          # Translate semver suffix to RPM Version+Release.
+          # '-' suffix (pre-release) sorts before final:  Release 0.1.<label>
+          # '+' suffix (post-release) sorts after final:  Release 1.<label>
+          # No suffix is a final release:                 Release 1
+          case "$UPSTREAM" in
+            *-*)
+              RPM_VERSION="${UPSTREAM%%-*}"
+              LABEL="${UPSTREAM#*-}"
+              RPM_RELEASE="0.1.${LABEL}%{?dist}" ;;
+            *+*)
+              RPM_VERSION="${UPSTREAM%%+*}"
+              LABEL="${UPSTREAM#*+}"
+              RPM_RELEASE="1.${LABEL}%{?dist}" ;;
+            *)
+              RPM_VERSION="$UPSTREAM"
+              RPM_RELEASE="1%{?dist}" ;;
+          esac
+
+          TOPDIR="$(pwd)/rpmbuild"
+          mkdir -p "$TOPDIR"/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+          cp ddclient-*.tar.gz "$TOPDIR/SOURCES/"
+          cp packaging/rpm/ddclient.spec "$TOPDIR/SPECS/"
+          rpmbuild \
+            --define "_topdir $TOPDIR" \
+            --define "upstream_version ${UPSTREAM}" \
+            --define "rpm_version ${RPM_VERSION}" \
+            --define "rpm_release ${RPM_RELEASE}" \
+            -ba "$TOPDIR/SPECS/ddclient.spec"
+
+          echo "upstream=${UPSTREAM}" >> "$GITHUB_OUTPUT"
+
+      - name: Collect RPMs
+        run: |
+          mkdir -p artifacts
+          find rpmbuild/RPMS rpmbuild/SRPMS -name '*.rpm' -exec cp {} artifacts/ \;
+          ls -lh artifacts/
+
+      - name: Upload RPM artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: ddclient-rpm-${{ steps.build.outputs.upstream }}-fc${{ matrix.fedora_version }}
+          path: artifacts/*.rpm
+
+      - name: Attach RPMs to GitHub release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v3
+        with:
+          files: artifacts/*.rpm
+
+  build-epel:
+    name: Build RPM (EPEL ${{ matrix.epel_version }})
+    runs-on: ubuntu-latest
+    container:
+      image: almalinux:${{ matrix.epel_version }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        epel_version:
+          - 8
+          - 9
+          - 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Enable EPEL and CRB repositories
+        run: |
+          dnf --refresh install -y 'dnf-command(config-manager)' epel-release
+          if [ "${{ matrix.epel_version }}" = "8" ]; then
+            dnf config-manager --set-enabled powertools
+          else
+            dnf config-manager --set-enabled crb
+          fi
+
+      - name: Install build dependencies
+        # --skip-broken works around packages bundled differently across
+        # EPEL versions (e.g. perl-Sys-Hostname is part of perl-core on el8/el9)
+        run: |
+          dnf --refresh install --skip-broken -y \
+              automake \
+              curl \
+              findutils \
+              make \
+              perl-core \
+              rpm-build \
+              systemd-rpm-macros \
+              perl-interpreter \
+              perl-Data-Dumper \
+              perl-File-Path \
+              perl-Getopt-Long \
+              perl-Socket \
+              perl-Sys-Hostname \
+              perl-version \
+              ;
+
+      - name: Build distribution tarball from source
+        run: |
+          ./autogen
+          ./configure
+          make dist
+
+      - name: Build RPMs
+        id: build
+        run: |
+          TARBALL=$(ls ddclient-*.tar.gz)
+          UPSTREAM="${TARBALL#ddclient-}"
+          UPSTREAM="${UPSTREAM%.tar.gz}"
+
+          case "$UPSTREAM" in
+            *-*)
+              RPM_VERSION="${UPSTREAM%%-*}"
+              LABEL="${UPSTREAM#*-}"
+              RPM_RELEASE="0.1.${LABEL}%{?dist}" ;;
+            *+*)
+              RPM_VERSION="${UPSTREAM%%+*}"
+              LABEL="${UPSTREAM#*+}"
+              RPM_RELEASE="1.${LABEL}%{?dist}" ;;
+            *)
+              RPM_VERSION="$UPSTREAM"
+              RPM_RELEASE="1%{?dist}" ;;
+          esac
+
+          TOPDIR="$(pwd)/rpmbuild"
+          mkdir -p "$TOPDIR"/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+          cp ddclient-*.tar.gz "$TOPDIR/SOURCES/"
+          cp packaging/rpm/ddclient.spec "$TOPDIR/SPECS/"
+          rpmbuild \
+            --define "_topdir $TOPDIR" \
+            --define "upstream_version ${UPSTREAM}" \
+            --define "rpm_version ${RPM_VERSION}" \
+            --define "rpm_release ${RPM_RELEASE}" \
+            -ba "$TOPDIR/SPECS/ddclient.spec"
+
+          echo "upstream=${UPSTREAM}" >> "$GITHUB_OUTPUT"
+
+      - name: Collect RPMs
+        run: |
+          mkdir -p artifacts
+          find rpmbuild/RPMS rpmbuild/SRPMS -name '*.rpm' -exec cp {} artifacts/ \;
+          ls -lh artifacts/
+
+      - name: Upload RPM artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: ddclient-rpm-${{ steps.build.outputs.upstream }}-epel${{ matrix.epel_version }}
+          path: artifacts/*.rpm
+
+      - name: Attach RPMs to GitHub release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v3
+        with:
+          files: artifacts/*.rpm

--- a/Makefile.am
+++ b/Makefile.am
@@ -7,6 +7,13 @@ EXTRA_DIST = \
 	README.cisco \
 	README.md \
 	autogen \
+	docs/Packaging.md \
+	packaging/debian/changelog \
+	packaging/debian/control \
+	packaging/debian/copyright \
+	packaging/debian/ddclient.service \
+	packaging/debian/rules \
+	packaging/rpm/ddclient.spec \
 	sample-ddclient-wrapper.sh \
 	sample-etc_cron.d_ddclient \
 	sample-etc_dhclient-exit-hooks \

--- a/README.md
+++ b/README.md
@@ -233,6 +233,11 @@ and monitor your ppp interface.
 
 ## USING DDCLIENT WITH `cron`
 
+The recommended way to run ddclient is via the provided systemd service, which
+keeps it running as a daemon and handles restarts automatically. If you cannot
+or prefer not to run a persistent daemon (e.g. on systems without systemd, or
+in constrained environments), cron is a good alternative.
+
 If you have not configured ddclient to use daemon-mode, you'll need to
 configure cron to force an update once a month so that the dns entry will
 not become stale.

--- a/docs/Packaging.md
+++ b/docs/Packaging.md
@@ -1,0 +1,396 @@
+# Packaging
+
+Author: [@beadon](https://github.com/beadon)\
+Date: 2026-05-05
+
+This document describes how ddclient is packaged for Linux distributions
+and how the packaging workflow operates.
+
+## Automated packaging
+
+Two GitHub Actions workflows build and publish distribution packages
+automatically whenever a release is published on GitHub. Both are also
+triggerable manually via `workflow_dispatch` for testing.
+
+| Workflow | File | Produces |
+|---|---|---|
+| Package RPM | [`.github/workflows/package-rpm.yml`](../.github/workflows/package-rpm.yml) | `.rpm` + `.src.rpm` |
+| Package DEB | [`.github/workflows/package-deb.yml`](../.github/workflows/package-deb.yml) | `.deb` |
+
+On each run each workflow:
+
+1. Checks out the source at the release tag.
+2. Builds the distribution tarball using the autotools build system
+   (`./autogen && ./configure && make dist`).
+3. Builds packages in parallel across distribution jobs (see
+   [Supported distributions](#supported-distributions)).
+4. Attaches all packages to the GitHub release as downloadable assets.
+
+### Manual dispatch
+
+Both workflows can be triggered manually without publishing a release,
+which is useful for testing packaging changes on a branch before cutting a
+release.
+
+**Via the GitHub UI:**
+
+1. Go to **Actions → Package RPM** (or **Package DEB**) on GitHub.
+2. Click **Run workflow**, select the branch to build from, and click
+   **Run workflow**.
+
+**Via the `gh` CLI:**
+
+```sh
+# Run against the default branch
+gh workflow run package-rpm.yml --repo ddclient/ddclient
+gh workflow run package-deb.yml --repo ddclient/ddclient
+
+# Run against a specific branch or tag
+gh workflow run package-rpm.yml --repo ddclient/ddclient --ref my-branch
+gh workflow run package-deb.yml --repo ddclient/ddclient --ref my-branch
+```
+
+When triggered this way packages are built and uploaded as workflow
+artifacts (visible in the Actions run summary) but are **not** attached to
+any release. The version is derived from whatever `make dist` produces on
+the selected branch.
+
+## Creating a release
+
+Publishing a release on GitHub (i.e. not a draft) automatically triggers
+the packaging workflow and attaches the resulting RPMs to the release.
+
+### Via the GitHub UI
+
+1. Go to **Releases → Draft a new release** on GitHub.
+2. Enter the tag (e.g. `v4.0.1-rc.1` or `v4.0.1`) and title.
+3. Write the release notes.
+4. For a pre-release (alpha, beta, rc), check **Set as a pre-release**.
+5. Click **Publish release**.
+
+### Via the `gh` CLI
+
+**Pre-release (alpha, beta, rc):**
+
+```sh
+gh release create v4.0.1-rc.1 \
+  --repo ddclient/ddclient \
+  --title "v4.0.1-rc.1" \
+  --notes "Release candidate 1 for v4.0.1." \
+  --prerelease
+```
+
+**Final release:**
+
+```sh
+gh release create v4.0.1 \
+  --repo ddclient/ddclient \
+  --title "v4.0.1" \
+  --notes-from-tag
+```
+
+`--notes-from-tag` uses the annotated git tag message as the release notes.
+To write notes inline use `--notes "..."` or `--notes-file changelog.md`
+instead.
+
+### Verifying the release artifacts
+
+After the workflows complete, all package artifacts are attached to the release
+and visible at:
+
+```
+https://github.com/ddclient/ddclient/releases/tag/v4.0.1-rc.1
+```
+
+To download and install a specific package to verify it:
+
+```sh
+# Fedora 44
+curl -fsSL -O https://github.com/ddclient/ddclient/releases/download/v4.0.1-rc.1/ddclient-4.0.1-0.1.rc.1.fc44.noarch.rpm
+sudo dnf install -y ./ddclient-4.0.1-0.1.rc.1.fc44.noarch.rpm
+ddclient --version
+
+# EPEL 9 (RHEL/AlmaLinux/Rocky 9)
+curl -fsSL -O https://github.com/ddclient/ddclient/releases/download/v4.0.1-rc.1/ddclient-4.0.1-0.1.rc.1.el9.noarch.rpm
+sudo dnf install -y ./ddclient-4.0.1-0.1.rc.1.el9.noarch.rpm
+ddclient --version
+
+# Debian 12 / Ubuntu 24.04
+curl -fsSL -O https://github.com/ddclient/ddclient/releases/download/v4.0.1-rc.1/ddclient_4.0.1~rc.1-1_all.deb
+sudo apt install -y ./ddclient_4.0.1~rc.1-1_all.deb
+ddclient --version
+```
+
+## Supported distributions
+
+### RPM-based
+
+| Distribution | Container | Builds produced | EOL |
+|---|---|---|---|
+| Fedora 42 | `fedora:42` | noarch RPM + SRPM | 2026-05-27 |
+| Fedora 43 | `fedora:43` | noarch RPM + SRPM | 2026-12-09 |
+| Fedora 44 | `fedora:44` | noarch RPM + SRPM | 2027-06-02 |
+| Fedora rawhide | `fedora:rawhide` | noarch RPM + SRPM | rolling |
+| EPEL 8 (RHEL/AlmaLinux 8) | `almalinux:8` | noarch RPM + SRPM | 2029-03-01 |
+| EPEL 9 (RHEL/AlmaLinux 9) | `almalinux:9` | noarch RPM + SRPM | 2032-05-31 |
+| EPEL 10 (RHEL/AlmaLinux 10) | `almalinux:10` | noarch RPM + SRPM | 2035-05-31 |
+
+The matrix in [`.github/workflows/package-rpm.yml`](../.github/workflows/package-rpm.yml) should be updated when Fedora releases
+reach stable or end-of-life. See <https://endoflife.date/fedora> for Fedora
+and <https://endoflife.date/almalinux> for EPEL/RHEL support windows.
+
+### DEB-based
+
+| Distribution | Container | Builds produced | EOL |
+|---|---|---|---|
+| Debian 12 (Bookworm) | `debian:12` | all.deb | 2028-06-10 |
+| Debian 13 (Trixie) | `debian:13` | all.deb | ~2031 |
+| Ubuntu 22.04 LTS (Jammy) | `ubuntu:22.04` | all.deb | 2027-04-01 |
+| Ubuntu 24.04 LTS (Noble) | `ubuntu:24.04` | all.deb | 2029-04-01 |
+
+The matrix in [`.github/workflows/package-deb.yml`](../.github/workflows/package-deb.yml) should be updated when Debian
+or Ubuntu releases reach stable or end-of-life. See <https://endoflife.date/debian>
+for Debian and <https://endoflife.date/ubuntu> for Ubuntu support windows.
+
+## Version translation
+
+ddclient uses [Semantic Versioning 2.0.0](https://semver.org/) with a
+pre-release suffix separated by `-` and a post-release suffix separated by
+`+`. Both RPM and Debian have their own conventions for encoding this.
+
+### RPM
+
+RPM forbids `-` in the `Version:` field, so the version is split at
+the boundary and the suffix is moved into `Release:`.
+
+| ddclient version | RPM `Version:` | RPM `Release:`         |
+|------------------|----------------|------------------------|
+| `4.0.0`          | `4.0.0`        | `1%{?dist}`            |
+| `4.0.1-alpha`    | `4.0.1`        | `0.1.alpha%{?dist}`    |
+| `4.0.1-beta.2`   | `4.0.1`        | `0.1.beta.2%{?dist}`   |
+| `4.0.1-rc.3`     | `4.0.1`        | `0.1.rc.3%{?dist}`     |
+| `4.0.1+r.2`      | `4.0.1`        | `1.r.2%{?dist}`        |
+
+Pre-release versions (leading `0.` in `Release:`) sort before the final
+release. Post-release versions sort after. This follows the
+[Fedora packaging versioning guidelines](https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/).
+
+The `%{?dist}` macro in `Release:` is automatically expanded by the RPM
+build system to a distribution tag derived from the build host — for
+example `.fc44` on Fedora 44 or `.el9` on EPEL 9. This means each
+per-distribution build gets a naturally unique filename at no extra effort:
+
+```
+ddclient-4.0.1-0.1.rc.1.fc44.noarch.rpm
+ddclient-4.0.1-0.1.rc.1.el9.noarch.rpm
+```
+
+If `%{?dist}` expands to nothing (e.g. on a plain RHEL host without the
+`redhat-rpm-config` macros), the dist tag is simply omitted from the
+filename, which is harmless for local builds.
+
+### Debian
+
+#### The tilde (`~`) separator
+
+The `~` (tilde) character has a special meaning in Debian version ordering:
+a tilde sorts *before* anything, including the empty string. The full rule is:
+
+```
+A~B  <  A  <  A+B
+```
+
+ddclient uses this in two ways, both applied in the packaging workflow:
+
+**1. Pre-release SemVer translation**
+
+The SemVer `-` pre-release separator is replaced with `~` so that Debian
+sees the correct ordering (`4.0.1~rc.1 < 4.0.1`). Post-release `+` suffixes
+are left unchanged as they already sort after the base version.
+
+**2. Distro-targeting suffix (`+CODENAMEn`)**
+
+Each build appends `+<codename>n` to the Debian revision (e.g. `+bookworm1`,
+`+jammy1`), giving every distribution a unique filename:
+
+```
+ddclient_4.0.1~rc.1-1+bookworm1_all.deb
+ddclient_4.0.1~rc.1-1+jammy1_all.deb
+```
+
+`+` is used rather than `~` for two reasons:
+
+- **GitHub release assets**: GitHub's API sanitizes `~` to `.` in release
+  asset filenames, mangling the name users download. `+` is preserved as-is.
+- **Semantic correctness**: `+` sorts *after* the base revision in Debian
+  version ordering, which accurately reflects that this is a distro-specific
+  build layered on top of the upstream release, not a pre-release of it.
+
+The trailing integer `n` is a **distro-build counter**. It starts at `1` (not
+`0`) because Debian version ordering treats `1` as the conventional first
+revision — the same reason the package revision itself starts at `-1`. In
+practice `n` will almost always stay at `1`. The only reason to increment it
+is if a packaging defect is found after a release and the package needs to be
+rebuilt for a specific distro without bumping the upstream version:
+
+```
+ddclient_4.0.1~rc.1-1+bookworm1_all.deb   ← original build
+ddclient_4.0.1~rc.1-1+bookworm2_all.deb   ← rebuilt to fix a packaging bug
+```
+
+Users already running `+bookworm1` will receive `+bookworm2` via `apt upgrade`
+without any change to the upstream version. Users on other distros are
+unaffected. To trigger a distro rebuild, edit the workflow's `printf` line for
+the relevant job and change the hardcoded `1` to `2`.
+
+The codename is read at build time from `/etc/os-release` inside the container
+(`VERSION_CODENAME`), so no mapping table needs to be maintained in the
+workflow as new distributions are added.
+
+#### Version table
+
+| ddclient version | Debian `Version:` (Bookworm example)    |
+|------------------|-----------------------------------------|
+| `4.0.0`          | `4.0.0-1+bookworm1`                     |
+| `4.0.1-alpha`    | `4.0.1~alpha-1+bookworm1`               |
+| `4.0.1-beta.2`   | `4.0.1~beta.2-1+bookworm1`              |
+| `4.0.1-rc.3`     | `4.0.1~rc.3-1+bookworm1`                |
+| `4.0.1+r.2`      | `4.0.1+r.2-1+bookworm1`                 |
+
+Replace `bookworm` with the target codename (`trixie`, `jammy`, `noble`, etc.)
+for other distributions.
+
+The Debian revision (`-1`) is always `1` for packages built directly from an
+upstream release. The workflows do not validate or restrict the SemVer suffix —
+any string after `-` is treated as a pre-release label and any string after `+`
+is treated as a post-release label, passed through verbatim.
+
+## Building a DEB locally
+
+**On Debian or Ubuntu:**
+
+```sh
+sudo apt-get install -y automake curl debhelper dpkg-dev make perl
+```
+
+Build the distribution tarball and the DEB using [`packaging/debian/`](../packaging/debian/):
+
+```sh
+./autogen
+./configure
+make dist
+
+TARBALL=$(ls ddclient-*.tar.gz)
+UPSTREAM="${TARBALL#ddclient-}"; UPSTREAM="${UPSTREAM%.tar.gz}"
+
+# Get distro codename and translate version
+CODENAME=$(. /etc/os-release && echo "${VERSION_CODENAME}")
+case "$UPSTREAM" in
+  *-*) DEB_VERSION="${UPSTREAM%%-*}~${UPSTREAM#*-}-1+${CODENAME}1" ;;
+  *)   DEB_VERSION="${UPSTREAM}-1+${CODENAME}1" ;;
+esac
+
+SRCDIR="ddclient-${UPSTREAM}"
+tar xzf "$TARBALL"
+cp -r packaging/debian "${SRCDIR}/debian"
+
+printf 'ddclient (%s) %s; urgency=low\n\n  * Local build of upstream version %s.\n\n -- Local Builder <local@localhost>  %s\n' \
+    "${DEB_VERSION}" "${CODENAME}" "${UPSTREAM}" "$(date -R)" \
+    > "${SRCDIR}/debian/changelog"
+
+cd "${SRCDIR}"
+dpkg-buildpackage -b --no-sign
+```
+
+The resulting `.deb` will be in the parent directory (`../ddclient_*.deb`).
+Install it with:
+
+```sh
+sudo apt install ../ddclient_${DEB_VERSION}_all.deb
+```
+
+## Building an RPM locally
+
+**On Fedora:**
+
+```sh
+sudo dnf install -y automake curl findutils make rpm-build systemd-rpm-macros \
+    perl-interpreter perl-Data-Dumper perl-File-Path perl-Getopt-Long \
+    perl-Socket perl-Sys-Hostname perl-version
+```
+
+**On EPEL (RHEL/AlmaLinux/Rocky):** enable EPEL and CRB first, then install
+with `--skip-broken` since some Perl modules are bundled into `perl-core`
+rather than shipped as separate packages:
+
+```sh
+sudo dnf install -y 'dnf-command(config-manager)' epel-release
+sudo dnf config-manager --set-enabled crb   # use 'powertools' on el8
+sudo dnf install --skip-broken -y automake curl findutils make perl-core \
+    rpm-build systemd-rpm-macros perl-interpreter perl-Data-Dumper \
+    perl-File-Path perl-Getopt-Long perl-Socket perl-Sys-Hostname perl-version
+```
+
+Build the distribution tarball and the RPMs using [`packaging/rpm/ddclient.spec`](../packaging/rpm/ddclient.spec):
+
+```sh
+./autogen
+./configure
+make dist
+
+TOPDIR="$(pwd)/rpmbuild"
+mkdir -p "$TOPDIR"/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+
+TARBALL=$(ls ddclient-*.tar.gz)
+UPSTREAM="${TARBALL#ddclient-}"; UPSTREAM="${UPSTREAM%.tar.gz}"
+
+case "$UPSTREAM" in
+  *-*) RPM_VERSION="${UPSTREAM%%-*}"; LABEL="${UPSTREAM#*-}"; RPM_RELEASE="0.1.${LABEL}%{?dist}" ;;
+  *+*) RPM_VERSION="${UPSTREAM%%+*}"; LABEL="${UPSTREAM#*+}"; RPM_RELEASE="1.${LABEL}%{?dist}" ;;
+  *)   RPM_VERSION="$UPSTREAM"; RPM_RELEASE="1%{?dist}" ;;
+esac
+
+cp "$TARBALL" "$TOPDIR/SOURCES/"
+cp packaging/rpm/ddclient.spec "$TOPDIR/SPECS/"
+
+rpmbuild \
+  --define "_topdir $TOPDIR" \
+  --define "upstream_version ${UPSTREAM}" \
+  --define "rpm_version ${RPM_VERSION}" \
+  --define "rpm_release ${RPM_RELEASE}" \
+  -ba "$TOPDIR/SPECS/ddclient.spec"
+```
+
+The resulting RPMs will be in `rpmbuild/RPMS/` and `rpmbuild/SRPMS/`.
+
+## Adding a new distribution
+
+### RPM-based (Fedora, AlmaLinux, RHEL)
+
+For a new **Fedora** release, add the version number to the `fedora_version`
+matrix in the `build-fedora` job in
+[`.github/workflows/package-rpm.yml`](../.github/workflows/package-rpm.yml).
+
+For a new **EPEL** release (RHEL/AlmaLinux/Rocky), add the major version to
+the `epel_version` matrix in the `build-epel` job. No changes to the spec
+file are needed in either case.
+
+### DEB-based (Debian, Ubuntu)
+
+For a new **Debian** release, add the version number to the `debian_version`
+matrix in the `build-debian` job in
+[`.github/workflows/package-deb.yml`](../.github/workflows/package-deb.yml).
+
+For a new **Ubuntu** release, add the version (e.g. `"26.04"`) to the
+`ubuntu_version` matrix in the `build-ubuntu` job. No changes to the
+`packaging/debian/` files are needed in either case.
+
+### Other package formats (Arch, etc.)
+
+Add a new spec or build file under `packaging/<format>/` and a
+corresponding workflow under `.github/workflows/package-<format>.yml`,
+following the same pattern as the RPM or DEB workflow:
+
+- Derive the version from the distribution tarball produced by `make dist`.
+- Pass version components to the build tool rather than hardcoding them.
+- Use `softprops/action-gh-release` to attach built packages to the release.

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,0 +1,5 @@
+ddclient (0.0.0-1) unstable; urgency=low
+
+  * Placeholder changelog entry — replaced by the packaging workflow.
+
+ -- ddclient packaging <ddclient@ddclient.net>  Sun, 17 May 2026 00:00:00 +0000

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -1,0 +1,33 @@
+Source: ddclient
+Section: net
+Priority: optional
+Maintainer: ddclient developers <ddclient@ddclient.net>
+Build-Depends:
+ debhelper-compat (= 13),
+ automake,
+ build-essential,
+ curl,
+ libhttp-daemon-perl (>= 6.12),
+ libhttp-daemon-ssl-perl,
+ libhttp-message-perl,
+ libplack-perl,
+ libtest-mockmodule-perl,
+ libtest-tcp-perl,
+ libtest-warnings-perl,
+ liburi-perl,
+ make,
+ perl,
+Standards-Version: 4.7.0
+Homepage: https://github.com/ddclient/ddclient
+Rules-Requires-Root: no
+
+Package: ddclient
+Architecture: all
+Depends:
+ ${misc:Depends},
+ curl,
+ perl,
+Description: Dynamic DNS update client
+ ddclient is a Perl client used to update dynamic DNS entries for accounts
+ on many dynamic DNS services. It supports multiple protocols and can detect
+ your IP address from a variety of sources.

--- a/packaging/debian/copyright
+++ b/packaging/debian/copyright
@@ -1,0 +1,18 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: ddclient
+Upstream-Contact: https://github.com/ddclient/ddclient/issues
+Source: https://github.com/ddclient/ddclient
+
+Files: *
+Copyright: 1999-2001 Paul Burry <paul@burry.ca>
+           The ddclient contributors
+License: GPL-2.0-or-later
+
+License: GPL-2.0-or-later
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 2 of the License, or
+ (at your option) any later version.
+ .
+ On Debian systems, the complete text of the GNU General Public License
+ version 2 can be found in '/usr/share/common-licenses/GPL-2'.

--- a/packaging/debian/ddclient.service
+++ b/packaging/debian/ddclient.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Dynamic DNS Update Client
+Wants=network-online.target
+After=network-online.target nss-lookup.target
+
+[Service]
+Type=exec
+Environment=daemon_interval=5m
+ExecStart=/usr/bin/ddclient --daemon ${daemon_interval} --foreground
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -1,0 +1,8 @@
+#!/usr/bin/make -f
+
+%:
+	dh $@
+
+override_dh_auto_configure:
+	./autogen
+	dh_auto_configure

--- a/packaging/rpm/ddclient.spec
+++ b/packaging/rpm/ddclient.spec
@@ -1,0 +1,83 @@
+Name:           ddclient
+Version:        %{rpm_version}
+Release:        %{rpm_release}
+Summary:        Dynamic DNS client
+
+License:        GPL-2.0-or-later
+URL:            https://github.com/ddclient/ddclient
+Source0:        ddclient-%{upstream_version}.tar.gz
+
+BuildArch:      noarch
+
+BuildRequires:  automake
+BuildRequires:  curl
+BuildRequires:  findutils
+BuildRequires:  make
+BuildRequires:  perl-interpreter
+BuildRequires:  perl(Data::Dumper)
+BuildRequires:  perl(File::Basename)
+BuildRequires:  perl(File::Path)
+BuildRequires:  perl(File::Temp)
+BuildRequires:  perl(Getopt::Long)
+BuildRequires:  perl(Socket)
+BuildRequires:  perl(Sys::Hostname)
+BuildRequires:  perl(version) >= 0.77
+
+Requires:       curl
+Requires:       perl-interpreter
+Requires:       perl(Data::Dumper)
+Requires:       perl(File::Basename)
+Requires:       perl(File::Path)
+Requires:       perl(File::Temp)
+Requires:       perl(Getopt::Long)
+Requires:       perl(Socket)
+Requires:       perl(Sys::Hostname)
+Requires:       perl(version) >= 0.77
+
+%description
+ddclient is a Perl client used to update dynamic DNS entries for accounts
+on many dynamic DNS services. It supports multiple protocols and can detect
+your IP address from a variety of sources.
+
+
+%prep
+%autosetup -n %{name}-%{upstream_version}
+
+
+%build
+./autogen
+%configure
+%make_build
+
+
+%install
+%make_install
+install -D -m 0644 sample-etc_systemd.service \
+    %{buildroot}%{_unitdir}/ddclient.service
+install -D -m 0644 sample-etc_cron.d_ddclient \
+    %{buildroot}%{_sysconfdir}/cron.d/ddclient
+
+
+%post
+%systemd_post ddclient.service
+
+%preun
+%systemd_preun ddclient.service
+
+%postun
+%systemd_postun_with_restart ddclient.service
+
+
+%files
+%license COPYING
+%doc README.md ChangeLog.md
+%{_bindir}/ddclient
+%config(noreplace) %attr(0600, root, root) %{_sysconfdir}/ddclient/ddclient.conf
+%dir %{_localstatedir}/cache/ddclient
+%{_unitdir}/ddclient.service
+%{_sysconfdir}/cron.d/ddclient
+
+
+%changelog
+* Tue May 05 2026 Bryant Eadon <bryant.eadon@gmail.com> - 4.0.0-1
+- Initial RPM packaging


### PR DESCRIPTION
## Summary

- Adds [`packaging/rpm/ddclient.spec`](packaging/rpm/ddclient.spec) — an RPM spec file following Fedora packaging guidelines, with no hardcoded version information
- Adds [`.github/workflows/package-rpm.yml`](.github/workflows/package-rpm.yml) — a GitHub Actions workflow that builds and publishes RPMs for all supported Fedora and EPEL releases automatically on every tagged release, and attaches them to the GitHub release as downloadable assets
- Adds [`docs/Packaging.md`](docs/Packaging.md) — documentation covering the automated workflow, release creation, version translation scheme, local build instructions, and guidance for adding new distributions

## How it works

On release, the workflow runs two parallel jobs:

1. **`build-fedora`** — builds inside `fedora:N` containers for Fedora 42, 43, 44, and rawhide
2. **`build-epel`** — builds inside `almalinux:N` containers (with EPEL and CRB/powertools enabled) for EPEL 8, 9, and 10 (RHEL/AlmaLinux/Rocky)

Each job:
1. Checks out source at the release tag
2. Builds the distribution tarball via `./autogen && ./configure && make dist`
3. Derives the version from the tarball name (no hardcoding anywhere)
4. Translates the ddclient semver suffix to RPM `Version:`/`Release:` fields generically — any suffix after `-` or `+` is handled without workflow changes
5. Builds a binary RPM and SRPM
6. Attaches all RPMs to the GitHub release via `softprops/action-gh-release`

The workflow is also triggerable manually via `workflow_dispatch` for testing packaging changes before cutting a release.

## Version translation

RPM forbids `-` in `Version:`, so suffixes are split generically:

| ddclient | RPM Version | RPM Release |
|---|---|---|
| `4.0.0` | `4.0.0` | `1%{?dist}` |
| `4.0.1-alpha` | `4.0.1` | `0.1.alpha%{?dist}` |
| `4.0.1-rc.3` | `4.0.1` | `0.1.rc.3%{?dist}` |
| `4.0.1+r.2` | `4.0.1` | `1.r.2%{?dist}` |

## Supported targets

| Distribution | Container | Builds produced |
|---|---|---|
| Fedora 42 | `fedora:42` | noarch RPM + SRPM |
| Fedora 43 | `fedora:43` | noarch RPM + SRPM |
| Fedora 44 | `fedora:44` | noarch RPM + SRPM |
| Fedora rawhide | `fedora:rawhide` | noarch RPM + SRPM |
| EPEL 8 (RHEL/AlmaLinux 8) | `almalinux:8` | noarch RPM + SRPM |
| EPEL 9 (RHEL/AlmaLinux 9) | `almalinux:9` | noarch RPM + SRPM |
| EPEL 10 (RHEL/AlmaLinux 10) | `almalinux:10` | noarch RPM + SRPM |

## Test plan

- [x] Workflow triggered manually (`workflow_dispatch`) on `beadon/ddclient` — all Fedora and EPEL targets build successfully
- [x] Workflow triggered by publishing a pre-release (`v4.0.1-rc.1`) on `beadon/ddclient` — RPMs built and attached to the release automatically
- [x] RPMs installed and verified on a Fedora 44 VM — `ddclient --version` reports correctly, no warnings on first run
- [x] `ddclient.conf` installed with `0600` permissions so no permission warnings on first run

See https://github.com/beadon/ddclient/releases/tag/v4.0.1-rc.1 for the test release with attached RPM artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## closes #880 