### PR TITLE
porkbun: Add missing recap for 'ipv4/ipv6' and 'mtime'

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,8 @@ repository history](https://github.com/ddclient/ddclient/commits/main).
     [#841](https://github.com/ddclient/ddclient/pull/841)
   * `digitalocean`: Save IPs to correct variables.
     [#870](https://github.com/ddclient/ddclient/pull/870)
+  * `porkbun`: Add missing recap for 'ipv4/ipv6' and 'mtime'.
+    [#885](https://github.com/ddclient/ddclient/pull/885)
 
 ## 2025-01-19 v4.0.0
 

--- a/ddclient.in
+++ b/ddclient.in
@@ -6893,6 +6893,8 @@ sub nic_porkbun_update {
             warning("There are multiple applicable records. Only first record is used. Overwrite all with the same content.")
                 if @$records > 1;
             if ($records->[0]{'content'} eq $ip) {
+                $recap{$h}{"ipv$ipv"} = $ip;
+                $recap{$h}{'mtime'} = $now;
                 $recap{$h}{"status-ipv$ipv"} = "good";
                 success("skipped: IPv$ipv address was already set to $ip");
                 next;
@@ -6915,6 +6917,8 @@ sub nic_porkbun_update {
                 }),
             );
             next if !header_ok($reply);
+            $recap{$h}{"ipv$ipv"} = $ip;
+            $recap{$h}{'mtime'} = $now;
             $recap{$h}{"status-ipv$ipv"} = "good";
             success("IPv$ipv address set to $ip");
         }


### PR DESCRIPTION
Add missing recap for 'ipv4/ipv6' and 'mtime' in `nic_porkbun_update`.

This is necessary to ensure that the cache is properly updated with the latest IP address and modification time.