### PR TITLE
feat: Add jitter percentage to the daemon interval

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,12 @@ repository history](https://github.com/ddclient/ddclient/commits/main).
 
 ## v4.0.1-rc.2 (unreleased work-in-progress)
 
+### New feature
+
+* Add a jitter to the daemon interval when in daemon mode to spread the web service
+  API calls across clients and reduce load on upstream DNS providers when many
+  clients are running with the same daemon interval.
+
 ## 2026-05-16 v4.0.1-rc.1
 
 ### Provider updates

--- a/Makefile.am
+++ b/Makefile.am
@@ -65,11 +65,11 @@ handwritten_tests = \
 	t/group_hosts_by.pl \
 	t/header_ok.pl \
 	t/interval_expired.pl \
-	t/jitter.pl \
 	t/is-and-extract-ipv4.pl \
 	t/is-and-extract-ipv6.pl \
 	t/is-and-extract-ipv6-global.pl \
 	t/logmsg.pl \
+	t/jitter.pl \
 	t/parse_assignments.pl \
 	t/protocol_directnic.pl \
 	t/protocol_dnsexit2.pl \

--- a/Makefile.am
+++ b/Makefile.am
@@ -65,6 +65,7 @@ handwritten_tests = \
 	t/group_hosts_by.pl \
 	t/header_ok.pl \
 	t/interval_expired.pl \
+	t/jitter.pl \
 	t/is-and-extract-ipv4.pl \
 	t/is-and-extract-ipv6.pl \
 	t/is-and-extract-ipv6-global.pl \

--- a/ddclient.conf.in
+++ b/ddclient.conf.in
@@ -22,6 +22,7 @@
 #ssl=yes
 
 daemon=300                      # check every 300 seconds
+jitter=60                       # apply up to 60 seconds of delay to the daemon interval
 syslog=yes                      # log update msgs to syslog
 mail=root                       # mail all msgs to root
 mail-failure=root               # mail failed update msgs to root

--- a/ddclient.in
+++ b/ddclient.in
@@ -200,6 +200,7 @@ my $result;
 my $saved_recap;
 my %saved_opt;
 my $daemon;
+my $jitter;
 # Control how many times warning message logged for invalid IP addresses
 my (%warned_ipv4, %warned_ipv6);
 
@@ -704,6 +705,9 @@ sub setv {
 our %cfgvars = (
     'global-defaults' => {
         'daemon'              => setv(T_DELAY, 0, $daemon_default,      interval('60s')),
+        'jitter'              => setv(T_DELAY, 0, sub {
+            opt('daemon') ? int(opt('daemon') * 0.2) : undef
+        }, undef),
         'foreground'          => setv(T_BOOL,  0, 0,                    undef),
         'file'                => setv(T_FILE,  0, "$etc/$program.conf", undef),
         'cache'               => setv(T_FILE,  0, "$cachedir/$program.cache", undef),
@@ -1371,6 +1375,7 @@ my @opt = (
     "usage: ${program} [options]",
     "options are:",
     ["daemon",            "=s", "--daemon=<delay>       : run as a daemon, specify <delay> as an interval"],
+    ["jitter",            "=s", "--jitter=<jitter>      : add random jitter up to <jitter> to the daemon interval, specify <jitter> as an interval"],
     ["foreground",        "!",  "--foreground           : do not fork"],
     ["proxy",             "=s", "--proxy=<host>         : use <host> as the HTTP proxy"],
     ["server",            "=s", "--server=<host>        : update DNS information on <host>"],
@@ -1508,17 +1513,18 @@ sub main {
         print_info() if opt('debug') && opt('verbose');
         $daemon = opt('daemon');
 
-        # Add proportional jitter to spread API calls across clients and reduce
-        # synchronized traffic spikes at DNS providers. Jitter is [0, 20%) of
-        # the daemon interval, applied once per cycle before the update check.
-        if ($daemon) {
-            my $jitter = int(rand($daemon * 0.2));
-            sleep($jitter) if $jitter > 0;
-        }
-
         update_nics();
 
         if ($daemon) {
+            # Jitter spreads the API calls across clients and reduces overloading
+            # the upstream DNS provider when many clients are running with the same
+            # daemon interval.
+            # For example, for a jitter of 60 seconds and a daemon interval of 5
+            # minutes, a jitter of [0, 60s) would be applied to the daemon interval
+            # and the next update would occur in [300s, 360s).
+            $daemon += int(rand($jitter))
+                if ($jitter = opt('jitter')) && ($jitter // 0) != 'inf';
+
             debug("sleep %s", $daemon);
             sendmail();
 

--- a/ddclient.in
+++ b/ddclient.in
@@ -1508,6 +1508,14 @@ sub main {
         print_info() if opt('debug') && opt('verbose');
         $daemon = opt('daemon');
 
+        # Add proportional jitter to spread API calls across clients and reduce
+        # synchronized traffic spikes at DNS providers. Jitter is [0, 20%) of
+        # the daemon interval, applied once per cycle before the update check.
+        if ($daemon) {
+            my $jitter = int(rand($daemon * 0.2));
+            sleep($jitter) if $jitter > 0;
+        }
+
         update_nics();
 
         if ($daemon) {

--- a/t/jitter.pl
+++ b/t/jitter.pl
@@ -1,0 +1,55 @@
+use strict;
+use warnings;
+use Test::More;
+SKIP: { eval { require Test::Warnings; } or skip($@, 1); }
+eval { require 'ddclient'; } or BAIL_OUT($@);
+
+# Stub sleep() in the ddclient namespace to capture calls without blocking.
+my @sleep_calls;
+{
+    no warnings 'redefine';
+    *ddclient::sleep = sub { push @sleep_calls, $_[0] };
+}
+
+# Compute jitter the same way ddclient does: int(rand($daemon * 0.2))
+sub compute_jitter {
+    my ($interval) = @_;
+    return int(rand($interval * 0.2));
+}
+
+# For a 5-minute (300s) interval, jitter must be in [0, 60).
+# Run several trials to ensure we never produce a value outside the range.
+{
+    my $interval = 300;
+    my $max_jitter = int($interval * 0.2);  # 60
+    my $out_of_range = 0;
+    for (1..200) {
+        my $j = compute_jitter($interval);
+        $out_of_range++ if $j < 0 || $j >= $max_jitter;
+        @sleep_calls = ();
+        ddclient::sleep($j) if $j > 0;
+        if ($j > 0) {
+            is($sleep_calls[0], $j, "sleep called with jitter value $j");
+        }
+    }
+    is($out_of_range, 0, "jitter always in [0, 60) for 300s interval");
+}
+
+# For a 1-second interval, int(rand(0.2)) is always 0 — sleep must not be called.
+{
+    my $interval = 1;
+    @sleep_calls = ();
+    my $jitter = compute_jitter($interval);
+    is($jitter, 0, "jitter is 0 for 1s interval");
+    ddclient::sleep($jitter) if $jitter > 0;
+    is(scalar @sleep_calls, 0, "sleep not called when jitter is 0");
+}
+
+# For a 0-second interval (daemon disabled), jitter must be 0.
+{
+    my $interval = 0;
+    my $jitter = compute_jitter($interval);
+    is($jitter, 0, "jitter is 0 for 0s interval");
+}
+
+done_testing();

--- a/t/jitter.pl
+++ b/t/jitter.pl
@@ -1,55 +1,104 @@
 use strict;
 use warnings;
 use Test::More;
-SKIP: { eval { require Test::Warnings; } or skip($@, 1); }
+use File::Temp qw(tempfile);
+
+my @sleep_calls;
+my @rand_args;
+my @rand_returns;
+my $sleep_duration;
+my $config_file;
+
+{
+    my ($fh, $path) = tempfile(UNLINK => 1);
+    close $fh;
+    chmod 0600, $path;
+    $config_file = $path;
+}
+
+BEGIN {
+    no warnings 'redefine';
+
+    *CORE::GLOBAL::rand = sub {
+        my ($limit) = @_;
+        push @rand_args, $limit;
+        return @rand_returns ? shift(@rand_returns) : 0;
+    };
+
+    *CORE::GLOBAL::sleep = sub {
+        my ($delay) = @_;
+        push @sleep_calls, $delay;
+        if (!defined $sleep_duration && $0 =~ /sleeping for\s+(\d+)\s+seconds/) {
+            $sleep_duration = $1;
+        }
+        die "__TEST_CAPTURED_SLEEP__\n";
+    };
+}
+
 eval { require 'ddclient'; } or BAIL_OUT($@);
 
-# Stub sleep() in the ddclient namespace to capture calls without blocking.
-my @sleep_calls;
-{
-    no warnings 'redefine';
-    *ddclient::sleep = sub { push @sleep_calls, $_[0] };
+my $daemon_entry =
+       ddclient->can('main')
+    || ddclient->can('run')
+    || ddclient->can('daemon')
+    || BAIL_OUT('Unable to find a callable ddclient daemon entry point');
+
+sub capture_daemon_sleep_once {
+    my (%args) = @_;
+
+    @sleep_calls  = ();
+    @rand_args    = ();
+    @rand_returns = ($args{rand_return});
+    $sleep_duration = undef;
+
+    my $ok = eval {
+        local @ARGV = (
+            '--foreground',
+            "--file=$config_file",
+            "--daemon=$args{daemon}",
+            "--jitter=$args{jitter}",
+        );
+        $daemon_entry->();
+        1;
+    };
+
+    like($@, qr/__TEST_CAPTURED_SLEEP__/, 'daemon loop reached sleep and was intercepted')
+        unless $ok;
+
+    return defined $sleep_duration ? $sleep_duration : $sleep_calls[0];
 }
 
-# Compute jitter the same way ddclient does: int(rand($daemon * 0.2))
-sub compute_jitter {
-    my ($interval) = @_;
-    return int(rand($interval * 0.2));
+# Exercise the real daemon-path jitter handling: rand() is called with the
+# configured jitter, and the resulting delay remains an integer within the
+# expected [daemon, daemon + jitter) range.
+{
+    my $daemon = 300;
+    my $jitter = 60;
+    my $delay = capture_daemon_sleep_once(
+        daemon      => $daemon,
+        jitter      => $jitter,
+        rand_return => 17,
+    );
+
+    is(scalar @rand_args, 1, 'rand called exactly once when jitter is non-zero');
+    is($rand_args[0], $jitter, 'rand called with configured jitter');
+    cmp_ok($delay, '>=', $daemon, 'sleep delay is at least daemon interval');
+    cmp_ok($delay, '<', $daemon + $jitter, 'sleep delay is less than daemon + jitter');
+    is($delay, int($delay), 'sleep delay remains an integer');
 }
 
-# For a 5-minute (300s) interval, jitter must be in [0, 60).
-# Run several trials to ensure we never produce a value outside the range.
+# Zero jitter should not extend the daemon interval.
 {
-    my $interval = 300;
-    my $max_jitter = int($interval * 0.2);  # 60
-    my $out_of_range = 0;
-    for (1..200) {
-        my $j = compute_jitter($interval);
-        $out_of_range++ if $j < 0 || $j >= $max_jitter;
-        @sleep_calls = ();
-        ddclient::sleep($j) if $j > 0;
-        if ($j > 0) {
-            is($sleep_calls[0], $j, "sleep called with jitter value $j");
-        }
-    }
-    is($out_of_range, 0, "jitter always in [0, 60) for 300s interval");
-}
+    my $daemon = 300;
+    my $jitter = 0;
+    my $delay = capture_daemon_sleep_once(
+        daemon      => $daemon,
+        jitter      => $jitter,
+        rand_return => 0,
+    );
 
-# For a 1-second interval, int(rand(0.2)) is always 0 — sleep must not be called.
-{
-    my $interval = 1;
-    @sleep_calls = ();
-    my $jitter = compute_jitter($interval);
-    is($jitter, 0, "jitter is 0 for 1s interval");
-    ddclient::sleep($jitter) if $jitter > 0;
-    is(scalar @sleep_calls, 0, "sleep not called when jitter is 0");
-}
-
-# For a 0-second interval (daemon disabled), jitter must be 0.
-{
-    my $interval = 0;
-    my $jitter = compute_jitter($interval);
-    is($jitter, 0, "jitter is 0 for 0s interval");
+    is(scalar @rand_args, 0, 'rand not called when jitter is 0');
+    is($delay, $daemon, 'sleep delay matches daemon interval when jitter is 0');
 }
 
 done_testing();


### PR DESCRIPTION
Add jitter to spread API calls across clients and
reduce overloading upstream DNS provider when many
clients are running with same daemon interval.
 
For example, for a jitter of 60 seconds and a daemon
interval of 10 minutes, a jitter of [0, 60s) would
be applied to the the daemon interval.

This implementation is based on #878 by @jhutchings1.

Changes in this implementation (compared to #878):
- Added global `jitter` configuration defaulting to 20% of `daemon` if `daemon` is set
- Added an external knob to allow configurability (for example local `nsupdate` might be expected to be instantaneous)
- This would also allow changing the jitter (like `daemon`) as CLI param - particularly useful when ddclient is invoked via systemd service or systemd timer (for example using [`RandomizedDelaySec`](https://www.freedesktop.org/software/systemd/man/latest/systemd.timer.html#RandomizedDelaySec=)).