### PR TITLE
cloudflare: add support for the 'comment' config variable

### DIFF
--- a/ddclient.in
+++ b/ddclient.in
@@ -937,6 +937,7 @@ our %protocols = (
         'examples'   => \&nic_cloudflare_examples,
         'cfgvars' => {
             %{$cfgvars{'protocol-common-defaults'}},
+            'comment'      => setv(T_STRING, 0, undef,                          undef),
             'login'        => setv(T_LOGIN,  0, 'token',                        undef),
             'min-interval' => setv(T_DELAY,  0, interval('5m'),                 0),
             'server'       => setv(T_FQDNP,  0, 'api.cloudflare.com/client/v4', undef),
@@ -5985,7 +5986,9 @@ sub nic_cloudflare_update {
                 debug("DNS '$type' record ID: $dns_rec_id");
                 # Set domain
                 $url = "https://" . opt('server', $domain) . "/zones/$zone_id/dns_records/$dns_rec_id";
-                my $data = "{\"content\":\"$ip\"}";
+                my %patch = (content => $ip);
+                $patch{comment} = opt('comment', $domain) if defined(opt('comment', $domain));
+                my $data = encode_json(\%patch);
                 $reply = geturl(proxy => opt('proxy'),
                                 url => $url,
                                 headers => $headers,


### PR DESCRIPTION
## Summary

- Adds a new optional `comment` config variable to the `cloudflare` protocol
- When set, the comment is included in the PATCH request to the Cloudflare DNS API, which supports it natively
- Replaces the hand-interpolated JSON string with `encode_json` for correct escaping

Closes #826.

## Configuration example

```
protocol=cloudflare
zone='example.com'
login='token'
password='your-api-token'
comment='managed by ddclient'
example.com
```

## Test plan

- Tested live against the Cloudflare API: confirmed `comment` field is accepted in a PATCH to `/zones/{zone_id}/dns_records/{record_id}` and returned correctly in the response
- Verified ddclient sends `{"comment":"managed by ddclient","content":"<ip>"}` in the PATCH body when `comment=` is set
- Verified no regression when `comment=` is omitted: PATCH body is `{"content":"<ip>"}` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)