### PR TITLE
feat: add Dynu DDNS protocol

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -41,6 +41,9 @@ repository history](https://github.com/ddclient/ddclient/commits/main).
     [#850](https://github.com/ddclient/ddclient/pull/850)
   * Added `DynV6` (https://dynv6.com) as a supported `dyndns2` provider.
     Authenticate with your zone's HTTP token; no username required (`login=none`).
+  * Added `dynu` protocol for Dynu Systems (https://www.dynu.com/), with
+    dual-stack IPv4+IPv6 support and optional `zone=` for custom domain updates.
+    [#904](https://github.com/ddclient/ddclient/pull/904)
   * Added `deSEC` (https://desec.io) and `DDNSS.de` (https://ddnss.de) as
     supported `dyndns2` providers, with dedicated `desec-ipv4`/`desec-ipv6`
     web IP check services.

--- a/Makefile.am
+++ b/Makefile.am
@@ -77,6 +77,7 @@ handwritten_tests = \
 	t/protocol_dnsexit2.pl \
 	t/protocol_dynadot.pl \
 	t/protocol_dyndns2.pl \
+	t/protocol_dynu.pl \
 	t/protocol_hetzner.pl \
 	t/protocol_ionos.pl \
 	t/protocol_ns1.pl \

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Dynamic DNS services currently supported include:
   * [DslReports](https://www.dslreports.com)
   * [Duck DNS](https://duckdns.org)
   * [Dynadot](https://www.dynadot.com)
+  * [Dynu](https://www.dynu.com)
   * [DynDNS.com](https://account.dyn.com)
   * [DynV6](https://dynv6.com)
   * [EasyDNS](https://www.easydns.com)

--- a/ddclient.conf.in
+++ b/ddclient.conf.in
@@ -494,6 +494,14 @@ pid=@runstatedir@/ddclient.pid  # record PID in file.
 # 12345678
 
 ##
+## Dynu (https://www.dynu.com/)
+##
+# protocol=dynu                                                \
+# login=myusername                                             \
+# password=mypassword                                          \
+# myhome.dynu.net
+
+##
 ## Spaceship (https://www.spaceship.com/)
 ##
 # protocol=spaceship,                       \

--- a/ddclient.in
+++ b/ddclient.in
@@ -290,6 +290,7 @@ our %recapvars = (
 ## strategies for obtaining an ip address.
 our %builtinweb = (
     'dyndns' => {'url' => 'http://checkip.dyndns.org/', 'skip' => 'Current IP Address:'},
+    'dynu' => {'url' => 'https://checkip.dynu.com/'},
     'freedns' => {'url' => 'https://freedns.afraid.org/dynamic/check.php'},
     'he' => {
         url => 'https://checkip.dns.he.net/',
@@ -1082,6 +1083,15 @@ our %protocols = (
             %{$recapvars{'dyndns-common'}},
         },
         'force_update_if_changed' => [qw(wildcard mx backupmx)],
+    ),
+    'dynu' => ddclient::Protocol->new(
+        'update'   => \&nic_dynu_update,
+        'examples' => \&nic_dynu_examples,
+        'cfgvars'  => {
+            %{$cfgvars{'protocol-common-defaults'}},
+            'server' => setv(T_FQDNP, 0, 'api.dynu.com', undef),
+            'zone'   => setv(T_STRING, 0, undef,          undef),
+        },
     ),
     'easydns' => ddclient::Protocol->new(
         'update'     => \&nic_easydns_update,
@@ -4207,6 +4217,144 @@ sub nic_dyndns2_update {
         warning("unexpected extra lines after per-host update status lines:\n" .
                 join("\n", @reply[@hosts..$#reply]))
             if (@reply > @hosts);
+    }
+}
+
+######################################################################
+## nic_dynu_examples
+######################################################################
+sub nic_dynu_examples {
+    my $self = shift;
+    return <<"EoEXAMPLE";
+o 'dynu'
+
+The 'dynu' protocol is used by the dynamic DNS service offered by
+Dynu Systems, Inc. (www.dynu.com).
+API documentation: https://www.dynu.com/DynamicDNS/IP-Update-Protocol
+
+The password must be the plain text, MD5, or SHA-256 hash of your
+Dynu account password.
+
+Configuration variables applicable to the 'dynu' protocol are:
+  protocol=dynu             ##
+  server=api.dynu.com       ## defaults to api.dynu.com
+  login=your-login          ## Dynu account username
+  password=your-password    ## Dynu account password (or MD5/SHA-256 hash)
+  zone=your-root-domain     ## root domain registered with Dynu; required
+                            ## when updating a subdomain (e.g. zone=example.com
+                            ## to update host.example.com)
+  fully.qualified.host      ## the hostname to update
+
+Example ${program}.conf file entries:
+  ## Dynu free hostname (e.g. myhome.dynu.net) — IPv4 only
+  protocol=dynu                    \\
+  login=myusername                 \\
+  password=mypassword              \\
+  myhome.dynu.net
+
+  ## Dynu free hostname — dual-stack IPv4 and IPv6
+  usev4=webv4
+  usev6=ifv6, ifv6=eth0
+
+  protocol=dynu                    \\
+  login=myusername                 \\
+  password=mypassword              \\
+  myhome.dynu.net
+
+  ## Custom domain — update a subdomain (zone required)
+  usev4=webv4
+  usev6=ifv6, ifv6=eth0
+
+  protocol=dynu                    \\
+  login=myusername                 \\
+  password=mypassword              \\
+  zone=example.com                 \\
+  host.example.com
+EoEXAMPLE
+}
+
+######################################################################
+## nic_dynu_update
+##
+## based on https://www.dynu.com/DynamicDNS/IP-Update-Protocol
+######################################################################
+sub nic_dynu_update {
+    my $self = shift;
+    my %errors = (
+        'badauth'     => 'Bad authorization (username or password)',
+        'notfqdn'     => 'A Fully-Qualified Domain Name was not provided',
+        'nohost'      => 'The hostname specified does not exist',
+        '!donator'    => 'Feature restricted to members',
+        'numhost'     => 'Too many hostnames specified',
+        'abuse'       => 'Update blocked due to abusive behaviour',
+        'servererror' => 'Server error; retry later',
+        'dnserr'      => 'DNS error encountered; retry later',
+        '911'         => 'Server maintenance; retry in 10 minutes',
+        'nochg'       => 'IP address is current; no update required',
+    );
+    for my $group (group_hosts_by(\@_, qw(login password server zone wantipv4 wantipv6))) {
+        my @hosts = @{$group->{hosts}};
+        my %gcfg  = %{$group->{cfg}};
+        my $ipv4  = $gcfg{'wantipv4'};
+        my $ipv6  = $gcfg{'wantipv6'};
+        delete $config{$_}{'wantipv4'} for @hosts;
+        delete $config{$_}{'wantipv6'} for @hosts;
+        for my $h (@hosts) {
+            local $_l = pushlogctx($h);
+            info("setting IPv4 address to $ipv4") if $ipv4;
+            info("setting IPv6 address to $ipv6") if $ipv6;
+            # Derive hostname and alias from zone.
+            # Dynu requires hostname=zone&alias=subdomain for custom domains
+            # (e.g. zone=example.com, alias=host for host.example.com).
+            # Without zone, the full FQDN is used as hostname, which works
+            # for free Dynu subdomains (e.g. myhome.dynu.net).
+            my $zone = $gcfg{'zone'};
+            my ($hostname, $alias);
+            if (defined $zone) {
+                my $stripped = $h;
+                unless ($stripped =~ s/(?:^|\.)\Q$zone\E$//) {
+                    failed("hostname does not end with the zone: $zone");
+                    next;
+                }
+                $hostname = $zone;
+                $alias    = $stripped;
+            } else {
+                $hostname = $h;
+                $alias    = undef;
+            }
+            my $url = "$gcfg{'server'}/nic/update?hostname=$hostname";
+            $url .= "&alias=$alias" if defined $alias && $alias ne '';
+            $url .= "&myip=$ipv4"   if $ipv4;
+            $url .= "&myip=no"      if !$ipv4 && $ipv6;  # prevent server auto-detecting v4
+            $url .= "&myipv6=$ipv6" if $ipv6;
+            my $reply = geturl(
+                proxy    => opt('proxy'),
+                url      => $url,
+                login    => $gcfg{'login'},
+                password => $gcfg{'password'},
+            );
+            next if !header_ok($reply);
+            (my $body = $reply) =~ s/^.*?\n\n//s;
+            my ($status) = split(/\s/, $body);
+            $status //= 'unknown';
+            if ($status eq 'nochg') {
+                warning("$status: $errors{$status}");
+                $status = 'good';
+            }
+            $recap{$h}{'status-ipv4'} = $status if $ipv4;
+            $recap{$h}{'status-ipv6'} = $status if $ipv6;
+            if ($status ne 'good') {
+                failed(exists($errors{$status})
+                    ? "$status: $errors{$status}"
+                    : "unknown error: $status");
+                next;
+            }
+            $recap{$h}{'ipv4'}  = $ipv4 if $ipv4;
+            $recap{$h}{'ipv6'}  = $ipv6 if $ipv6;
+            $recap{$h}{'mtime'} = $now;
+            success("IPv4 address set to $ipv4") if $ipv4;
+            success("IPv6 address set to $ipv6") if $ipv6;
+        }
     }
 }
 

--- a/t/protocol_dynu.pl
+++ b/t/protocol_dynu.pl
@@ -1,0 +1,166 @@
+use Test::More;
+BEGIN { SKIP: { eval { require Test::Warnings; 1; } or skip($@, 1); } }
+use MIME::Base64;
+BEGIN { eval { require 'ddclient'; } or BAIL_OUT($@); }
+use ddclient::t::HTTPD;
+use ddclient::t::Logger;
+
+httpd_required();
+
+httpd()->run(sub {
+    my ($req) = @_;
+    diag('==============================================================================');
+    diag("Test server received request:\n" . $req->as_string());
+    return undef if $req->uri()->path() eq '/control';
+    my $wantauthn = 'Basic ' . encode_base64('username:password', '');
+    return [401, [@$textplain, 'www-authenticate' => 'Basic realm="realm", charset="UTF-8"'],
+            ['authentication required']] if ($req->header('authorization') // '') ne $wantauthn;
+    return [400, $textplain, ['invalid method: ' . $req->method()]] if $req->method() ne 'GET';
+    return undef;
+});
+
+my @test_cases = (
+    {
+        desc => 'IPv4 only, good',
+        cfg => {'myhome.dynu.net' => {wantipv4 => '192.0.2.1'}},
+        resp => ['good'],
+        wantquery => 'hostname=myhome.dynu.net&myip=192.0.2.1',
+        wantrecap => {
+            'myhome.dynu.net' => {'status-ipv4' => 'good', 'ipv4' => '192.0.2.1', 'mtime' => $ddclient::now},
+        },
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['myhome.dynu.net'], msg => qr/IPv4/},
+        ],
+    },
+    {
+        desc => 'IPv6 only, good',
+        cfg => {'myhome.dynu.net' => {wantipv6 => '2001:db8::1'}},
+        resp => ['good'],
+        wantquery => 'hostname=myhome.dynu.net&myip=no&myipv6=2001:db8::1',
+        wantrecap => {
+            'myhome.dynu.net' => {'status-ipv6' => 'good', 'ipv6' => '2001:db8::1', 'mtime' => $ddclient::now},
+        },
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['myhome.dynu.net'], msg => qr/IPv6/},
+        ],
+    },
+    {
+        desc => 'dual-stack IPv4+IPv6, good',
+        cfg => {'myhome.dynu.net' => {wantipv4 => '192.0.2.1', wantipv6 => '2001:db8::1'}},
+        resp => ['good'],
+        wantquery => 'hostname=myhome.dynu.net&myip=192.0.2.1&myipv6=2001:db8::1',
+        wantrecap => {
+            'myhome.dynu.net' => {
+                'status-ipv4' => 'good', 'ipv4' => '192.0.2.1',
+                'status-ipv6' => 'good', 'ipv6' => '2001:db8::1',
+                'mtime' => $ddclient::now,
+            },
+        },
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['myhome.dynu.net'], msg => qr/IPv4/},
+            {label => 'SUCCESS', ctx => ['myhome.dynu.net'], msg => qr/IPv6/},
+        ],
+    },
+    {
+        desc => 'nochg treated as good',
+        cfg => {'myhome.dynu.net' => {wantipv4 => '192.0.2.1'}},
+        resp => ['nochg'],
+        wantquery => 'hostname=myhome.dynu.net&myip=192.0.2.1',
+        wantrecap => {
+            'myhome.dynu.net' => {'status-ipv4' => 'good', 'ipv4' => '192.0.2.1', 'mtime' => $ddclient::now},
+        },
+        wantlogs => [
+            {label => 'WARNING', ctx => ['myhome.dynu.net'], msg => qr/nochg/},
+            {label => 'SUCCESS', ctx => ['myhome.dynu.net'], msg => qr/IPv4/},
+        ],
+    },
+    {
+        desc => 'error response',
+        cfg => {'myhome.dynu.net' => {wantipv4 => '192.0.2.1'}},
+        resp => ['badauth'],
+        wantquery => 'hostname=myhome.dynu.net&myip=192.0.2.1',
+        wantrecap => {
+            'myhome.dynu.net' => {'status-ipv4' => 'badauth'},
+        },
+        wantlogs => [
+            {label => 'FAILED', ctx => ['myhome.dynu.net'], msg => qr/badauth/},
+        ],
+    },
+    {
+        desc => 'zone: hostname+alias construction',
+        cfg => {'host.example.com' => {zone => 'example.com', wantipv4 => '192.0.2.1'}},
+        resp => ['good'],
+        wantquery => 'hostname=example.com&alias=host&myip=192.0.2.1',
+        wantrecap => {
+            'host.example.com' => {'status-ipv4' => 'good', 'ipv4' => '192.0.2.1', 'mtime' => $ddclient::now},
+        },
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv4/},
+        ],
+    },
+    {
+        desc => 'zone mismatch: hostname outside zone',
+        cfg => {'host.other.com' => {zone => 'example.com', wantipv4 => '192.0.2.1'}},
+        wantrecap => {},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['host.other.com'], msg => qr/does not end with the zone/},
+        ],
+    },
+);
+
+for my $tc (@test_cases) {
+    diag('==============================================================================');
+    diag("Starting test: $tc->{desc}");
+    diag('==============================================================================');
+    local $ddclient::globals{debug} = 1;
+    local $ddclient::globals{verbose} = 1;
+    my $l = ddclient::t::Logger->new($ddclient::_l, qr/^(?:WARNING|FATAL|SUCCESS|FAILED)$/);
+    local %ddclient::config;
+    local %ddclient::recap;
+    $ddclient::config{$_} = {
+        login    => 'username',
+        password => 'password',
+        server   => httpd()->endpoint(),
+        %{$tc->{cfg}{$_}},
+    } for keys(%{$tc->{cfg}});
+    httpd()->reset([200, $textplain, [map("$_\n", @{$tc->{resp}})]]) if defined $tc->{resp};
+    {
+        local $ddclient::_l = $l;
+        ddclient::nic_dynu_update(undef, sort(keys(%{$tc->{cfg}})));
+    }
+    my @requests = httpd()->reset();
+    if (defined $tc->{wantquery}) {
+        is(scalar(@requests), 1, "$tc->{desc}: single update request");
+        my $req = shift(@requests);
+        is($req->uri()->path(), '/nic/update', "$tc->{desc}: request path");
+        is($req->uri()->query(), $tc->{wantquery}, "$tc->{desc}: request query");
+    } else {
+        is(scalar(@requests), 0, "$tc->{desc}: no requests sent");
+    }
+    is_deeply(\%ddclient::recap, $tc->{wantrecap}, "$tc->{desc}: recap")
+        or diag(ddclient::repr(Values => [\%ddclient::recap, $tc->{wantrecap}],
+                               Names => ['*got', '*want']));
+    $tc->{wantlogs} //= [];
+    subtest("$tc->{desc}: logs" => sub {
+        my @got = @{$l->{logs}};
+        my @want = @{$tc->{wantlogs}};
+        for my $i (0..$#want) {
+            last if $i >= @got;
+            my $got = $got[$i];
+            my $want = $want[$i];
+            subtest("log $i" => sub {
+                is($got->{label}, $want->{label}, "label matches");
+                is_deeply($got->{ctx}, $want->{ctx}, "context matches");
+                like($got->{msg}, $want->{msg}, "message matches");
+            }) or diag(ddclient::repr(Values => [$got, $want], Names => ['*got', '*want']));
+        }
+        my @unexpected = @got[@want..$#got];
+        ok(@unexpected == 0, "no unexpected logs")
+            or diag(ddclient::repr(\@unexpected, Names => ['*unexpected']));
+        my @missing = @want[@got..$#want];
+        ok(@missing == 0, "no missing logs")
+            or diag(ddclient::repr(\@missing, Names => ['*missing']));
+    });
+}
+
+done_testing();


### PR DESCRIPTION
## Summary

- Adds a new `dynu` protocol for [Dynu Systems](https://www.dynu.com) dynamic DNS
- Adds `checkip.dynu.com` to `%builtinweb` as the `'dynu'` web IP source
- Adds Dynu to the supported services list in `README.md`

## Why a new protocol instead of reusing dyndns2?

Dynu's API is DynDNS2-compatible for single-stack updates, but for dual-stack the two protocols differ:

- **dyndns2** sends a single `myip=v4,v6` (comma-separated)
- **Dynu** requires separate parameters: `myip=v4&myipv6=v6`

This difference makes a dedicated protocol necessary for correct dual-stack behaviour.

## Zone / alias support

Dynu free subdomains (e.g. `myhome.dynu.net`) use `hostname=myhome.dynu.net`. Custom domain subdomain updates require `hostname=example.com&alias=host`. The optional `zone=` config variable triggers this form automatically by stripping the zone suffix from the FQDN.

## Test plan

- [x] `make VERBOSE=1 check` — 749 pass, 6 skip, 0 fail
- [ ] Live test against Dynu API with a free account

Closes #688

🤖 Generated with [Claude Code](https://claude.com/claude-code)