### PR TITLE
feat: add NS1 (IBM NS1 Connect) DNS protocol

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,8 @@ repository history](https://github.com/ddclient/ddclient/commits/main).
     [#888](https://github.com/ddclient/ddclient/pull/888)
   * Added `simply.com` (https://www.simply.com).
     [#850](https://github.com/ddclient/ddclient/pull/850)
+  * Added `ns1` protocol for NS1 / IBM NS1 Connect (https://ns1.com/).
+    [#907](https://github.com/ddclient/ddclient/pull/907)
   * Added `spaceship` protocol for Spaceship (https://www.spaceship.com/).
     [#896](https://github.com/ddclient/ddclient/pull/896)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -76,6 +76,7 @@ handwritten_tests = \
 	t/protocol_dnsexit2.pl \
 	t/protocol_dyndns2.pl \
 	t/protocol_hetzner.pl \
+	t/protocol_ns1.pl \
 	t/protocol_simplycom.pl \
 	t/protocol_spaceship.pl \
 	t/read_recap.pl \

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Dynamic DNS services currently supported include:
   * [NearlyFreeSpeech.net](https://www.nearlyfreespeech.net/services/dns)
   * [Njalla](https://njal.la/docs/ddns)
   * [Noip](https://www.noip.com)
+  * [NS1 / IBM NS1 Connect](https://ns1.com)
   * nsupdate - see nsupdate(1) and ddns-confgen(8)
   * [OVH](https://www.ovhcloud.com)
   * [Porkbun](https://porkbun.com)

--- a/ddclient.conf.in
+++ b/ddclient.conf.in
@@ -447,6 +447,14 @@ pid=@runstatedir@/ddclient.pid  # record PID in file.
 # myhost.example.org
 
 ##
+## NS1 / IBM NS1 Connect (https://ns1.com/)
+##
+# protocol=ns1                                                 \
+# login=myapikey                                               \
+# zone=example.com                                             \
+# myhost.example.com
+
+##
 ## Spaceship (https://www.spaceship.com/)
 ##
 # protocol=spaceship,                       \

--- a/ddclient.in
+++ b/ddclient.in
@@ -1209,6 +1209,17 @@ our %protocols = (
             'server' => setv(T_FQDNP, 0, 'dynupdate.no-ip.com', undef),
         },
     ),
+    'ns1' => ddclient::Protocol->new(
+        'update'   => \&nic_ns1_update,
+        'examples' => \&nic_ns1_examples,
+        'cfgvars'  => {
+            %{$cfgvars{'protocol-common-defaults'}},
+            'login'  => undef,
+            'zone'   => setv(T_FQDN,   0, undef,              undef),
+            'ttl'    => setv(T_NUMBER, 0, 300,                undef),
+            'server' => setv(T_FQDNP,  0, 'api.nsone.net/v1', undef),
+        },
+    ),
     'nsupdate' => ddclient::Protocol->new(
         'update'     => \&nic_nsupdate_update,
         'examples'   => \&nic_nsupdate_examples,
@@ -2173,7 +2184,7 @@ sub init_config {
     load_sha1_support(join(', ', @needs_sha1)) if @needs_sha1;
     my @needs_json = grep({ my $p = $_; grep($_ eq $p, @protos); }
                           qw(1984 cloudflare digitalocean directnic dnsexit2 gandi godaddy hetzner
-                             nfsn njalla porkbun spaceship yandex));
+                             nfsn njalla ns1 porkbun spaceship yandex));
     load_json_support(join(', ', @needs_json)) if @needs_json;
 }
 
@@ -5778,6 +5789,166 @@ sub nic_mythicdyn_update {
             }
         }
     }
+}
+
+######################################################################
+## nic_ns1_examples
+######################################################################
+sub nic_ns1_examples {
+    my $self = shift;
+    return <<"EoEXAMPLE";
+o 'ns1'
+
+The 'ns1' protocol is used by NS1 / IBM NS1 Connect (ns1.com).
+
+Before configuring, create an API key in the NS1 portal (my.nsone.net) under
+Account Settings > Users & Teams > API Keys with DNS read and write permissions.
+
+Configuration variables applicable to the 'ns1' protocol are:
+  protocol=ns1                 ##
+  server=fqdn.of.service       ## can be omitted, defaults to api.nsone.net/v1
+  zone=dns.zone                ## optional; root DNS zone.  Inferred from hostname if omitted.
+  login=service-login          ## NS1 API key
+  ttl=seconds                  ## optional; DNS record TTL in seconds.  Defaults to 300.
+  fully.qualified.host         ## the host registered with the service.
+
+Example \${program}.conf file entries:
+  protocol=ns1                                                 \\
+  login=myapikey                                               \\
+  zone=example.com                                             \\
+  myhost.example.com
+
+EoEXAMPLE
+}
+
+######################################################################
+## nic_ns1_update
+######################################################################
+sub nic_ns1_update {
+    my $self = shift;
+    for my $h (@_) {
+        local $_l = pushlogctx($h);
+        my $domain;
+        if (opt('zone', $h)) {
+            $domain = opt('zone', $h);
+            if ($h !~ /(?:^|\.)\Q$domain\E$/) {
+                failed("hostname '$h' does not end with zone '$domain'");
+                next;
+            }
+        } else {
+            my @labels = split(/\./, $h);
+            if (@labels < 2) {
+                failed("cannot infer zone from '$h': no dot in hostname; use zone=");
+                next;
+            }
+            $domain = @labels == 2 ? $h : (split(/\./, $h, 2))[1];
+        }
+
+        for my $ipv ('4', '6') {
+            my $ip = delete $config{$h}{"wantipv$ipv"} or next;
+            my $rrtype = $ipv eq '4' ? 'A' : 'AAAA';
+            info("setting IPv$ipv address to $ip");
+
+            my $get_resp = _ns1_call(
+                server  => opt('server', $h),
+                method  => 'GET',
+                path    => "/zones/$domain/$h/$rrtype",
+                api_key => opt('login', $h),
+            );
+
+            if (!defined $get_resp) {
+                $recap{$h}{"status-ipv$ipv"} = 'failed';
+                next;
+            }
+
+            my $ttl  = opt('ttl', $h);
+            my $body = encode_json({
+                answers => [{ answer => [$ip] }],
+                ttl     => $ttl + 0,
+            });
+
+            my $exists      = ref($get_resp) eq 'HASH' && exists $get_resp->{type};
+            my $update_resp = _ns1_call(
+                server  => opt('server', $h),
+                method  => $exists ? 'POST' : 'PUT',
+                path    => "/zones/$domain/$h/$rrtype",
+                api_key => opt('login', $h),
+                body    => $body,
+            );
+
+            if (!defined $update_resp) {
+                $recap{$h}{"status-ipv$ipv"} = 'failed';
+                next;
+            }
+
+            $recap{$h}{"ipv$ipv"}        = $ip;
+            $recap{$h}{'mtime'}          = $now;
+            $recap{$h}{"status-ipv$ipv"} = 'good';
+            success("IPv$ipv address set to $ip");
+        }
+    }
+}
+
+######################################################################
+## _ns1_call: make an authenticated NS1 API call
+######################################################################
+sub _ns1_call {
+    my (%args) = @_;
+    my $server  = delete $args{server};
+    my $method  = delete $args{method};
+    my $path    = delete $args{path};
+    my $api_key = delete $args{api_key};
+    my $body    = delete $args{body} // '';
+
+    my $url   = "$server$path";
+    my $reply = geturl(
+        proxy   => opt('proxy'),
+        url     => $url,
+        method  => $method,
+        headers => [
+            'Content-Type: application/json',
+            'Accept: application/json',
+            "X-NSONE-Key: $api_key",
+        ],
+        ($body ? (data => $body) : ()),
+    );
+
+    if (!$reply) {
+        failed("could not connect to $server");
+        return undef;
+    }
+
+    my ($status) = ($reply =~ m{^HTTP/\S+\s+(\d+)}i);
+    if (!defined $status) {
+        failed("unexpected HTTP response from $server");
+        return undef;
+    }
+    (my $resp_body = $reply) =~ s/^.*?\n\n//s;
+    $resp_body =~ s/^\s+|\s+$//g;
+
+    if ($status == 404 && $method eq 'GET') {
+        return {};
+    }
+
+    if ($status !~ /^2/) {
+        my $detail = '';
+        if ($resp_body) {
+            my $parsed = eval { decode_json($resp_body) };
+            $detail = ": $parsed->{message}"
+                if ref($parsed) eq 'HASH' && defined $parsed->{message};
+        }
+        failed("API error $status$detail");
+        return undef;
+    }
+
+    return {} if !$resp_body;
+
+    my $parsed = eval { decode_json($resp_body) };
+    if (!defined $parsed) {
+        failed("unexpected API response: $resp_body");
+        return undef;
+    }
+    return $parsed;
 }
 
 ######################################################################

--- a/t/protocol_ns1.pl
+++ b/t/protocol_ns1.pl
@@ -1,0 +1,368 @@
+use Test::More;
+BEGIN { SKIP: { eval { require Test::Warnings; 1; } or skip($@, 1); } }
+BEGIN { eval { require JSON::PP; 1; } or plan(skip_all => $@); JSON::PP->import(); }
+BEGIN { eval { require 'ddclient'; } or BAIL_OUT($@); }
+use ddclient::t::HTTPD;
+use ddclient::t::Logger;
+
+httpd_required();
+
+ddclient::load_json_support('ns1');
+
+my $j = ['Content-Type' => 'application/json'];
+
+sub record_resp {
+    my ($ip, $type) = @_;
+    encode_json({
+        zone    => 'example.com',
+        domain  => 'host.example.com',
+        type    => $type // 'A',
+        answers => [{ answer => [$ip] }],
+        ttl     => 3600,
+    });
+}
+
+httpd()->run();
+
+my @test_cases = (
+    {
+        desc => 'IPv4 success, no existing record (PUT)',
+        cfg => {'host.example.com' => {
+            protocol => 'ns1',
+            login    => 'myapikey',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [404, $j, [encode_json({message => 'record not found'})]],
+            [200, $j, [record_resp('192.0.2.1')]],
+        ],
+        wantrecap => {'host.example.com' => {
+            'status-ipv4' => 'good',
+            'ipv4'        => '192.0.2.1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv4/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 2, 'exactly 2 requests: GET + PUT');
+            is($reqs[0]->method(), 'GET', 'first request is GET');
+            like($reqs[0]->uri()->path(), qr{/zones/example\.com/host\.example\.com/A}, 'GET path correct');
+            is($reqs[1]->method(), 'PUT', 'second request is PUT (new record)');
+            my $body = decode_json($reqs[1]->content());
+            is($body->{answers}[0]{answer}[0], '192.0.2.1', 'PUT answer correct');
+            is($body->{ttl}, 300, 'PUT ttl defaults to 300');
+        },
+    },
+    {
+        desc => 'IPv4 success, existing record updated (POST)',
+        cfg => {'host.example.com' => {
+            protocol => 'ns1',
+            login    => 'myapikey',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.2',
+        }},
+        responses => [
+            [200, $j, [record_resp('192.0.2.99')]],
+            [200, $j, [record_resp('192.0.2.2')]],
+        ],
+        wantrecap => {'host.example.com' => {
+            'status-ipv4' => 'good',
+            'ipv4'        => '192.0.2.2',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv4/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 2, 'exactly 2 requests: GET + POST');
+            is($reqs[0]->method(), 'GET',  'first request is GET');
+            is($reqs[1]->method(), 'POST', 'second request is POST (update existing)');
+            my $body = decode_json($reqs[1]->content());
+            is($body->{answers}[0]{answer}[0], '192.0.2.2', 'POST answer correct');
+        },
+    },
+    {
+        desc => 'IPv6 success, no existing record',
+        cfg => {'host.example.com' => {
+            protocol => 'ns1',
+            login    => 'myapikey',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv6 => '2001:db8::1',
+        }},
+        responses => [
+            [404, $j, [encode_json({message => 'record not found'})]],
+            [200, $j, [record_resp('2001:db8::1', 'AAAA')]],
+        ],
+        wantrecap => {'host.example.com' => {
+            'status-ipv6' => 'good',
+            'ipv6'        => '2001:db8::1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv6/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 2, 'exactly 2 requests');
+            like($reqs[0]->uri()->path(), qr{/AAAA$}, 'GET path ends with AAAA');
+            is($reqs[1]->method(), 'PUT', 'PUT for new AAAA record');
+            my $body = decode_json($reqs[1]->content());
+            is($body->{answers}[0]{answer}[0], '2001:db8::1', 'PUT answer correct');
+        },
+    },
+    {
+        desc => 'both IPv4 and IPv6 success',
+        cfg => {'host.example.com' => {
+            protocol => 'ns1',
+            login    => 'myapikey',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+            wantipv6 => '2001:db8::1',
+        }},
+        responses => [
+            [404, $j, [encode_json({message => 'not found'})]],
+            [200, $j, [record_resp('192.0.2.1')]],
+            [404, $j, [encode_json({message => 'not found'})]],
+            [200, $j, [record_resp('2001:db8::1', 'AAAA')]],
+        ],
+        wantrecap => {'host.example.com' => {
+            'status-ipv4' => 'good', 'ipv4' => '192.0.2.1',
+            'status-ipv6' => 'good', 'ipv6' => '2001:db8::1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv4/},
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv6/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 4, '4 requests: GET+PUT for each version');
+            is($reqs[0]->method(), 'GET', 'first GET');
+            is($reqs[1]->method(), 'PUT', 'first PUT');
+            is($reqs[2]->method(), 'GET', 'second GET');
+            is($reqs[3]->method(), 'PUT', 'second PUT');
+        },
+    },
+    {
+        desc => 'custom TTL is sent',
+        cfg => {'host.example.com' => {
+            protocol => 'ns1',
+            login    => 'myapikey',
+            zone     => 'example.com',
+            ttl      => 600,
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [404, $j, [encode_json({message => 'not found'})]],
+            [200, $j, [record_resp('192.0.2.1')]],
+        ],
+        wantrecap => {'host.example.com' => {
+            'status-ipv4' => 'good',
+            'ipv4'        => '192.0.2.1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv4/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            my $body = decode_json($reqs[1]->content());
+            is($body->{ttl}, 600, 'custom TTL 600 is sent');
+        },
+    },
+    {
+        desc => 'zone inferred from hostname when not set',
+        cfg => {'host.example.com' => {
+            protocol => 'ns1',
+            login    => 'myapikey',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [404, $j, [encode_json({message => 'not found'})]],
+            [200, $j, [record_resp('192.0.2.1')]],
+        ],
+        wantrecap => {'host.example.com' => {
+            'status-ipv4' => 'good',
+            'ipv4'        => '192.0.2.1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv4/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            like($reqs[0]->uri()->path(), qr{/zones/example\.com/}, 'inferred zone used in path');
+        },
+    },
+    {
+        desc => 'correct auth header sent',
+        cfg => {'host.example.com' => {
+            protocol => 'ns1',
+            login    => 'supersecretkey',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [404, $j, [encode_json({message => 'not found'})]],
+            [200, $j, [record_resp('192.0.2.1')]],
+        ],
+        wantrecap => {'host.example.com' => {
+            'status-ipv4' => 'good',
+            'ipv4'        => '192.0.2.1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv4/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is($reqs[0]->header('X-NSONE-Key'), 'supersecretkey', 'X-NSONE-Key header correct');
+        },
+    },
+    {
+        desc => 'API auth failure (401)',
+        cfg => {'host.example.com' => {
+            protocol => 'ns1',
+            login    => 'badkey',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [401, $j, [encode_json({message => 'Unauthorized'})]],
+        ],
+        wantrecap => {'host.example.com' => {'status-ipv4' => 'failed'}},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['host.example.com'], msg => qr/API error 401.*Unauthorized/},
+        ],
+    },
+    {
+        desc => 'PUT fails after 404 GET',
+        cfg => {'host.example.com' => {
+            protocol => 'ns1',
+            login    => 'myapikey',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [404, $j, [encode_json({message => 'not found'})]],
+            [500, $j, [encode_json({message => 'Internal Server Error'})]],
+        ],
+        wantrecap => {'host.example.com' => {'status-ipv4' => 'failed'}},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['host.example.com'], msg => qr/API error 500/},
+        ],
+    },
+    {
+        desc => 'hostname does not end with zone',
+        cfg => {'other.example.org' => {
+            protocol => 'ns1',
+            login    => 'myapikey',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [],
+        wantrecap => {},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['other.example.org'], msg => qr/does not end with zone/},
+        ],
+    },
+    {
+        desc => 'bare hostname without dot fails with useful error',
+        cfg => {'localhostname' => {
+            protocol => 'ns1',
+            login    => 'myapikey',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [],
+        wantrecap => {},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['localhostname'], msg => qr/no dot in hostname.*use zone=/},
+        ],
+    },
+    {
+        desc => 'apex domain inferred as zone when hostname has exactly one dot',
+        cfg => {'example.com' => {
+            protocol => 'ns1',
+            login    => 'myapikey',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [404, $j, [encode_json({message => 'not found'})]],
+            [200, $j, [record_resp('192.0.2.1')]],
+        ],
+        wantrecap => {'example.com' => {
+            'status-ipv4' => 'good',
+            'ipv4'        => '192.0.2.1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['example.com'], msg => qr/IPv4/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            like($reqs[0]->uri()->path(), qr{/zones/example\.com/example\.com/A}, 'apex zone used in path');
+        },
+    },
+);
+
+for my $tc (@test_cases) {
+    subtest($tc->{desc} => sub {
+        local $ddclient::globals{debug}   = 1;
+        local $ddclient::globals{verbose} = 1;
+        local %ddclient::config  = %{$tc->{cfg}};
+        local %ddclient::recap;
+
+        httpd()->reset(@{$tc->{responses}});
+
+        my $l = ddclient::t::Logger->new($ddclient::_l, qr/^(?:WARNING|FATAL|SUCCESS|FAILED)$/);
+        {
+            local $ddclient::_l = $l;
+            ddclient::nic_ns1_update(undef, sort(keys(%{$tc->{cfg}})));
+        }
+
+        my @reqs = httpd()->reset();
+
+        is_deeply(\%ddclient::recap, $tc->{wantrecap}, 'recap matches')
+            or diag(ddclient::repr(Values => [\%ddclient::recap, $tc->{wantrecap}],
+                                   Names  => ['*got', '*want']));
+
+        subtest('logs' => sub {
+            my @got  = @{$l->{logs}};
+            my @want = @{$tc->{wantlogs} // []};
+            for my $i (0..$#want) {
+                last if $i >= @got;
+                subtest("log $i" => sub {
+                    is($got[$i]{label}, $want[$i]{label}, 'label');
+                    is_deeply($got[$i]{ctx}, $want[$i]{ctx}, 'context');
+                    like($got[$i]{msg}, $want[$i]{msg}, 'message');
+                });
+            }
+            my @unexpected = @got[@want..$#got];
+            ok(@unexpected == 0, 'no unexpected logs')
+                or diag(ddclient::repr(\@unexpected, Names => ['*unexpected']));
+            my @missing = @want[@got..$#want];
+            ok(@missing == 0, 'no missing logs')
+                or diag(ddclient::repr(\@missing, Names => ['*missing']));
+        });
+
+        $tc->{check_reqs}->(@reqs) if $tc->{check_reqs};
+    });
+}
+
+done_testing();


### PR DESCRIPTION
## Summary

- Implements `protocol=ns1` for updating A/AAAA records hosted at NS1 (ns1.com), now part of IBM NS1 Connect, via the NS1 REST API
- Adds `nic_ns1_update`, `nic_ns1_examples`, and supporting helpers to `ddclient.in`
- Registers NS1 in `@needs_json` in `init_config` (consistent with the pattern established in #896)
- Adds a full test suite at `t/protocol_ns1.pl` covering both IPv4 and IPv6 updates, zone-inference, error responses, and missing-zone guards
- TTL default set to 300 s (appropriate for dynamic DNS)

Closes #630.

## Example config

```
## NS1 / IBM NS1 Connect (https://ns1.com)
## API key from: Account Settings > Users & Teams > API Keys (DNS read/write)
protocol=ns1,                   \
login=your-api-key,             \
zone=example.com,               \
myhost.example.com
```

`zone=` is optional when the hostname contains a dot — ddclient infers it from the hostname. The `server=` default is `api.nsone.net/v1`.

## Notes

- Applies lessons from the PR #896 (Spaceship) review cycle: `@needs_json` registration, terse `##`-comment example style, guard for undefined `$domain` when `zone=` is omitted on a bare hostname
- Tested end-to-end by @dkoppenh on Ubuntu against a live NS1 account (see issue #630)

## Test plan

- [ ] `make check` / `prove t/protocol_ns1.pl` passes
- [ ] Manual test: `ddclient --foreground --debug --verbose` against a live NS1 account
- [ ] Confirm `zone=` inference works when hostname is `myhost.example.com` (no explicit `zone=`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)