### PR TITLE
feat: add ASUS DDNS (asuscomm) protocol

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -28,6 +28,9 @@ repository history](https://github.com/ddclient/ddclient/commits/main).
     [#907](https://github.com/ddclient/ddclient/pull/907)
   * Added `spaceship` protocol for Spaceship (https://www.spaceship.com/).
     [#896](https://github.com/ddclient/ddclient/pull/896)
+  * Added `asuscomm` protocol for ASUS DDNS (https://www.asuscomm.com/), with
+    support for both `asuscomm.com` and `asuscomm.cn` (mainland China).
+    [#909](https://github.com/ddclient/ddclient/pull/909)
 
 ## 2026-05-16 v4.0.1-rc.1
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -71,6 +71,7 @@ handwritten_tests = \
 	t/logmsg.pl \
 	t/jitter.pl \
 	t/parse_assignments.pl \
+	t/protocol_asuscomm.pl \
 	t/protocol_cloudflare.pl \
 	t/protocol_directnic.pl \
 	t/protocol_dnsexit2.pl \

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ your dynamic DNS provider(s): <https://github.com/troglobit/inadyn> or
 Dynamic DNS services currently supported include:
 
   * [1984.is](https://www.1984.is/product/freedns)
+  * [ASUS DDNS](https://www.asuscomm.com)
   * [ChangeIP](https://www.changeip.com)
   * [CloudFlare](https://www.cloudflare.com)
   * [ClouDNS](https://www.cloudns.net)

--- a/ddclient.conf.in
+++ b/ddclient.conf.in
@@ -455,6 +455,17 @@ pid=@runstatedir@/ddclient.pid  # record PID in file.
 # myhost.example.com
 
 ##
+##
+## ASUS DDNS (https://www.asuscomm.com/)
+##
+## MAC address and WPS PIN are printed on the label on the bottom of the router.
+## Register the hostname first via the router's web interface (WAN → DDNS).
+# protocol=asuscomm,                       \
+# login=001122AABBCC,                      \ # router MAC address, no colons, uppercase
+# password=12345670                        \ # WPS PIN (secret_code from router label)
+# myhost.asuscomm.com
+
+##
 ## Spaceship (https://www.spaceship.com/)
 ##
 # protocol=spaceship,                       \

--- a/ddclient.in
+++ b/ddclient.in
@@ -34,6 +34,7 @@ use Data::Dumper;
 use File::Basename;
 use File::Path qw(make_path);
 use File::Temp;
+use Digest::MD5 qw(md5);
 use Getopt::Long;
 use Sys::Hostname;
 
@@ -928,6 +929,14 @@ our %protocols = (
             %{$cfgvars{'protocol-common-defaults'}},
             'login' => undef,
             'server' => setv(T_FQDNP, 0, 'api.1984.is', undef),
+        },
+    ),
+    'asuscomm' => ddclient::Protocol->new(
+        'update'   => \&nic_asuscomm_update,
+        'examples' => \&nic_asuscomm_examples,
+        'cfgvars'  => {
+            %{$cfgvars{'protocol-common-defaults'}},
+            'server' => setv(T_FQDNP, 0, 'ns1.asuscomm.com', undef),
         },
     ),
     'changeip' => ddclient::LegacyProtocol->new(
@@ -5475,6 +5484,116 @@ sub nic_1984_update {
             success("skipped: IP was already set to $response->{ip}");
         } else {
             success("updated successfully to $response->{ip}");
+        }
+    }
+}
+
+######################################################################
+## nic_asuscomm_examples
+######################################################################
+sub nic_asuscomm_examples {
+    my $self = shift;
+    return <<"EoEXAMPLE";
+o 'asuscomm'
+
+The 'asuscomm' protocol updates ASUS DDNS hostnames under asuscomm.com
+(and asuscomm.cn for mainland China).
+
+The hostname must be registered first via the router's web interface
+(WAN → DDNS) before ddclient can update it.
+
+Configuration variables applicable to the 'asuscomm' protocol are:
+  protocol=asuscomm            ##
+  server=ns1.asuscomm.com      ## can be omitted; use ns1.asuscomm.cn for China
+  login=001122AABBCC           ## router MAC address — hex digits only, no colons, uppercase
+  password=12345670            ## WPS PIN (secret_code from the router label)
+  myhost.asuscomm.com          ## full hostname registered with ASUS DDNS
+
+Example ${program}.conf file entries:
+  ## ASUS router DDNS (asuscomm.com)
+  ## MAC and WPS PIN are printed on the label on the bottom of the router.
+  protocol=asuscomm,                                        \\
+  login=001122AABBCC,                                       \\
+  password=12345670                                         \\
+  myhost.asuscomm.com
+EoEXAMPLE
+}
+
+######################################################################
+## nic_asuscomm_update
+##
+## ASUS DDNS update protocol.  Authentication uses HTTP Basic Auth where
+## the username is the router MAC address and the password is an
+## HMAC-MD5 digest computed from the stripped hostname and IP using the
+## WPS PIN as the key.  Response codes are returned in the HTTP body.
+##
+## Reference: asuswrt-merlin.ng inadyn plugin (plugins/asuscomm.c)
+######################################################################
+sub _asuscomm_hmac_md5 {
+    my ($data, $key) = @_;
+    my $bs   = 64;
+    $key     = md5($key) if length($key) > $bs;
+    $key    .= "\x00" x ($bs - length($key));
+    my $ipad = $key ^ ("\x36" x $bs);
+    my $opad = $key ^ ("\x5c" x $bs);
+    return uc(unpack('H*', md5($opad . md5($ipad . $data))));
+}
+
+sub nic_asuscomm_update {
+    my $self = shift;
+    for my $domain (@_) {
+        local $_l = pushlogctx($domain);
+
+        my $ip = delete $config{$domain}{'wantipv4'};
+        if (!defined $ip) {
+            failed("asuscomm protocol only supports IPv4");
+            $recap{$domain}{'status-ipv4'} = 'failed';
+            next;
+        }
+
+        my $login  = uc(opt('login',    $domain));
+        my $pin    =    opt('password', $domain);
+        my $server =    opt('server',   $domain);
+
+        # Password sent to server: HMAC-MD5(stripped_fqdn + stripped_ip, wps_pin)
+        # "stripped" means all non-alphanumeric characters removed.
+        (my $stripped_host = $domain) =~ s/[^a-zA-Z0-9]//g;
+        (my $stripped_ip   = $ip)     =~ s/[^a-zA-Z0-9]//g;
+        my $hmac = _asuscomm_hmac_md5($stripped_host . $stripped_ip, $pin);
+
+        info("updating $domain to $ip");
+        $recap{$domain}{'status-ipv4'} = 'failed';
+
+        my $reply = geturl(
+            proxy    => opt('proxy'),
+            url      => "http://$server/ddns/update.jsp?hostname=$domain&myip=$ip",
+            login    => $login,
+            password => $hmac,
+        );
+        next if !header_ok($reply);
+
+        (my $body = $reply) =~ s/^.*?\n\n//s;
+        my ($code) = $body =~ /^(\d+)/;
+        $code //= 0;
+
+        if ($code == 200 || $code == 230) {
+            $recap{$domain}{'ipv4'}        = $ip;
+            $recap{$domain}{'mtime'}       = $now;
+            $recap{$domain}{'status-ipv4'} = 'good';
+            success("IPv4 address set to $ip");
+        } elsif ($code == 220) {
+            $recap{$domain}{'ipv4'}        = $ip;
+            $recap{$domain}{'mtime'}       = $now;
+            $recap{$domain}{'status-ipv4'} = 'good';
+            success("IPv4 address unchanged at $ip");
+        } elsif ($code == 203 || $code == 233) {
+            failed("hostname $domain is already registered to a different MAC address");
+        } elsif ($code == 297 || $code == 298) {
+            failed("invalid hostname: $domain");
+        } elsif ($code == 299) {
+            failed("invalid IP address: $ip");
+        } else {
+            failed("unexpected server response: $body");
         }
     }
 }

--- a/t/protocol_asuscomm.pl
+++ b/t/protocol_asuscomm.pl
@@ -3,6 +3,7 @@ BEGIN { SKIP: { eval { require Test::Warnings; 1; } or skip($@, 1); } }
 BEGIN { eval { require 'ddclient'; } or BAIL_OUT($@); }
 use ddclient::t::HTTPD;
 use ddclient::t::Logger;
+use MIME::Base64 qw(decode_base64);
 
 httpd_required();
 
@@ -21,8 +22,11 @@ httpd()->run(sub {
         return [400, ['Content-Type' => 'text/plain'], ['unexpected request: ' . $uri]];
     }
 
-    # Reject anything with wrong MAC (simulate auth check)
-    if ($auth !~ /AABBCCDDEEFF/) {
+    # Decode Basic Auth and check MAC (username)
+    my ($auth_user) = do {
+        $auth =~ /^Basic\s+(\S+)$/ ? (split(/:/, decode_base64($1), 2))[0] : ();
+    };
+    unless (defined($auth_user) && $auth_user eq 'AABBCCDDEEFF') {
         return [401, ['Content-Type' => 'text/plain'], []];
     }
 
@@ -52,12 +56,12 @@ my $hostname = httpd()->endpoint();
 my @test_cases = (
     {
         desc => 'IPv4 update success (200)',
-        cfg  => {h1 => {
+        cfg  => {
             server   => $server,
             login    => 'AABBCCDDEEFF',
             password => '12345670',
             wantipv4 => '1.2.3.4',
-        }, 'h1' => 'myhost.asuscomm.com'},
+        },
         host    => 'myhost.asuscomm.com',
         wantrecap => {
             'myhost.asuscomm.com' => {'status-ipv4' => 'good', 'ipv4' => '1.2.3.4', mtime => $ddclient::now},
@@ -148,10 +152,8 @@ my @test_cases = (
     },
 );
 
-plan(tests => scalar(@test_cases));
-
 for my $tc (@test_cases) {
-    run_logger_test($tc->{desc}, sub {
+    subtest($tc->{desc} => sub {
         local %ddclient::config;
         local %ddclient::recap;
         my $host = $tc->{host};
@@ -159,7 +161,36 @@ for my $tc (@test_cases) {
             %{$tc->{cfg}},
             wantipv4 => $tc->{cfg}{wantipv4} // '1.2.3.4',
         };
-        ddclient::nic_asuscomm_update(undef, $host);
-        return \%ddclient::recap;
-    }, $tc->{wantrecap}, $tc->{wantlogs});
+
+        my $l = ddclient::t::Logger->new($ddclient::_l, qr/^(?:WARNING|FATAL|SUCCESS|FAILED)$/);
+        {
+            local $ddclient::_l = $l;
+            ddclient::nic_asuscomm_update(undef, $host);
+        }
+
+        is_deeply(\%ddclient::recap, $tc->{wantrecap}, 'recap matches')
+            or diag(ddclient::repr(Values => [\%ddclient::recap, $tc->{wantrecap}],
+                                   Names  => ['*got', '*want']));
+
+        subtest('logs' => sub {
+            my @got  = @{$l->{logs}};
+            my @want = @{$tc->{wantlogs} // []};
+            for my $i (0..$#want) {
+                last if $i >= @got;
+                subtest("log $i" => sub {
+                    is($got[$i]{label}, $want[$i]{label}, 'label');
+                    is_deeply($got[$i]{ctx}, $want[$i]{ctx}, 'context');
+                    like($got[$i]{msg}, $want[$i]{msg}, 'message');
+                });
+            }
+            my @unexpected = @got[@want..$#got];
+            ok(@unexpected == 0, 'no unexpected logs')
+                or diag(ddclient::repr(\@unexpected, Names => ['*unexpected']));
+            my @missing = @want[@got..$#want];
+            ok(@missing == 0, 'no missing logs')
+                or diag(ddclient::repr(\@missing, Names => ['*missing']));
+        });
+    });
 }
+
+done_testing();

--- a/t/protocol_asuscomm.pl
+++ b/t/protocol_asuscomm.pl
@@ -1,0 +1,165 @@
+use Test::More;
+BEGIN { SKIP: { eval { require Test::Warnings; 1; } or skip($@, 1); } }
+BEGIN { eval { require 'ddclient'; } or BAIL_OUT($@); }
+use ddclient::t::HTTPD;
+use ddclient::t::Logger;
+
+httpd_required();
+
+# Stand up a local test server that mimics ns1.asuscomm.com
+httpd()->run(sub {
+    my ($req) = @_;
+    diag('==============================================================================');
+    diag("Test server received request:\n" . $req->as_string());
+
+    my $uri    = $req->uri->as_string;
+    my $auth   = $req->header('Authorization') // '';
+    my $method = $req->method;
+
+    # All ASUS DDNS requests must be GET to /ddns/update.jsp
+    unless ($method eq 'GET' && $uri =~ m{^/ddns/update\.jsp}) {
+        return [400, ['Content-Type' => 'text/plain'], ['unexpected request: ' . $uri]];
+    }
+
+    # Reject anything with wrong MAC (simulate auth check)
+    if ($auth !~ /AABBCCDDEEFF/) {
+        return [401, ['Content-Type' => 'text/plain'], []];
+    }
+
+    my %params = map { split(/=/, $_, 2) } split(/&/, ($uri =~ /\?(.*)/)[0] // '');
+    my $hostname = $params{hostname} // '';
+    my $myip     = $params{myip}     // '';
+
+    if ($hostname eq 'myhost.asuscomm.com' && $myip =~ /^\d+\.\d+\.\d+\.\d+$/) {
+        return [200, ['Content-Type' => 'text/plain'], ["200||"]];
+    } elsif ($hostname eq 'nochg.asuscomm.com') {
+        return [200, ['Content-Type' => 'text/plain'], ["220||"]];
+    } elsif ($hostname eq 'transferred.asuscomm.com') {
+        return [200, ['Content-Type' => 'text/plain'], ["230||old.asuscomm.com"]];
+    } elsif ($hostname eq 'conflict.asuscomm.com') {
+        return [200, ['Content-Type' => 'text/plain'], ["203||suggested.asuscomm.com"]];
+    } elsif ($hostname eq 'badip.asuscomm.com') {
+        return [200, ['Content-Type' => 'text/plain'], ["299||"]];
+    } else {
+        return [200, ['Content-Type' => 'text/plain'], ["297||"]];
+    }
+});
+
+my $hostname = httpd()->endpoint();
+# Strip scheme — protocol builds "http://$server/..."
+(my $server = $hostname) =~ s{^https?://}{};
+
+my @test_cases = (
+    {
+        desc => 'IPv4 update success (200)',
+        cfg  => {h1 => {
+            server   => $server,
+            login    => 'AABBCCDDEEFF',
+            password => '12345670',
+            wantipv4 => '1.2.3.4',
+        }, 'h1' => 'myhost.asuscomm.com'},
+        host    => 'myhost.asuscomm.com',
+        wantrecap => {
+            'myhost.asuscomm.com' => {'status-ipv4' => 'good', 'ipv4' => '1.2.3.4', mtime => $ddclient::now},
+        },
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['myhost.asuscomm.com'], msg => qr/1\.2\.3\.4/},
+        ],
+    },
+    {
+        desc => 'IPv4 no-change (220)',
+        cfg  => {
+            server   => $server,
+            login    => 'AABBCCDDEEFF',
+            password => '12345670',
+            wantipv4 => '1.2.3.4',
+        },
+        host    => 'nochg.asuscomm.com',
+        wantrecap => {
+            'nochg.asuscomm.com' => {'status-ipv4' => 'good', 'ipv4' => '1.2.3.4', mtime => $ddclient::now},
+        },
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['nochg.asuscomm.com'], msg => qr/unchanged/},
+        ],
+    },
+    {
+        desc => 'IPv4 update success after MAC transfer (230)',
+        cfg  => {
+            server   => $server,
+            login    => 'AABBCCDDEEFF',
+            password => '12345670',
+            wantipv4 => '1.2.3.4',
+        },
+        host    => 'transferred.asuscomm.com',
+        wantrecap => {
+            'transferred.asuscomm.com' => {'status-ipv4' => 'good', 'ipv4' => '1.2.3.4', mtime => $ddclient::now},
+        },
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['transferred.asuscomm.com'], msg => qr/1\.2\.3\.4/},
+        ],
+    },
+    {
+        desc => 'bad auth (401)',
+        cfg  => {
+            server   => $server,
+            login    => 'WRONGMACADDR',
+            password => '00000000',
+            wantipv4 => '1.2.3.4',
+        },
+        host    => 'myhost.asuscomm.com',
+        wantrecap => {
+            'myhost.asuscomm.com' => {'status-ipv4' => 'failed'},
+        },
+        wantlogs => [
+            {label => 'FAILED', ctx => ['myhost.asuscomm.com'], msg => qr/401/},
+        ],
+    },
+    {
+        desc => 'hostname registered to different MAC (203)',
+        cfg  => {
+            server   => $server,
+            login    => 'AABBCCDDEEFF',
+            password => '12345670',
+            wantipv4 => '1.2.3.4',
+        },
+        host    => 'conflict.asuscomm.com',
+        wantrecap => {
+            'conflict.asuscomm.com' => {'status-ipv4' => 'failed'},
+        },
+        wantlogs => [
+            {label => 'FAILED', ctx => ['conflict.asuscomm.com'], msg => qr/different MAC/},
+        ],
+    },
+    {
+        desc => 'invalid IP (299)',
+        cfg  => {
+            server   => $server,
+            login    => 'AABBCCDDEEFF',
+            password => '12345670',
+            wantipv4 => '1.2.3.4',
+        },
+        host    => 'badip.asuscomm.com',
+        wantrecap => {
+            'badip.asuscomm.com' => {'status-ipv4' => 'failed'},
+        },
+        wantlogs => [
+            {label => 'FAILED', ctx => ['badip.asuscomm.com'], msg => qr/invalid IP/},
+        ],
+    },
+);
+
+plan(tests => scalar(@test_cases));
+
+for my $tc (@test_cases) {
+    run_logger_test($tc->{desc}, sub {
+        local %ddclient::config;
+        local %ddclient::recap;
+        my $host = $tc->{host};
+        $ddclient::config{$host} = {
+            %{$tc->{cfg}},
+            wantipv4 => $tc->{cfg}{wantipv4} // '1.2.3.4',
+        };
+        ddclient::nic_asuscomm_update(undef, $host);
+        return \%ddclient::recap;
+    }, $tc->{wantrecap}, $tc->{wantlogs});
+}


### PR DESCRIPTION
## Summary

Implements `protocol=asuscomm` for updating hostnames under `asuscomm.com` (and `asuscomm.cn` for mainland China) via the ASUS DDNS HTTP API.

Closes #816.

## Details

**Authentication** uses HTTP Basic Auth with a per-update computed password:

```
username = router MAC address (hex digits only, uppercase, no colons)
password = UPPERCASE(HEX(HMAC-MD5(stripped_fqdn + stripped_ip, wps_pin)))
```

where "stripped" means all non-alphanumeric characters removed, and `wps_pin` is the WPS PIN / secret code printed on the router label.

**Example config:**
```
protocol=asuscomm,       \
login=001122AABBCC,      \
password=12345670        \
myhost.asuscomm.com
```

The hostname must be registered first via the router's web interface (WAN → DDNS) before ddclient can update it.

**Response codes** (returned in HTTP response body):
| Code | Meaning |
|---|---|
| 200 | Success |
| 220 | No change (IP unchanged) |
| 230 | Success after MAC transfer |
| 203 / 233 | Hostname registered to a different MAC |
| 297 / 298 | Invalid hostname |
| 299 | Invalid IP address |
| HTTP 401 | Authentication failure (wrong MAC or WPS PIN) |

## Implementation notes

- Adds `use Digest::MD5` (Perl core — no new package dependency)
- IPv4 only; IPv6 via ASUS DDNS is firmware-internal and not exposed externally
- Reference implementation: `RMerl/asuswrt-merlin.ng` inadyn `plugins/asuscomm.c`
- Endpoint probed live during development to confirm response format

## Test plan

- [ ] `make check` / `prove t/protocol_asuscomm.pl` passes
- [ ] Live test with a real ASUS router (MAC + WPS PIN from label)
- [ ] Confirm `ns1.asuscomm.cn` override works for China users

🤖 Generated with [Claude Code](https://claude.com/claude-code)