### PR TITLE
docs: add ChangeLog entry for deSEC and DDNSS.de providers

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,10 @@ repository history](https://github.com/ddclient/ddclient/commits/main).
     [#888](https://github.com/ddclient/ddclient/pull/888)
   * Added `simply.com` (https://www.simply.com).
     [#850](https://github.com/ddclient/ddclient/pull/850)
+  * Added `deSEC` (https://desec.io) and `DDNSS.de` (https://ddnss.de) as
+    supported `dyndns2` providers, with dedicated `desec-ipv4`/`desec-ipv6`
+    web IP check services.
+    [#906](https://github.com/ddclient/ddclient/pull/906)
   * Added `ns1` protocol for NS1 / IBM NS1 Connect (https://ns1.com/).
     [#907](https://github.com/ddclient/ddclient/pull/907)
   * Added `spaceship` protocol for Spaceship (https://www.spaceship.com/).


### PR DESCRIPTION
ChangeLog entry was missed when PR #906 was merged. This adds it to the unreleased v4.0.1-rc.2 section.