### PR TITLE
feat: add Alibaba Cloud DNS (alicloud) protocol

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -75,6 +75,7 @@ repository history](https://github.com/ddclient/ddclient/commits/main).
     [#882](https://github.com/ddclient/ddclient/pull/882)
   * Added `ddnss` protocol for DDNSS.de (https://ddnss.de) key-based
     authentication, complementing existing dyndns2 username/password support.
+  * Added `alicloud` protocol for Alibaba Cloud DNS / AliDNS (https://www.alibabacloud.com/product/dns).
   * Added `LuaDNS` (https://luadns.com) as a supported `dyndns2` provider
     via `app.luadns.com`. Use your account email as login and API key as password.
   * Added `netcup` protocol for Netcup (https://www.netcup.de).

--- a/Makefile.am
+++ b/Makefile.am
@@ -72,6 +72,7 @@ handwritten_tests = \
 	t/logmsg.pl \
 	t/jitter.pl \
 	t/parse_assignments.pl \
+	t/protocol_alicloud.pl \
 	t/protocol_ddnss.pl \
 	t/protocol_cloudflare.pl \
 	t/protocol_directnic.pl \

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ your dynamic DNS provider(s): <https://github.com/troglobit/inadyn> or
 Dynamic DNS services currently supported include:
 
   * [1984.is](https://www.1984.is/product/freedns)
+  * [Alibaba Cloud DNS (AliDNS)](https://www.alibabacloud.com/product/dns)
   * [All-inkl.com](https://all-inkl.com)
   * [ChangeIP](https://www.changeip.com)
   * [CloudFlare](https://www.cloudflare.com)

--- a/ddclient.conf.in
+++ b/ddclient.conf.in
@@ -193,6 +193,17 @@ pid=@runstatedir@/ddclient.pid  # record PID in file.
 # domain.tld,sub.domain.tld
 
 ##
+## Alibaba Cloud DNS / AliDNS (www.alibabacloud.com)
+## Create an AccessKey at ram.console.aliyun.com/manage/ak with DNS read/write permissions.
+## Existing A/AAAA records must already exist in the zone before updating.
+##
+# protocol=alicloud,                                          \
+# login=LTAI4GxxxxxxxxxxxxxxxxxxX,                           \
+# password=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,                  \
+# zone=example.com,                                          \
+# myhost.example.com
+
+##
 ## Gandi (gandi.net)
 ##
 ## Single host update

--- a/ddclient.in
+++ b/ddclient.in
@@ -934,6 +934,16 @@ our %protocols = (
             'server' => setv(T_FQDNP, 0, 'api.1984.is', undef),
         },
     ),
+    'alicloud' => ddclient::Protocol->new(
+        'update'   => \&nic_alicloud_update,
+        'examples' => \&nic_alicloud_examples,
+        'cfgvars'  => {
+            %{$cfgvars{'protocol-common-defaults'}},
+            'server' => setv(T_FQDNP, 0, 'alidns.aliyuncs.com', undef),
+            'zone'   => setv(T_FQDN,  0, undef,                  undef),
+            'ttl'    => setv(T_NUMBER,0, undef,                   undef),
+        },
+    ),
     'changeip' => ddclient::LegacyProtocol->new(
         'update'     => \&nic_changeip_update,
         'examples'   => \&nic_changeip_examples,
@@ -2267,8 +2277,8 @@ sub init_config {
     my @needs_sha1 = grep({ my $p = $_; grep($_ eq $p, @protos); } qw(freedns nfsn));
     load_sha1_support(join(', ', @needs_sha1)) if @needs_sha1;
     my @needs_json = grep({ my $p = $_; grep($_ eq $p, @protos); }
-                          qw(1984 cloudflare digitalocean directnic dnsexit2 gandi godaddy hetzner
-                             ionos netcup nfsn njalla ns1 porkbun spaceship yandex));
+                          qw(1984 alicloud cloudflare digitalocean directnic dnsexit2 gandi godaddy
+                             hetzner ionos netcup nfsn njalla ns1 porkbun spaceship yandex));
     load_json_support(join(', ', @needs_json)) if @needs_json;
 }
 
@@ -5786,6 +5796,195 @@ sub nic_1984_update {
             success("updated successfully to $response->{ip}");
         }
     }
+}
+
+######################################################################
+## nic_alicloud_examples
+######################################################################
+sub nic_alicloud_examples {
+    my $self = shift;
+    return <<"EoEXAMPLE";
+o 'alicloud'
+
+The 'alicloud' protocol is used by Alibaba Cloud DNS (www.alibabacloud.com),
+also known as AliDNS or Aliyun DNS.
+
+Before configuring, create an AccessKey in the Alibaba Cloud RAM console
+(ram.console.aliyun.com/manage/ak) with DNS read and write permissions.
+Each hostname must already have an A (IPv4) or AAAA (IPv6) record in Alibaba
+Cloud DNS — this protocol updates existing records, it does not create them.
+
+Configuration variables applicable to the 'alicloud' protocol are:
+  protocol=alicloud            ##
+  server=fqdn.of.service       ## can be omitted, defaults to alidns.aliyuncs.com
+  zone=dns.zone                ## optional; root DNS zone.  Inferred from hostname if omitted.
+  login=service-login          ## Alibaba Cloud AccessKey ID
+  password=service-password    ## Alibaba Cloud AccessKey Secret
+  ttl=seconds                  ## optional; defaults to existing record TTL if omitted.
+  fully.qualified.host         ## the host registered with the service.
+
+Example \${program}.conf file entries:
+  protocol=alicloud                                            \\
+  login=LTAI4GxxxxxxxxxxxxxxxxxxX                              \\
+  password=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx                    \\
+  zone=example.com                                            \\
+  myhost.example.com
+
+EoEXAMPLE
+}
+
+######################################################################
+## nic_alicloud_update
+######################################################################
+sub nic_alicloud_update {
+    my $self = shift;
+    eval { require Digest::SHA; }
+        or fatal("Error loading the Perl module Digest::SHA needed for alicloud update.");
+    eval { require MIME::Base64; }
+        or fatal("Error loading the Perl module MIME::Base64 needed for alicloud update.");
+
+    for my $h (@_) {
+        local $_l = pushlogctx($h);
+        my ($sub_domain, $domain);
+        if (opt('zone', $h)) {
+            $domain     = opt('zone', $h);
+            $sub_domain = $h;
+            if ($sub_domain !~ s/(?:^|\.)\Q$domain\E$//) {
+                failed("hostname '$h' does not end with zone '$domain'");
+                next;
+            }
+            $sub_domain ||= '@';
+        } else {
+            ($sub_domain, $domain) = split(/\./, $h, 2);
+            if (!defined $domain) {
+                failed("cannot infer zone from '$h': no dot in hostname; use zone=");
+                next;
+            }
+        }
+        my $server            = opt('server', $h);
+        my $access_key_id     = opt('login', $h);
+        my $access_key_secret = opt('password', $h);
+        my $ttl               = opt('ttl', $h);
+        for my $ipv ('4', '6') {
+            my $ip = delete $config{$h}{"wantipv$ipv"} or next;
+            my $rrtype = $ipv eq '4' ? 'A' : 'AAAA';
+            $recap{$h}{"status-ipv$ipv"} = 'failed';
+            info("setting IPv$ipv address to $ip");
+
+            my $list_resp = _alicloud_call(
+                server            => $server,
+                access_key_id     => $access_key_id,
+                access_key_secret => $access_key_secret,
+                Action            => 'DescribeDomainRecords',
+                DomainName        => $domain,
+                RRKeyWord         => $sub_domain,
+                TypeKeyWord       => $rrtype,
+            );
+            if (!defined $list_resp) {
+                $recap{$h}{"status-ipv$ipv"} = 'failed';
+                next;
+            }
+            my $records = $list_resp->{DomainRecords}{Record};
+            if (ref($records) ne 'ARRAY' || !@$records) {
+                $recap{$h}{"status-ipv$ipv"} = 'failed';
+                failed("no $rrtype record found for $sub_domain.$domain");
+                next;
+            }
+            my @matching = grep { $_->{RR} eq $sub_domain } @$records;
+            if (!@matching) {
+                $recap{$h}{"status-ipv$ipv"} = 'failed';
+                failed("no $rrtype record found for $sub_domain.$domain");
+                next;
+            }
+            warning("multiple $rrtype records found for $sub_domain.$domain; using the first one")
+                if @matching > 1;
+            my $record_id = $matching[0]{RecordId};
+            my $line      = $matching[0]{Line} // 'default';
+            if (!defined $record_id) {
+                failed("no RecordId in DescribeDomainRecords response");
+                next;
+            }
+
+            my %update_args = (
+                server            => $server,
+                access_key_id     => $access_key_id,
+                access_key_secret => $access_key_secret,
+                Action            => 'UpdateDomainRecord',
+                Line              => $line,
+                RecordId          => $record_id,
+                RR                => $sub_domain,
+                Type              => $rrtype,
+                Value             => $ip,
+            );
+            $update_args{TTL} = $ttl if defined $ttl;
+            my $update_resp = _alicloud_call(%update_args);
+            if (!defined $update_resp) {
+                $recap{$h}{"status-ipv$ipv"} = 'failed';
+                next;
+            }
+            $recap{$h}{"ipv$ipv"}        = $ip;
+            $recap{$h}{'mtime'}          = $now;
+            $recap{$h}{"status-ipv$ipv"} = 'good';
+            success("IPv$ipv address set to $ip");
+        }
+    }
+}
+
+######################################################################
+## _alicloud_call: make an authenticated Alibaba Cloud DNS API call
+######################################################################
+sub _alicloud_call {
+    my (%args) = @_;
+    my $server            = delete $args{server};
+    my $access_key_id     = delete $args{access_key_id};
+    my $access_key_secret = delete $args{access_key_secret};
+
+    my @t         = gmtime();
+    my $timestamp = sprintf('%04d-%02d-%02dT%02d:%02d:%02dZ',
+        $t[5] + 1900, $t[4] + 1, $t[3], $t[2], $t[1], $t[0]);
+
+    my %params = (
+        %args,
+        AccessKeyId      => $access_key_id,
+        Format           => 'json',
+        SignatureMethod  => 'HMAC-SHA1',
+        SignatureNonce   => sprintf('%d%06d', time(), int(rand(1_000_000))),
+        SignatureVersion => '1.0',
+        Timestamp        => $timestamp,
+        Version          => '2015-01-09',
+    );
+
+    my $canonical = join('&',
+        map { _alicloud_encode($_) . '=' . _alicloud_encode($params{$_}) }
+        sort keys %params
+    );
+    my $string_to_sign = 'GET&' . _alicloud_encode('/') . '&' . _alicloud_encode($canonical);
+    my $sig = MIME::Base64::encode_base64(
+        Digest::SHA::hmac_sha1($string_to_sign, $access_key_secret . '&'), '');
+
+    my $url   = "$server/?" . $canonical . '&Signature=' . _alicloud_encode($sig);
+    my $reply = geturl(proxy => opt('proxy'), url => $url);
+    return undef if !header_ok($reply);
+    (my $body = $reply) =~ s/^.*?\n\n//s;
+    my $resp = eval { decode_json($body) };
+    if (ref($resp) ne 'HASH') {
+        failed("unexpected API response: $body");
+        return undef;
+    }
+    if (defined $resp->{Code}) {
+        failed("API error ($resp->{Code}): " . ($resp->{Message} // 'unknown'));
+        return undef;
+    }
+    return $resp;
+}
+
+######################################################################
+## _alicloud_encode: percent-encode per RFC 3986 for Alibaba Cloud signing
+######################################################################
+sub _alicloud_encode {
+    my ($str) = @_;
+    $str =~ s/([^A-Za-z0-9\-_.~])/sprintf('%%%02X', ord($1))/ge;
+    return $str;
 }
 
 ######################################################################

--- a/t/protocol_alicloud.pl
+++ b/t/protocol_alicloud.pl
@@ -1,0 +1,432 @@
+use Test::More;
+BEGIN { SKIP: { eval { require Test::Warnings; 1; } or skip($@, 1); } }
+BEGIN { eval { require JSON::PP; 1; } or plan(skip_all => $@); JSON::PP->import(); }
+BEGIN { eval { require 'ddclient'; } or BAIL_OUT($@); }
+use ddclient::t::HTTPD;
+use ddclient::t::Logger;
+
+httpd_required();
+
+ddclient::load_json_support('alicloud');
+
+my $j = ['Content-Type' => 'application/json'];
+
+sub list_resp {
+    my @records = @_;
+    encode_json({DomainRecords => {Record => \@records}});
+}
+
+sub record {
+    my (%args) = @_;
+    return {
+        RR       => $args{rr}   // 'myhost',
+        RecordId => $args{id}   // 'rec001',
+        Line     => $args{line} // 'default',
+        Type     => $args{type} // 'A',
+    };
+}
+
+sub update_resp {
+    my ($id) = @_;
+    encode_json({RequestId => 'req-001', RecordId => $id // 'rec001'});
+}
+
+sub api_error {
+    my ($code, $msg) = @_;
+    encode_json({Code => $code, Message => $msg});
+}
+
+sub query_params {
+    my ($req) = @_;
+    my %params;
+    for my $pair (split(/&/, $req->uri()->query() // '')) {
+        my ($k, $v) = split(/=/, $pair, 2);
+        s/%([0-9A-Fa-f]{2})/chr(hex($1))/ge for ($k, $v);
+        $params{$k} = $v;
+    }
+    return \%params;
+}
+
+httpd()->run();
+
+my @test_cases = (
+    {
+        desc => 'IPv4 success',
+        cfg => {'myhost.example.com' => {
+            protocol => 'alicloud',
+            login    => 'key1',
+            password => 'secret1',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [200, $j, [list_resp(record(rr => 'myhost', id => 'rec001', type => 'A'))]],
+            [200, $j, [update_resp('rec001')]],
+        ],
+        wantrecap => {'myhost.example.com' => {
+            'status-ipv4' => 'good',
+            'ipv4'        => '192.0.2.1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['myhost.example.com'], msg => qr/IPv4 address set to 192\.0\.2\.1/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 2, '2 requests: DescribeDomainRecords + UpdateDomainRecord');
+            my $lp = query_params($reqs[0]);
+            is($lp->{Action},      'DescribeDomainRecords', 'first request is DescribeDomainRecords');
+            is($lp->{DomainName},  'example.com',           'DomainName correct');
+            is($lp->{RRKeyWord},   'myhost',                'RRKeyWord correct');
+            is($lp->{TypeKeyWord}, 'A',                     'TypeKeyWord is A');
+            my $up = query_params($reqs[1]);
+            is($up->{Action},   'UpdateDomainRecord', 'second request is UpdateDomainRecord');
+            is($up->{RecordId}, 'rec001',             'RecordId matches');
+            is($up->{RR},       'myhost',             'RR correct');
+            is($up->{Type},     'A',                  'Type is A');
+            is($up->{Value},    '192.0.2.1',          'Value is new IP');
+        },
+    },
+    {
+        desc => 'IPv6 success',
+        cfg => {'myhost.example.com' => {
+            protocol => 'alicloud',
+            login    => 'key1',
+            password => 'secret1',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv6 => '2001:db8::1',
+        }},
+        responses => [
+            [200, $j, [list_resp(record(rr => 'myhost', id => 'rec002', type => 'AAAA'))]],
+            [200, $j, [update_resp('rec002')]],
+        ],
+        wantrecap => {'myhost.example.com' => {
+            'status-ipv6' => 'good',
+            'ipv6'        => '2001:db8::1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['myhost.example.com'], msg => qr/IPv6 address set to 2001:db8::1/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 2, '2 requests for IPv6');
+            is(query_params($reqs[0])->{TypeKeyWord}, 'AAAA', 'TypeKeyWord is AAAA');
+            is(query_params($reqs[1])->{Value},       '2001:db8::1', 'Value is IPv6 address');
+        },
+    },
+    {
+        desc => 'dual-stack IPv4 and IPv6',
+        cfg => {'myhost.example.com' => {
+            protocol => 'alicloud',
+            login    => 'key1',
+            password => 'secret1',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+            wantipv6 => '2001:db8::1',
+        }},
+        responses => [
+            [200, $j, [list_resp(record(rr => 'myhost', id => 'rec001', type => 'A'))]],
+            [200, $j, [update_resp('rec001')]],
+            [200, $j, [list_resp(record(rr => 'myhost', id => 'rec002', type => 'AAAA'))]],
+            [200, $j, [update_resp('rec002')]],
+        ],
+        wantrecap => {'myhost.example.com' => {
+            'status-ipv4' => 'good', 'ipv4' => '192.0.2.1',
+            'status-ipv6' => 'good', 'ipv6' => '2001:db8::1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['myhost.example.com'], msg => qr/IPv4/},
+            {label => 'SUCCESS', ctx => ['myhost.example.com'], msg => qr/IPv6/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 4, '4 requests: list+update for each address family');
+            is(query_params($reqs[0])->{TypeKeyWord}, 'A',    'first list is for A');
+            is(query_params($reqs[2])->{TypeKeyWord}, 'AAAA', 'second list is for AAAA');
+        },
+    },
+    {
+        desc => 'custom TTL included in update request',
+        cfg => {'myhost.example.com' => {
+            protocol => 'alicloud',
+            login    => 'key1',
+            password => 'secret1',
+            zone     => 'example.com',
+            ttl      => 600,
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [200, $j, [list_resp(record(rr => 'myhost', id => 'rec001', type => 'A'))]],
+            [200, $j, [update_resp('rec001')]],
+        ],
+        wantrecap => {'myhost.example.com' => {
+            'status-ipv4' => 'good',
+            'ipv4'        => '192.0.2.1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['myhost.example.com'], msg => qr/IPv4/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(query_params($reqs[1])->{TTL}, '600', 'TTL=600 included in UpdateDomainRecord');
+        },
+    },
+    {
+        desc => 'zone inferred from hostname when not set',
+        cfg => {'myhost.example.com' => {
+            protocol => 'alicloud',
+            login    => 'key1',
+            password => 'secret1',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [200, $j, [list_resp(record(rr => 'myhost', id => 'rec001', type => 'A'))]],
+            [200, $j, [update_resp('rec001')]],
+        ],
+        wantrecap => {'myhost.example.com' => {
+            'status-ipv4' => 'good',
+            'ipv4'        => '192.0.2.1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['myhost.example.com'], msg => qr/IPv4/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            my $lp = query_params($reqs[0]);
+            is($lp->{DomainName}, 'example.com', 'DomainName inferred from hostname');
+            is($lp->{RRKeyWord},  'myhost',      'RRKeyWord is first component');
+        },
+    },
+    {
+        desc => 'root zone update uses @ as subdomain',
+        cfg => {'example.com' => {
+            protocol => 'alicloud',
+            login    => 'key1',
+            password => 'secret1',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [200, $j, [list_resp(record(rr => '@', id => 'rec001', type => 'A'))]],
+            [200, $j, [update_resp('rec001')]],
+        ],
+        wantrecap => {'example.com' => {
+            'status-ipv4' => 'good',
+            'ipv4'        => '192.0.2.1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['example.com'], msg => qr/IPv4/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(query_params($reqs[0])->{RRKeyWord}, '@', 'root zone uses @ as RRKeyWord');
+            is(query_params($reqs[1])->{RR},        '@', 'root zone uses @ in UpdateDomainRecord');
+        },
+    },
+    {
+        desc => 'zone mismatch fails with no requests sent',
+        cfg => {'myhost.example.net' => {
+            protocol => 'alicloud',
+            login    => 'key1',
+            password => 'secret1',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [],
+        wantrecap => {},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['myhost.example.net'],
+             msg => qr/does not end with zone 'example\.com'/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 0, 'no requests sent on zone mismatch');
+        },
+    },
+    {
+        desc => 'bare hostname without dot fails with useful error',
+        cfg => {'localhostname' => {
+            protocol => 'alicloud',
+            login    => 'key1',
+            password => 'secret1',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [],
+        wantrecap => {},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['localhostname'],
+             msg => qr/no dot in hostname.*use zone=/},
+        ],
+    },
+    {
+        desc => 'record not found leaves status-ipv4 failed',
+        cfg => {'myhost.example.com' => {
+            protocol => 'alicloud',
+            login    => 'key1',
+            password => 'secret1',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [200, $j, [list_resp()]],
+        ],
+        wantrecap => {'myhost.example.com' => {'status-ipv4' => 'failed'}},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['myhost.example.com'],
+             msg => qr/no A record found for myhost\.example\.com/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 1, 'only DescribeDomainRecords sent, no update');
+        },
+    },
+    {
+        desc => 'API error in list call leaves status-ipv4 failed',
+        cfg => {'myhost.example.com' => {
+            protocol => 'alicloud',
+            login    => 'key1',
+            password => 'secret1',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [200, $j, [api_error('InvalidAccessKeyId', 'Specified access key is not found')]],
+        ],
+        wantrecap => {'myhost.example.com' => {'status-ipv4' => 'failed'}},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['myhost.example.com'],
+             msg => qr/API error \(InvalidAccessKeyId\)/},
+        ],
+    },
+    {
+        desc => 'HTTP error on list call leaves status-ipv4 failed',
+        cfg => {'myhost.example.com' => {
+            protocol => 'alicloud',
+            login    => 'key1',
+            password => 'secret1',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [500, $j, [encode_json({Code => 'InternalError', Message => 'server error'})]],
+        ],
+        wantrecap => {'myhost.example.com' => {'status-ipv4' => 'failed'}},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['myhost.example.com'], msg => qr/500/},
+        ],
+    },
+    {
+        desc => 'API error in update call leaves status-ipv4 failed',
+        cfg => {'myhost.example.com' => {
+            protocol => 'alicloud',
+            login    => 'key1',
+            password => 'secret1',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [200, $j, [list_resp(record(rr => 'myhost', id => 'rec001', type => 'A'))]],
+            [200, $j, [api_error('InvalidParameter', 'The parameter Value is invalid')]],
+        ],
+        wantrecap => {'myhost.example.com' => {'status-ipv4' => 'failed'}},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['myhost.example.com'],
+             msg => qr/API error \(InvalidParameter\)/},
+        ],
+    },
+    {
+        desc => 'multiple matching records logs warning and uses first',
+        cfg => {'myhost.example.com' => {
+            protocol => 'alicloud',
+            login    => 'key1',
+            password => 'secret1',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [200, $j, [list_resp(
+                record(rr => 'myhost', id => 'rec001', type => 'A'),
+                record(rr => 'myhost', id => 'rec002', type => 'A'),
+            )]],
+            [200, $j, [update_resp('rec001')]],
+        ],
+        wantrecap => {'myhost.example.com' => {
+            'status-ipv4' => 'good',
+            'ipv4'        => '192.0.2.1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'WARNING', ctx => ['myhost.example.com'],
+             msg => qr/multiple A records found.*using the first one/},
+            {label => 'SUCCESS', ctx => ['myhost.example.com'], msg => qr/IPv4/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(query_params($reqs[1])->{RecordId}, 'rec001', 'first record ID used in update');
+        },
+    },
+);
+
+for my $tc (@test_cases) {
+    subtest($tc->{desc} => sub {
+        local $ddclient::globals{debug}   = 1;
+        local $ddclient::globals{verbose} = 1;
+        local %ddclient::config  = %{$tc->{cfg}};
+        local %ddclient::recap;
+
+        httpd()->reset(@{$tc->{responses}});
+
+        my $l = ddclient::t::Logger->new($ddclient::_l, qr/^(?:WARNING|FATAL|SUCCESS|FAILED)$/);
+        {
+            local $ddclient::_l = $l;
+            ddclient::nic_alicloud_update(undef, sort(keys(%{$tc->{cfg}})));
+        }
+
+        my @reqs = httpd()->reset();
+
+        is_deeply(\%ddclient::recap, $tc->{wantrecap}, 'recap matches')
+            or diag(ddclient::repr(Values => [\%ddclient::recap, $tc->{wantrecap}],
+                                   Names  => ['*got', '*want']));
+
+        subtest('logs' => sub {
+            my @got  = @{$l->{logs}};
+            my @want = @{$tc->{wantlogs} // []};
+            for my $i (0..$#want) {
+                last if $i >= @got;
+                subtest("log $i" => sub {
+                    is($got[$i]{label}, $want[$i]{label}, 'label');
+                    is_deeply($got[$i]{ctx}, $want[$i]{ctx}, 'context');
+                    like($got[$i]{msg}, $want[$i]{msg}, 'message');
+                });
+            }
+            my @unexpected = @got[@want..$#got];
+            ok(@unexpected == 0, 'no unexpected logs')
+                or diag(ddclient::repr(\@unexpected, Names => ['*unexpected']));
+            my @missing = @want[@got..$#want];
+            ok(@missing == 0, 'no missing logs')
+                or diag(ddclient::repr(\@missing, Names => ['*missing']));
+        });
+
+        $tc->{check_reqs}->(@reqs) if $tc->{check_reqs};
+    });
+}
+
+done_testing();


### PR DESCRIPTION
## Summary

Implements `protocol=alicloud` for updating A and AAAA records hosted at
Alibaba Cloud DNS (AliDNS / Aliyun DNS) via the AliDNS REST API.

- Authenticates using an AccessKey ID (`login=`) and AccessKey Secret (`password=`) with HMAC-SHA1 request signing per the AliDNS API spec
- Supports IPv4 (`wantipv4`) and IPv6 (`wantipv6`) updates, each sending a separate `UpdateDomainRecord` API call
- Looks up the existing record ID via `DescribeDomainRecords` before updating; logs `FAILED` if no existing record is found (the API does not support creating records)
- Optional `zone=` to specify the root zone explicitly; inferred from the hostname if omitted
- Optional `ttl=` to override the record TTL; leaves the existing TTL unchanged if omitted
- Added `alicloud` to `@needs_json` in `init_config`
- Added entry to `README.md`, `ddclient.conf.in`, and `ChangeLog.md`

 #908 (partial — AliDNS item).

## Test plan

- [ ] Verify `make check` passes
- [ ] Manually test with a real Alibaba Cloud DNS zone (A and AAAA record updates)
- [ ] Confirm `FAILED` log appears when no existing record exists for the hostname

🤖 Generated with [Claude Code](https://claude.com/claude-code)