### PR TITLE
feat: add ddnss protocol for DDNSS.de key-based authentication

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -59,6 +59,8 @@ repository history](https://github.com/ddclient/ddclient/commits/main).
     [#868](https://github.com/ddclient/ddclient/pull/868)
   * Added `dynadot` protocol for Dynadot (https://www.dynadot.com/).
     [#882](https://github.com/ddclient/ddclient/pull/882)
+  * Added `ddnss` protocol for DDNSS.de (https://ddnss.de) key-based
+    authentication, complementing existing dyndns2 username/password support.
 
 ### Improvements
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -72,6 +72,7 @@ handwritten_tests = \
 	t/logmsg.pl \
 	t/jitter.pl \
 	t/parse_assignments.pl \
+	t/protocol_ddnss.pl \
 	t/protocol_cloudflare.pl \
 	t/protocol_directnic.pl \
 	t/protocol_dnsexit2.pl \

--- a/ddclient.conf.in
+++ b/ddclient.conf.in
@@ -290,6 +290,13 @@ pid=@runstatedir@/ddclient.pid  # record PID in file.
 # myhost.example.com
 
 ##
+## DDNSS.de (https://ddnss.de) - key-based authentication
+##
+# protocol=ddnss,
+# password=your-api-key,
+# myhost.ddnss.de
+
+##
 ## MyOnlinePortal (http://myonlineportal.net)
 ##
 # # ipv6=yes # optional

--- a/ddclient.in
+++ b/ddclient.in
@@ -972,6 +972,15 @@ our %protocols = (
             'server' => setv(T_FQDNP, 0, 'https://api.ddns.fm', undef),
         },
     ),
+    'ddnss' => ddclient::Protocol->new(
+        'update'   => \&nic_ddnss_update,
+        'examples' => \&nic_ddnss_examples,
+        'cfgvars' => {
+            %{$cfgvars{'protocol-common-defaults'}},
+            'login'  => undef,
+            'server' => setv(T_FQDNP, 0, 'ddnss.de', undef),
+        },
+    ),
     'digitalocean' => ddclient::Protocol->new(
         'update' => \&nic_digitalocean_update,
         'examples' => \&nic_digitalocean_examples,
@@ -7304,6 +7313,63 @@ sub nic_ddnsfm_update {
             next if !header_ok($reply);
             $recap{$h}{"ipv$ipv"} = $ip;
             $recap{$h}{'mtime'} = $now;
+            $recap{$h}{"status-ipv$ipv"} = 'good';
+            success("IPv$ipv address set to $ip");
+        }
+    }
+}
+
+######################################################################
+## nic_ddnss_examples
+######################################################################
+sub nic_ddnss_examples {
+    my $self = shift;
+    return <<"EoEXAMPLE";
+o 'ddnss'
+
+The 'ddnss' protocol is used by the free dynamic DNS service at ddnss.de
+using key-based authentication.
+
+Configuration variables applicable to the 'ddnss' protocol are:
+  protocol=ddnss               ##
+  server=fqdn.of.service       ## can be omitted, defaults to ddnss.de
+  password=your-api-key        ## API key from ddnss.de account settings
+  fully.qualified.host         ## the host registered with the service.
+
+Example \${program}.conf file entries:
+  protocol=ddnss,                        \\
+  password=your-api-key                  \\
+  myhost.ddnss.de
+EoEXAMPLE
+}
+
+######################################################################
+## nic_ddnss_update
+######################################################################
+sub nic_ddnss_update {
+    my $self = shift;
+    for my $h (@_) {
+        local $_l = pushlogctx($h);
+        for my $ipv ('4', '6') {
+            my $ip = delete $config{$h}{"wantipv$ipv"} or next;
+            $recap{$h}{"status-ipv$ipv"} = 'failed';
+            my $param = $ipv eq '4' ? "ip=$ip" : "ip6=$ip";
+            info("setting IPv$ipv address to $ip");
+            my $reply = geturl(
+                proxy => opt('proxy'),
+                url   => opt('server', $h) . "/upd.php?key=" . opt('password', $h) . "&host=$h&$param",
+            );
+            next if !header_ok($reply);
+            (my $body = $reply) =~ s/^.*?\n\n//s or do {
+                failed("invalid response from server");
+                next;
+            };
+            if ($body !~ /\bgood\b/i) {
+                failed("server said: $body");
+                next;
+            }
+            $recap{$h}{"ipv$ipv"}        = $ip;
+            $recap{$h}{'mtime'}          = $now;
             $recap{$h}{"status-ipv$ipv"} = 'good';
             success("IPv$ipv address set to $ip");
         }

--- a/t/protocol_ddnss.pl
+++ b/t/protocol_ddnss.pl
@@ -1,0 +1,217 @@
+use Test::More;
+BEGIN { SKIP: { eval { require Test::Warnings; 1; } or skip($@, 1); } }
+BEGIN { eval { require 'ddclient'; } or BAIL_OUT($@); }
+use ddclient::t::HTTPD;
+use ddclient::t::Logger;
+
+httpd_required();
+
+my $textplain = ['Content-Type' => 'text/plain'];
+
+httpd()->run();
+
+my @test_cases = (
+    {
+        desc => 'IPv4 success',
+        cfg => {'myhost.ddnss.de' => {
+            protocol => 'ddnss',
+            server   => httpd()->endpoint(),
+            password => 'myapikey',
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [200, $textplain, ["good 192.0.2.1\n"]],
+        ],
+        wantrecap => {'myhost.ddnss.de' => {
+            'status-ipv4' => 'good',
+            'ipv4'        => '192.0.2.1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['myhost.ddnss.de'], msg => qr/IPv4/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 1, '1 request');
+            is($reqs[0]->uri()->path(), '/upd.php', 'correct path');
+            my $q = $reqs[0]->uri()->query();
+            like($q,   qr/key=myapikey/,          'key param present');
+            like($q,   qr/host=myhost\.ddnss\.de/, 'host param present');
+            like($q,   qr/\bip=192\.0\.2\.1\b/,   'ip param present');
+            unlike($q, qr/\bip6=/,                 'no ip6 param');
+        },
+    },
+    {
+        desc => 'IPv6 success',
+        cfg => {'myhost.ddnss.de' => {
+            protocol => 'ddnss',
+            server   => httpd()->endpoint(),
+            password => 'myapikey',
+            wantipv6 => '2001:db8::1',
+        }},
+        responses => [
+            [200, $textplain, ["good 2001:db8::1\n"]],
+        ],
+        wantrecap => {'myhost.ddnss.de' => {
+            'status-ipv6' => 'good',
+            'ipv6'        => '2001:db8::1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['myhost.ddnss.de'], msg => qr/IPv6/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 1, '1 request');
+            is($reqs[0]->uri()->path(), '/upd.php', 'correct path');
+            my $q = $reqs[0]->uri()->query();
+            like($q,   qr/key=myapikey/,          'key param present');
+            like($q,   qr/host=myhost\.ddnss\.de/, 'host param present');
+            like($q,   qr/\bip6=/,                 'ip6 param present');
+            unlike($q, qr/[&?]ip=/,                'no bare ip param');
+        },
+    },
+    {
+        desc => 'dual-stack success',
+        cfg => {'myhost.ddnss.de' => {
+            protocol => 'ddnss',
+            server   => httpd()->endpoint(),
+            password => 'myapikey',
+            wantipv4 => '192.0.2.1',
+            wantipv6 => '2001:db8::1',
+        }},
+        responses => [
+            [200, $textplain, ["good 192.0.2.1\n"]],
+            [200, $textplain, ["good 2001:db8::1\n"]],
+        ],
+        wantrecap => {'myhost.ddnss.de' => {
+            'status-ipv4' => 'good',
+            'ipv4'        => '192.0.2.1',
+            'status-ipv6' => 'good',
+            'ipv6'        => '2001:db8::1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['myhost.ddnss.de'], msg => qr/IPv4/},
+            {label => 'SUCCESS', ctx => ['myhost.ddnss.de'], msg => qr/IPv6/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 2, '2 requests (one per IP version)');
+        },
+    },
+    {
+        desc => 'server returns non-good response',
+        cfg => {'myhost.ddnss.de' => {
+            protocol => 'ddnss',
+            server   => httpd()->endpoint(),
+            password => 'badkey',
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [200, $textplain, ["badauth\n"]],
+        ],
+        wantrecap => {'myhost.ddnss.de' => {
+            'status-ipv4' => 'failed',
+        }},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['myhost.ddnss.de'], msg => qr/server said: badauth/},
+        ],
+    },
+    {
+        desc => 'HTTP error leaves recap with failed status',
+        cfg => {'myhost.ddnss.de' => {
+            protocol => 'ddnss',
+            server   => httpd()->endpoint(),
+            password => 'myapikey',
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [500, $textplain, ["internal server error\n"]],
+        ],
+        wantrecap => {'myhost.ddnss.de' => {
+            'status-ipv4' => 'failed',
+        }},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['myhost.ddnss.de'], msg => qr/500/},
+        ],
+    },
+    {
+        desc => 'dual-stack partial success: IPv4 fails, IPv6 succeeds',
+        cfg => {'myhost.ddnss.de' => {
+            protocol => 'ddnss',
+            server   => httpd()->endpoint(),
+            password => 'myapikey',
+            wantipv4 => '192.0.2.1',
+            wantipv6 => '2001:db8::1',
+        }},
+        responses => [
+            [200, $textplain, ["badauth\n"]],
+            [200, $textplain, ["good 2001:db8::1\n"]],
+        ],
+        wantrecap => {'myhost.ddnss.de' => {
+            'status-ipv4' => 'failed',
+            'status-ipv6' => 'good',
+            'ipv6'        => '2001:db8::1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'FAILED',  ctx => ['myhost.ddnss.de'], msg => qr/server said: badauth/},
+            {label => 'SUCCESS', ctx => ['myhost.ddnss.de'], msg => qr/IPv6/},
+        ],
+    },
+    {
+        desc => 'no wantipv4 or wantipv6, no request sent',
+        cfg => {'myhost.ddnss.de' => {
+            protocol => 'ddnss',
+            server   => httpd()->endpoint(),
+            password => 'myapikey',
+        }},
+        responses => [],
+        wantrecap => {},
+        wantlogs  => [],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 0, 'no requests sent');
+        },
+    },
+);
+
+for my $tc (@test_cases) {
+    subtest($tc->{desc} => sub {
+        local %ddclient::config = %{$tc->{cfg}};
+        local %ddclient::recap;
+        httpd()->reset(@{$tc->{responses}});
+        my $l = ddclient::t::Logger->new($ddclient::_l, qr/^(?:WARNING|FATAL|SUCCESS|FAILED)$/);
+        {
+            local $ddclient::_l = $l;
+            ddclient::nic_ddnss_update(undef, sort(keys(%{$tc->{cfg}})));
+        }
+        my @reqs = httpd()->reset();
+        is_deeply(\%ddclient::recap, $tc->{wantrecap}, 'recap matches')
+            or diag(ddclient::repr(Values => [\%ddclient::recap, $tc->{wantrecap}],
+                                   Names => ['*got', '*want']));
+        subtest('logs' => sub {
+            my @got  = @{$l->{logs}};
+            my @want = @{$tc->{wantlogs}};
+            for my $i (0..$#want) {
+                last if $i >= @got;
+                my ($got, $want) = ($got[$i], $want[$i]);
+                subtest("log $i" => sub {
+                    is($got->{label},        $want->{label},  'label matches');
+                    is_deeply($got->{ctx},   $want->{ctx},    'context matches');
+                    like($got->{msg},        $want->{msg},    'message matches');
+                }) or diag(ddclient::repr(Values => [$got, $want], Names => ['*got', '*want']));
+            }
+            my @unexpected = @got[@want..$#got];
+            ok(@unexpected == 0, 'no unexpected logs')
+                or diag(ddclient::repr(\@unexpected, Names => ['*unexpected']));
+            my @missing = @want[@got..$#want];
+            ok(@missing == 0, 'no missing logs')
+                or diag(ddclient::repr(\@missing, Names => ['*missing']));
+        });
+        $tc->{check_reqs}->(@reqs) if $tc->{check_reqs};
+    });
+}
+
+done_testing();


### PR DESCRIPTION
## Summary

- Adds a new `ddnss` protocol supporting DDNSS.de's key-based `/upd.php` API
- IPv4 and IPv6 are updated separately (one request per IP version), matching DDNSS.de API design
- Pre-sets `status-ipvN = 'failed'` before each request so crashes/timeouts leave the recap in a known state
- Complements the existing `dyndns2` username/password support for DDNSS.de (PR #906)

## Configuration

```conf
protocol=ddnss,
password=your-api-key,
myhost.ddnss.de
```

The `server` defaults to `ddnss.de` and can be overridden for testing.

## Test plan

- [x] 7 test cases covering IPv4-only, IPv6-only, dual-stack, server error, HTTP error, partial failure, and no-op
- [x] `make check` passes (885/887, 2 skips are pre-existing)
- [x] URL parameters verified: `key=`, `host=`, `ip=` (IPv4) / `ip6=` (IPv6)

Closes #916

🤖 Generated with [Claude Code](https://claude.com/claude-code)