### PR TITLE
docs: add All-inkl.com as supported dyndns2 provider

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -39,6 +39,9 @@ repository history](https://github.com/ddclient/ddclient/commits/main).
     [#888](https://github.com/ddclient/ddclient/pull/888)
   * Added `simply.com` (https://www.simply.com).
     [#850](https://github.com/ddclient/ddclient/pull/850)
+  * Added `All-inkl.com` (https://all-inkl.com) as a supported `dyndns2`
+    provider via `dyndns.kasserver.com`. DDNS credentials are created in the
+    KAS control panel under Tools → DDNS Settings.
   * Added `DynV6` (https://dynv6.com) as a supported `dyndns2` provider.
     Authenticate with your zone's HTTP token; no username required (`login=none`).
   * Added `dynu` protocol for Dynu Systems (https://www.dynu.com/), with

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ your dynamic DNS provider(s): <https://github.com/troglobit/inadyn> or
 Dynamic DNS services currently supported include:
 
   * [1984.is](https://www.1984.is/product/freedns)
+  * [All-inkl.com](https://all-inkl.com)
   * [ChangeIP](https://www.changeip.com)
   * [CloudFlare](https://www.cloudflare.com)
   * [ClouDNS](https://www.cloudns.net)

--- a/ddclient.conf.in
+++ b/ddclient.conf.in
@@ -550,6 +550,17 @@ pid=@runstatedir@/ddclient.pid  # record PID in file.
 # myhost.example.com
 
 ##
+## All-inkl.com (https://all-inkl.com)
+## Create DDNS credentials in KAS under Tools → DDNS Settings.
+## Supports IPv4 and IPv6 (enable Dual-Stack in KAS for IPv6).
+##
+# protocol=dyndns2,                         \
+# server=dyndns.kasserver.com,               \
+# login=your-kas-ddns-login,                \
+# password=your-kas-ddns-password           \
+# yourhost.yourdomain.com
+
+##
 ## UpdatedIP (updatedip.com)
 ##
 # protocol=dyndns2

--- a/ddclient.in
+++ b/ddclient.in
@@ -4063,6 +4063,15 @@ Example ${program}.conf file entries:
   password=my-dyndns.org-password                           \\
   my-toplevel-domain.com,my-other-domain.com
 
+  ## All-inkl.com (https://all-inkl.com) - hosted DNS with DDNS support
+  ## Create DDNS credentials in KAS under Tools → DDNS Settings.
+  ## Supports both IPv4 and IPv6 (enable Dual-Stack in KAS for IPv6).
+  protocol=dyndns2,                                         \\
+  server=dyndns.kasserver.com,                              \\
+  login=your-kas-ddns-login,                                \\
+  password=your-kas-ddns-password                           \\
+  yourhost.yourdomain.com
+
   ## deSEC (https://desec.io) - free, open-source, DNSSEC-enabled dynamic DNS
   ## The dynDNS update password is displayed after sign-up when a .dedyn.io
   ## domain is created. Alternatively, create an API token at


### PR DESCRIPTION
## Summary

- Documents [All-inkl.com](https://all-inkl.com) as a `dyndns2`-compatible provider
- Server: `dyndns.kasserver.com`
- DDNS credentials are created in the KAS control panel under Tools → DDNS Settings
- Supports both IPv4 and IPv6 (Dual-Stack must be enabled in KAS for IPv6)

## Changes

- `ddclient.in`: Added All-inkl.com example block in `nic_dyndns2_examples`, alphabetically before deSEC
- `README.md`: Added All-inkl.com to the supported services list (between 1984.is and ChangeIP)
- `ddclient.conf.in`: Added commented All-inkl.com example block after Spaceship
- `ChangeLog.md`: Added entry under v4.0.1-rc.2 New feature section

## Test plan

- [ ] Run `ddclient --help` and confirm All-inkl.com example appears in dyndns2 output
- [ ] Confirm a real All-inkl.com account can update DNS via `dyndns.kasserver.com` with these settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)