### PR TITLE
docs: add WebSupport as supported dyndns2 provider

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -56,6 +56,8 @@ repository history](https://github.com/ddclient/ddclient/commits/main).
   * Added `dynu` protocol for Dynu Systems (https://www.dynu.com/), with
     dual-stack IPv4+IPv6 support and optional `zone=` for custom domain updates.
     [#904](https://github.com/ddclient/ddclient/pull/904)
+  * Added `WebSupport` (https://www.websupport.sk) as a supported `dyndns2`
+    provider via `dyndns.websupport.sk`.
   * Added `deSEC` (https://desec.io) and `DDNSS.de` (https://ddnss.de) as
     supported `dyndns2` providers, with dedicated `desec-ipv4`/`desec-ipv6`
     web IP check services.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Dynamic DNS services currently supported include:
   * [Sitelutions](https://www.sitelutions.com)
   * [Technitium DNS Server](https://technitium.com/dns/) (via RFC 2136 `protocol=nsupdate`)
   * [UpdatedIP](https://www.updatedip.com)
+  * [WebSupport](https://www.websupport.sk)
   * [Yandex](https://dns.yandex.com)
   * [Zoneedit](https://www.zoneedit.com)
 

--- a/ddclient.conf.in
+++ b/ddclient.conf.in
@@ -590,6 +590,17 @@ pid=@runstatedir@/ddclient.pid  # record PID in file.
 # yourhostname.example.com
 
 ##
+## WebSupport (https://www.websupport.sk)
+## Generate a DynDNS API key in Admin > Security and Login > API Authentication.
+## Use the generated identifier as login and the secret as password.
+##
+# protocol=dyndns2,                         \
+# server=dyndns.websupport.sk,              \
+# login=your-websupport-api-identifier,     \
+# password=your-websupport-api-secret       \
+# yourhostname.yourdomain.sk
+
+##
 ## PowerDNS via PowerDNS-Admin (https://github.com/PowerDNS-Admin/PowerDNS-Admin)
 ## Self-hosted PowerDNS with dyndns2-compatible /nic/update endpoint.
 ## Replace 'your.powerdns-admin.example.com' with your PowerDNS-Admin hostname.

--- a/ddclient.in
+++ b/ddclient.in
@@ -4155,6 +4155,15 @@ Example ${program}.conf file entries:
   password=your-nicru-password                              \\
   yourhostname.example.ru
 
+  ## WebSupport (https://www.websupport.sk) - Slovak domain registrar with DDNS support
+  ## Generate a DynDNS API key in Admin > Security and Login > API Authentication.
+  ## Use the generated identifier as login and the secret as password.
+  protocol=dyndns2,                                         \\
+  server=dyndns.websupport.sk,                              \\
+  login=your-websupport-api-identifier,                     \\
+  password=your-websupport-api-secret                       \\
+  yourhostname.yourdomain.sk
+
   ## PowerDNS via PowerDNS-Admin (https://github.com/PowerDNS-Admin/PowerDNS-Admin)
   ## Self-hosted PowerDNS with dyndns2-compatible /nic/update endpoint.
   ## Replace 'your.powerdns-admin.example.com' with your PowerDNS-Admin hostname.


### PR DESCRIPTION
## Summary

- Documents [WebSupport](https://www.websupport.sk) as a \`dyndns2\`-compatible provider
- Server: \`dyndns.websupport.sk\`
- Authentication uses a dedicated DynDNS API key generated in Admin > Security and Login > API Authentication (identifier as login, secret as password)

## Changes

- \`ddclient.in\`: Added WebSupport example block in \`nic_dyndns2_examples\`
- \`README.md\`: Added WebSupport to the supported services list (between Sitelutions and Yandex)
- \`ddclient.conf.in\`: Added commented WebSupport example block after Spaceship
- \`ChangeLog.md\`: Added entry under v4.0.1-rc.2 New features section

## Test plan

- [ ] Run \`ddclient --help\` and confirm WebSupport example appears in dyndns2 output
- [ ] Confirm a real WebSupport account can update DNS with these settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)