### PR TITLE
docs: add LuaDNS as supported dyndns2 provider

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -61,6 +61,8 @@ repository history](https://github.com/ddclient/ddclient/commits/main).
     [#882](https://github.com/ddclient/ddclient/pull/882)
   * Added `ddnss` protocol for DDNSS.de (https://ddnss.de) key-based
     authentication, complementing existing dyndns2 username/password support.
+  * Added `LuaDNS` (https://luadns.com) as a supported `dyndns2` provider
+    via `app.luadns.com`. Use your account email as login and API key as password.
 
 ### Improvements
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Dynamic DNS services currently supported include:
   * [IONOS](https://ionos.com)
   * [Joker.com](https://joker.com)
   * [Loopia](https://www.loopia.se)
+  * [LuaDNS](https://luadns.com)
   * [Mythic Beasts](https://www.mythic-beasts.com/support/api/dnsv2/dynamic-dns)
   * [NameCheap](https://www.namecheap.com)
   * [NearlyFreeSpeech.net](https://www.nearlyfreespeech.net/services/dns)

--- a/ddclient.conf.in
+++ b/ddclient.conf.in
@@ -557,3 +557,13 @@ pid=@runstatedir@/ddclient.pid  # record PID in file.
 # login=my-updatedip-login
 # password=my-updatedip-password
 # subdomain.updatedip.com
+
+##
+## LuaDNS (https://luadns.com) - programmable DNS with DDNS support
+## Use your account email as login and your API key as password.
+##
+# protocol=dyndns2,                         \
+# server=app.luadns.com,                    \
+# login=your-luadns-email,                  \
+# password=your-luadns-api-key              \
+# yourhostname.example.com

--- a/ddclient.in
+++ b/ddclient.in
@@ -4129,6 +4129,14 @@ Example ${program}.conf file entries:
   login=your-joker-ddns-login,                              \\
   password=your-joker-ddns-password                         \\
   myhost.example.com
+
+  ## LuaDNS (https://luadns.com) - programmable DNS with DDNS support
+  ## Use your account email as login and your API key as password.
+  protocol=dyndns2,                                         \\
+  server=app.luadns.com,                                    \\
+  login=your-luadns-email,                                  \\
+  password=your-luadns-api-key                              \\
+  yourhostname.example.com
 EoEXAMPLE
 }
 


### PR DESCRIPTION
## Summary

- Documents [LuaDNS](https://luadns.com) as a \`dyndns2\`-compatible provider
- Server: \`app.luadns.com\`
- Authentication: account email as login, API key as password

## Changes

- \`ddclient.in\`: Added LuaDNS example block in \`nic_dyndns2_examples\`
- \`README.md\`: Added LuaDNS to the supported services list (between Loopia and Mythic Beasts)
- \`ddclient.conf.in\`: Added commented LuaDNS example block (after Spaceship)
- \`ChangeLog.md\`: Added entry under v4.0.1-rc.2 New feature section

## Test plan

- [ ] Run \`ddclient --help\` and confirm LuaDNS example appears in dyndns2 output
- [ ] Confirm a real LuaDNS account can update DNS with these settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)