### PR TITLE
docs: add NIC.RU as supported dyndns2 provider

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -39,6 +39,8 @@ repository history](https://github.com/ddclient/ddclient/commits/main).
   * Documented `ISC BIND` (https://www.isc.org/bind/), `Knot DNS` (https://www.knot-dns.cz/),
     and `Technitium DNS Server` (https://technitium.com/dns/) as supported via
     `protocol=nsupdate` (RFC 2136 DNS UPDATE).
+  * Added `NIC.RU` (https://www.nic.ru) as a supported `dyndns2` provider
+    via `api.nic.ru` for Russian .ru domain dynamic DNS.
   * Add a jitter to the daemon interval when in daemon mode to spread the web service
     API calls across clients and reduce load on upstream DNS providers when many
     clients are running with the same daemon interval.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Dynamic DNS services currently supported include:
   * [Mythic Beasts](https://www.mythic-beasts.com/support/api/dnsv2/dynamic-dns)
   * [NameCheap](https://www.namecheap.com)
   * [NearlyFreeSpeech.net](https://www.nearlyfreespeech.net/services/dns)
+  * [NIC.RU](https://www.nic.ru)
   * [Njalla](https://njal.la/docs/ddns)
   * [Noip](https://www.noip.com)
   * [NS1 / IBM NS1 Connect](https://ns1.com)

--- a/ddclient.conf.in
+++ b/ddclient.conf.in
@@ -561,6 +561,16 @@ pid=@runstatedir@/ddclient.pid  # record PID in file.
 # yourhost.yourdomain.com
 
 ##
+## NIC.RU (https://www.nic.ru) - Russian .ru domain registry
+## Use your NIC.RU account login and password from the DNS hosting panel.
+##
+# protocol=dyndns2,                         \
+# server=api.nic.ru,                        \
+# login=your-nicru-login,                   \
+# password=your-nicru-password              \
+# yourhostname.example.ru
+
+##
 ## UpdatedIP (updatedip.com)
 ##
 # protocol=dyndns2

--- a/ddclient.in
+++ b/ddclient.in
@@ -4147,6 +4147,14 @@ Example ${program}.conf file entries:
   password=your-luadns-api-key                              \\
   yourhostname.example.com
 
+  ## NIC.RU (https://www.nic.ru) - Russian .ru domain registry with DDNS support
+  ## Use your NIC.RU account login and password from the DNS hosting panel.
+  protocol=dyndns2,                                         \\
+  server=api.nic.ru,                                        \\
+  login=your-nicru-login,                                   \\
+  password=your-nicru-password                              \\
+  yourhostname.example.ru
+
   ## PowerDNS via PowerDNS-Admin (https://github.com/PowerDNS-Admin/PowerDNS-Admin)
   ## Self-hosted PowerDNS with dyndns2-compatible /nic/update endpoint.
   ## Replace 'your.powerdns-admin.example.com' with your PowerDNS-Admin hostname.


### PR DESCRIPTION
## Summary

- Documents [NIC.RU](https://www.nic.ru) as a \`dyndns2\`-compatible provider
- Server: \`api.nic.ru\`
- Russian .ru domain registry with DDNS support; standard HTTP Basic auth

## Changes

- \`ddclient.in\`: Added NIC.RU example block in \`nic_dyndns2_examples\`
- \`README.md\`: Added NIC.RU to the supported services list (between NearlyFreeSpeech.net and Njalla)
- \`ddclient.conf.in\`: Added commented NIC.RU example block (after Spaceship)
- \`ChangeLog.md\`: Added entry under v4.0.1-rc.2 New feature section

## Test plan

- [ ] Run \`ddclient --help\` and confirm NIC.RU example appears in dyndns2 output
- [ ] Confirm a real NIC.RU account can update DNS with these settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)