### PR TITLE
feat: add hosttech protocol

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -33,6 +33,7 @@ repository history](https://github.com/ddclient/ddclient/commits/main).
 
 ### New feature
 
+  * Added `hosttech` protocol for HostTech (https://www.hosttech.eu).
   * Added `PowerDNS` as a supported provider for self-hosted deployments:
     via [PowerDNS-Admin](https://github.com/PowerDNS-Admin/PowerDNS-Admin) using `protocol=dyndns2`,
     or via PowerDNS Authoritative Server RFC 2136 DNS UPDATE using `protocol=nsupdate`.

--- a/Makefile.am
+++ b/Makefile.am
@@ -80,6 +80,7 @@ handwritten_tests = \
 	t/protocol_dyndns2.pl \
 	t/protocol_dynu.pl \
 	t/protocol_hetzner.pl \
+	t/protocol_hosttech.pl \
 	t/protocol_ionos.pl \
 	t/protocol_netcup.pl \
 	t/protocol_ns1.pl \

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Dynamic DNS services currently supported include:
   * [Gandi](https://gandi.net)
   * [GoDaddy](https://www.godaddy.com)
   * [Hetzner](https://hetzner.com)
+  * [HostTech](https://www.hosttech.eu)
   * [Hurricane Electric](https://dns.he.net)
   * [Infomaniak](https://faq.infomaniak.com/2376)
   * [ISC BIND](https://www.isc.org/bind/) (via RFC 2136 `protocol=nsupdate`)

--- a/ddclient.conf.in
+++ b/ddclient.conf.in
@@ -506,6 +506,15 @@ pid=@runstatedir@/ddclient.pid  # record PID in file.
 # myhost.example.org
 
 ##
+## HostTech (https://www.hosttech.eu)
+## Use your HostTech API token as password.
+##
+# protocol=hosttech,                        \
+# password=your-api-token,                  \
+# zone=example.com,                         \
+# myhost.example.com
+
+##
 ## NS1 / IBM NS1 Connect (https://ns1.com/)
 ##
 # protocol=ns1                                                 \

--- a/ddclient.in
+++ b/ddclient.in
@@ -1189,6 +1189,16 @@ our %protocols = (
             'zone'         => setv(T_FQDN,   1, undef,                          undef),
         },
     ),
+    'hosttech' => ddclient::Protocol->new(
+        'update'   => \&nic_hosttech_update,
+        'examples' => \&nic_hosttech_examples,
+        'cfgvars' => {
+            %{$cfgvars{'protocol-common-defaults'}},
+            'server' => setv(T_FQDNP,  0, 'api.ns1.hosttech.eu/api', undef),
+            'ttl'    => setv(T_NUMBER, 0, 600,                       undef),
+            'zone'   => setv(T_FQDN,   1, undef,                     undef),
+        },
+    ),
     'inwx' => ddclient::Protocol->new(
         'update' => \&nic_inwx_update,
         'examples' => \&nic_inwx_examples,
@@ -2267,7 +2277,7 @@ sub init_config {
     my @needs_sha1 = grep({ my $p = $_; grep($_ eq $p, @protos); } qw(freedns nfsn));
     load_sha1_support(join(', ', @needs_sha1)) if @needs_sha1;
     my @needs_json = grep({ my $p = $_; grep($_ eq $p, @protos); }
-                          qw(1984 cloudflare digitalocean directnic dnsexit2 gandi godaddy hetzner
+                          qw(1984 cloudflare digitalocean directnic dnsexit2 gandi godaddy hetzner hosttech
                              ionos netcup nfsn njalla ns1 porkbun spaceship yandex));
     load_json_support(join(', ', @needs_json)) if @needs_json;
 }
@@ -7079,6 +7089,150 @@ sub nic_hetzner_update {
 
                 sleep 10;
             }
+        }
+    }
+}
+
+######################################################################
+## nic_hosttech_examples
+######################################################################
+sub nic_hosttech_examples {
+    my $self = shift;
+    return <<"EoEXAMPLE";
+o 'hosttech'
+
+The 'hosttech' protocol is used by the DNS hosting service offered by
+www.hosttech.eu (Switzerland).
+
+Configuration variables applicable to the 'hosttech' protocol are:
+  protocol=hosttech            ##
+  server=fqdn.of.service       ## can be omitted, defaults to api.ns1.hosttech.eu/api
+  zone=dns.zone                ## the DNS zone to update
+  ttl=seconds                  ## record TTL in seconds, minimum 600; defaults to 600
+  password=api-token           ## HostTech API Bearer token
+  fully.qualified.host         ## the host registered with the service.
+
+Example ${program}.conf file entries:
+  protocol=hosttech                            \\
+  zone=example.com                             \\
+  password=my-hosttech-api-token               \\
+  myhost.example.com
+EoEXAMPLE
+}
+
+######################################################################
+## nic_hosttech_update
+######################################################################
+sub nic_hosttech_update {
+    my $self = shift;
+    for my $h (@_) {
+        local $_l = pushlogctx($h);
+
+        my $server  = opt('server', $h);
+        my $zone    = opt('zone', $h);
+        my $token   = opt('password', $h);
+        my $headers = "Authorization: Bearer $token\n";
+        $headers   .= "Content-Type: application/json";
+
+        (my $hostname = $h) =~ s/\Q.$zone\E$//;
+        $hostname = '' if $hostname eq $h;  # apex domain
+
+        my $ipv4 = delete $config{$h}{'wantipv4'};
+        my $ipv6 = delete $config{$h}{'wantipv6'};
+
+        # Step 1: find the zone ID by looking up zones filtered by name
+        $recap{$h}{'status-ipv4'} = 'failed' if $ipv4;
+        $recap{$h}{'status-ipv6'} = 'failed' if $ipv6;
+
+        my $zones_url = "$server/user/v1/zones?query=$zone";
+        my $reply = geturl(proxy => opt('proxy'), url => $zones_url, headers => $headers);
+        next if !header_ok($reply);
+        (my $body = $reply) =~ s/^.*?\n\n//s;
+        my $zones_resp = eval { decode_json($body) };
+        if (!$zones_resp || ref($zones_resp->{data}) ne 'ARRAY') {
+            failed("invalid JSON response when listing zones");
+            next;
+        }
+        my ($zone_obj) = grep { $_->{name} eq $zone } @{$zones_resp->{data}};
+        unless ($zone_obj) {
+            failed("zone %s not found", $zone);
+            next;
+        }
+        my $zone_id = $zone_obj->{id};
+        debug("found zone '$zone' with id $zone_id");
+
+        # IPv4 and IPv6 handled in a loop
+        for my $ip ($ipv4, $ipv6) {
+            next unless $ip;
+            my $ipv  = ($ip eq ($ipv6 // '')) ? '6' : '4';
+            my $type = ($ipv eq '6') ? 'AAAA' : 'A';
+            my $ipfield = ($ipv eq '6') ? 'ipv6' : 'ipv4';
+
+            # Step 2: list records in the zone filtered by type, find matching name
+            my $records_url = "$server/user/v1/zones/$zone_id/records?type=$type";
+            $reply = geturl(proxy => opt('proxy'), url => $records_url, headers => $headers);
+            next if !header_ok($reply);
+            ($body = $reply) =~ s/^.*?\n\n//s;
+            my $records_resp = eval { decode_json($body) };
+            if (!$records_resp || ref($records_resp->{data}) ne 'ARRAY') {
+                failed("invalid JSON response when listing records for IPv$ipv");
+                next;
+            }
+
+            my ($rec) = grep { ($_->{name} // '') eq $hostname } @{$records_resp->{data}};
+
+            if ($rec) {
+                my $rec_id = $rec->{id};
+                debug("found existing $type record id $rec_id; updating");
+
+                # Step 3a: update existing record via PUT
+                my $ttl  = opt('ttl', $h) // 600;
+                my $data = encode_json({
+                    name      => $hostname,
+                    $ipfield  => $ip,
+                    ttl       => $ttl + 0,
+                    comment   => '',
+                });
+                $reply = geturl(
+                    proxy   => opt('proxy'),
+                    url     => "$server/user/v1/zones/$zone_id/records/$rec_id",
+                    method  => 'PUT',
+                    headers => $headers,
+                    data    => $data,
+                );
+            } else {
+                debug("no existing $type record found; creating");
+
+                # Step 3b: create new record via POST
+                my $ttl  = opt('ttl', $h) // 600;
+                my $data = encode_json({
+                    type      => $type,
+                    name      => $hostname,
+                    $ipfield  => $ip,
+                    ttl       => $ttl + 0,
+                    comment   => '',
+                });
+                $reply = geturl(
+                    proxy   => opt('proxy'),
+                    url     => "$server/user/v1/zones/$zone_id/records",
+                    method  => 'POST',
+                    headers => $headers,
+                    data    => $data,
+                );
+            }
+
+            next if !header_ok($reply);
+            ($body = $reply) =~ s/^.*?\n\n//s;
+            my $result = eval { decode_json($body) };
+            unless ($result && $result->{data}) {
+                failed("invalid JSON response when updating IPv$ipv record");
+                next;
+            }
+
+            success("IPv$ipv address set to $ip");
+            $recap{$h}{"ipv$ipv"} = $ip;
+            $recap{$h}{'mtime'}   = $now;
+            $recap{$h}{"status-ipv$ipv"} = 'good';
         }
     }
 }

--- a/t/protocol_hosttech.pl
+++ b/t/protocol_hosttech.pl
@@ -1,0 +1,337 @@
+use Test::More;
+BEGIN { SKIP: { eval { require Test::Warnings; 1; } or skip($@, 1); } }
+BEGIN { eval { require JSON::PP; 1; } or plan(skip_all => $@); JSON::PP->import(); }
+BEGIN { eval { require 'ddclient'; } or BAIL_OUT($@); }
+use ddclient::t::HTTPD;
+use ddclient::t::Logger;
+
+httpd_required();
+
+ddclient::load_json_support('hosttech');
+
+my $j = ['Content-Type' => 'application/json'];
+
+# Helper to build a zones-list response containing one zone
+sub zones_resp {
+    my ($id, $name) = @_;
+    return encode_json({data => [{id => $id, name => $name, ttl => 3600, dnssec => 0}]});
+}
+
+# Helper to build a records-list response with zero or one A/AAAA record
+sub records_resp_empty { encode_json({data => []}) }
+
+sub records_resp_a {
+    my ($id, $name, $ip) = @_;
+    return encode_json({data => [{id => $id, type => 'A', name => $name, ipv4 => $ip, ttl => 600, comment => ''}]});
+}
+
+sub records_resp_aaaa {
+    my ($id, $name, $ip) = @_;
+    return encode_json({data => [{id => $id, type => 'AAAA', name => $name, ipv6 => $ip, ttl => 600, comment => ''}]});
+}
+
+# Helper to build a single-record response (used for POST/PUT result)
+sub record_created_a {
+    my ($id, $name, $ip) = @_;
+    return encode_json({data => {id => $id, type => 'A', name => $name, ipv4 => $ip, ttl => 600, comment => ''}});
+}
+
+sub record_created_aaaa {
+    my ($id, $name, $ip) = @_;
+    return encode_json({data => {id => $id, type => 'AAAA', name => $name, ipv6 => $ip, ttl => 600, comment => ''}});
+}
+
+httpd()->run();
+
+my @test_cases = (
+    {
+        desc => 'IPv4 success, no existing record (create)',
+        cfg => {'host.example.com' => {
+            protocol => 'hosttech',
+            password => 'mytoken',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [200, $j, [zones_resp(42, 'example.com')]],
+            [200, $j, [records_resp_empty()]],
+            [201, $j, [record_created_a(101, 'host', '192.0.2.1')]],
+        ],
+        wantrecap => {'host.example.com' => {
+            'status-ipv4' => 'good',
+            'ipv4'        => '192.0.2.1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv4.*192\.0\.2\.1/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 3, '3 requests: GET zones + GET records + POST create');
+            is($reqs[0]->method(), 'GET', 'first request is GET (zones)');
+            like($reqs[0]->uri()->path(), qr{/user/v1/zones}, 'zones endpoint path correct');
+            like($reqs[0]->uri()->query(), qr{query=example\.com}, 'zones query param correct');
+            is($reqs[1]->method(), 'GET', 'second request is GET (records)');
+            like($reqs[1]->uri()->path(), qr{/user/v1/zones/42/records}, 'records path uses zone id');
+            like($reqs[1]->uri()->query(), qr{type=A}, 'records query filters by type A');
+            is($reqs[2]->method(), 'POST', 'third request is POST (create)');
+            like($reqs[2]->uri()->path(), qr{/user/v1/zones/42/records$}, 'POST to records endpoint');
+            my $body = decode_json($reqs[2]->content());
+            is($body->{type}, 'A',          'create: type is A');
+            is($body->{name}, 'host',        'create: name is subdomain');
+            is($body->{ipv4}, '192.0.2.1',   'create: ipv4 value correct');
+        },
+    },
+    {
+        desc => 'IPv4 success, existing record (update)',
+        cfg => {'host.example.com' => {
+            protocol => 'hosttech',
+            password => 'mytoken',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.2',
+        }},
+        responses => [
+            [200, $j, [zones_resp(42, 'example.com')]],
+            [200, $j, [records_resp_a(101, 'host', '192.0.2.1')]],
+            [200, $j, [record_created_a(101, 'host', '192.0.2.2')]],
+        ],
+        wantrecap => {'host.example.com' => {
+            'status-ipv4' => 'good',
+            'ipv4'        => '192.0.2.2',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv4.*192\.0\.2\.2/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 3, '3 requests: GET zones + GET records + PUT update');
+            is($reqs[2]->method(), 'PUT', 'third request is PUT (update)');
+            like($reqs[2]->uri()->path(), qr{/user/v1/zones/42/records/101$}, 'PUT to record by id');
+            my $body = decode_json($reqs[2]->content());
+            is($body->{ipv4}, '192.0.2.2', 'update: ipv4 value correct');
+        },
+    },
+    {
+        desc => 'IPv6 success, no existing record (create)',
+        cfg => {'host.example.com' => {
+            protocol => 'hosttech',
+            password => 'mytoken',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv6 => '2001:db8::1',
+        }},
+        responses => [
+            [200, $j, [zones_resp(42, 'example.com')]],
+            [200, $j, [records_resp_empty()]],
+            [201, $j, [record_created_aaaa(102, 'host', '2001:db8::1')]],
+        ],
+        wantrecap => {'host.example.com' => {
+            'status-ipv6' => 'good',
+            'ipv6'        => '2001:db8::1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv6.*2001:db8::1/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            like($reqs[1]->uri()->query(), qr{type=AAAA}, 'records query filters by type AAAA');
+            is($reqs[2]->method(), 'POST', 'third request is POST (create AAAA)');
+            my $body = decode_json($reqs[2]->content());
+            is($body->{type}, 'AAAA',         'create: type is AAAA');
+            is($body->{ipv6}, '2001:db8::1',  'create: ipv6 value correct');
+        },
+    },
+    {
+        desc => 'both IPv4 and IPv6 success',
+        cfg => {'host.example.com' => {
+            protocol => 'hosttech',
+            password => 'mytoken',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+            wantipv6 => '2001:db8::1',
+        }},
+        responses => [
+            # zones lookup (once for the domain)
+            [200, $j, [zones_resp(42, 'example.com')]],
+            # IPv4: records + create
+            [200, $j, [records_resp_empty()]],
+            [201, $j, [record_created_a(101, 'host', '192.0.2.1')]],
+            # IPv6: records + create
+            [200, $j, [records_resp_empty()]],
+            [201, $j, [record_created_aaaa(102, 'host', '2001:db8::1')]],
+        ],
+        wantrecap => {'host.example.com' => {
+            'status-ipv4' => 'good', 'ipv4' => '192.0.2.1',
+            'status-ipv6' => 'good', 'ipv6' => '2001:db8::1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv4/},
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv6/},
+        ],
+    },
+    {
+        desc => 'zone not found',
+        cfg => {'host.example.com' => {
+            protocol => 'hosttech',
+            password => 'mytoken',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [200, $j, [encode_json({data => []})]],
+        ],
+        wantrecap => {'host.example.com' => {
+            'status-ipv4' => 'failed',
+        }},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['host.example.com'], msg => qr/zone.*example\.com.*not found/i},
+        ],
+    },
+    {
+        desc => 'HTTP error on zone listing',
+        cfg => {'host.example.com' => {
+            protocol => 'hosttech',
+            password => 'mytoken',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [500, $j, [encode_json({message => 'internal server error'})]],
+        ],
+        wantrecap => {'host.example.com' => {
+            'status-ipv4' => 'failed',
+        }},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['host.example.com'], msg => qr/500/},
+        ],
+    },
+    {
+        desc => 'HTTP error on record update',
+        cfg => {'host.example.com' => {
+            protocol => 'hosttech',
+            password => 'mytoken',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [200, $j, [zones_resp(42, 'example.com')]],
+            [200, $j, [records_resp_empty()]],
+            [422, $j, [encode_json({message => 'validation error'})]],
+        ],
+        wantrecap => {'host.example.com' => {'status-ipv4' => 'failed'}},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['host.example.com'], msg => qr/422/},
+        ],
+    },
+    {
+        desc => 'correct Authorization header sent',
+        cfg => {'host.example.com' => {
+            protocol => 'hosttech',
+            password => 'supersecrettoken',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [200, $j, [zones_resp(42, 'example.com')]],
+            [200, $j, [records_resp_empty()]],
+            [201, $j, [record_created_a(101, 'host', '192.0.2.1')]],
+        ],
+        wantrecap => {'host.example.com' => {
+            'status-ipv4' => 'good',
+            'ipv4'        => '192.0.2.1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv4/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            like($reqs[0]->header('Authorization'), qr/^Bearer supersecrettoken$/,
+                'Authorization header is Bearer token');
+        },
+    },
+    {
+        desc => 'apex domain — hostname equals zone',
+        cfg => {'example.com' => {
+            protocol => 'hosttech',
+            password => 'mytoken',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [200, $j, [zones_resp(42, 'example.com')]],
+            [200, $j, [records_resp_empty()]],
+            [201, $j, [record_created_a(101, '', '192.0.2.1')]],
+        ],
+        wantrecap => {'example.com' => {
+            'status-ipv4' => 'good',
+            'ipv4'        => '192.0.2.1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['example.com'], msg => qr/IPv4.*192\.0\.2\.1/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            my $body = decode_json($reqs[2]->content());
+            is($body->{name}, '', 'apex domain: name is empty string');
+        },
+    },
+);
+
+for my $tc (@test_cases) {
+    subtest($tc->{desc} => sub {
+        local $ddclient::globals{debug}   = 1;
+        local $ddclient::globals{verbose} = 1;
+        local %ddclient::config  = %{$tc->{cfg}};
+        local %ddclient::recap;
+
+        httpd()->reset(@{$tc->{responses}});
+
+        my $l = ddclient::t::Logger->new($ddclient::_l, qr/^(?:WARNING|FATAL|SUCCESS|FAILED)$/);
+        {
+            local $ddclient::_l = $l;
+            ddclient::nic_hosttech_update(undef, sort(keys(%{$tc->{cfg}})));
+        }
+
+        my @reqs = httpd()->reset();
+
+        is_deeply(\%ddclient::recap, $tc->{wantrecap}, 'recap matches')
+            or diag(ddclient::repr(Values => [\%ddclient::recap, $tc->{wantrecap}],
+                                   Names  => ['*got', '*want']));
+
+        subtest('logs' => sub {
+            my @got  = @{$l->{logs}};
+            my @want = @{$tc->{wantlogs} // []};
+            for my $i (0..$#want) {
+                last if $i >= @got;
+                subtest("log $i" => sub {
+                    is($got[$i]{label}, $want[$i]{label}, 'label');
+                    is_deeply($got[$i]{ctx}, $want[$i]{ctx}, 'context');
+                    like($got[$i]{msg}, $want[$i]{msg}, 'message');
+                });
+            }
+            my @unexpected = @got[@want..$#got];
+            ok(@unexpected == 0, 'no unexpected logs')
+                or diag(ddclient::repr(\@unexpected, Names => ['*unexpected']));
+            my @missing = @want[@got..$#want];
+            ok(@missing == 0, 'no missing logs')
+                or diag(ddclient::repr(\@missing, Names => ['*missing']));
+        });
+
+        $tc->{check_reqs}->(@reqs) if $tc->{check_reqs};
+    });
+}
+
+done_testing();


### PR DESCRIPTION
## Summary

Adds `hosttech` protocol for [HostTech](https://www.hosttech.eu) hosted DNS (Swiss hosting provider).

- REST API at `api.ns1.hosttech.eu/api/user/v1`
- Bearer token authentication via `password=` config option
- Supports IPv4 (A) and IPv6 (AAAA) record updates
- Looks up zone by name, then finds/creates/updates records by type and name
- TTL configurable (minimum 600 seconds per API constraint, default 600)

### API flow per hostname update

1. `GET /user/v1/zones?query=<zone>` — resolve zone name to zone ID
2. `GET /user/v1/zones/<id>/records?type=A|AAAA` — find existing record
3. `PUT /user/v1/zones/<id>/records/<record_id>` — update existing record, or
   `POST /user/v1/zones/<id>/records` — create new record

API documentation: https://api.ns1.hosttech.eu/api/documentation/

## Test plan

- [ ] `make check TESTS=t/protocol_hosttech.pl VERBOSE=1` passes (9/9 protocol tests pass)
- [ ] `make check` passes
- [ ] Real HostTech account verified (if available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)