### PR TITLE
feat: add Scaleway DNS protocol

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -69,6 +69,7 @@ repository history](https://github.com/ddclient/ddclient/commits/main).
     [#907](https://github.com/ddclient/ddclient/pull/907)
   * Added `spaceship` protocol for Spaceship (https://www.spaceship.com/).
     [#896](https://github.com/ddclient/ddclient/pull/896)
+  * Added `scaleway` protocol for Scaleway DNS (https://www.scaleway.com/en/dns/).
   * Added `updatedip` built-in web IP check service for UpdatedIP (https://www.updatedip.com).
     [#868](https://github.com/ddclient/ddclient/pull/868)
   * Added `dynadot` protocol for Dynadot (https://www.dynadot.com/).

--- a/Makefile.am
+++ b/Makefile.am
@@ -82,6 +82,7 @@ handwritten_tests = \
 	t/protocol_hetzner.pl \
 	t/protocol_ionos.pl \
 	t/protocol_ns1.pl \
+	t/protocol_scaleway.pl \
 	t/protocol_simplycom.pl \
 	t/protocol_spaceship.pl \
 	t/read_recap.pl \

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Dynamic DNS services currently supported include:
   * [Porkbun](https://porkbun.com)
   * [PowerDNS](https://www.powerdns.com) (via [PowerDNS-Admin](https://github.com/PowerDNS-Admin/PowerDNS-Admin) with `protocol=dyndns2`, or via RFC 2136 DNS UPDATE with `protocol=nsupdate`)
   * [regfish.de](https://www.regfish.de/domains/dyndns)
+  * [Scaleway](https://www.scaleway.com/en/dns/)
   * [Simply.com](https://www.simply.com)
   * [Sitelutions](https://www.sitelutions.com)
   * [Technitium DNS Server](https://technitium.com/dns/) (via RFC 2136 `protocol=nsupdate`)

--- a/ddclient.conf.in
+++ b/ddclient.conf.in
@@ -561,6 +561,16 @@ pid=@runstatedir@/ddclient.pid  # record PID in file.
 # yourhost.yourdomain.com
 
 ##
+## LuaDNS (https://luadns.com) - programmable DNS with DDNS support
+## Use your account email as login and your API key as password.
+##
+# protocol=dyndns2,                         \
+# server=app.luadns.com,                    \
+# login=your-luadns-email,                  \
+# password=your-luadns-api-key              \
+# yourhostname.example.com
+
+##
 ## NIC.RU (https://www.nic.ru) - Russian .ru domain registry
 ## Use your NIC.RU account login and password from the DNS hosting panel.
 ##
@@ -571,6 +581,15 @@ pid=@runstatedir@/ddclient.pid  # record PID in file.
 # yourhostname.example.ru
 
 ##
+## Scaleway DNS (https://www.scaleway.com/en/dns/)
+## Use your Scaleway API secret key as password.
+##
+# protocol=scaleway,                        \
+# password=your-scaleway-api-key,           \
+# zone=example.com,                         \
+# myhost.example.com
+
+##
 ## UpdatedIP (updatedip.com)
 ##
 # protocol=dyndns2
@@ -578,16 +597,6 @@ pid=@runstatedir@/ddclient.pid  # record PID in file.
 # login=my-updatedip-login
 # password=my-updatedip-password
 # subdomain.updatedip.com
-
-##
-## LuaDNS (https://luadns.com) - programmable DNS with DDNS support
-## Use your account email as login and your API key as password.
-##
-# protocol=dyndns2,                         \
-# server=app.luadns.com,                    \
-# login=your-luadns-email,                  \
-# password=your-luadns-api-key              \
-# yourhostname.example.com
 
 ##
 ## WebSupport (https://www.websupport.sk)

--- a/ddclient.in
+++ b/ddclient.in
@@ -1319,6 +1319,7 @@ our %protocols = (
             'password' => undef,
             'zone'     => setv(T_FQDN,  1, undef,                          undef),
             'ttl'      => setv(T_NUMBER, 0, 300,                            undef),
+            'ssl'      => setv(T_BOOL,   0, 1,                                 undef),
             'server'   => setv(T_FQDNP,  0, 'api.scaleway.com/domain/v2beta1', undef),
         },
     ),

--- a/ddclient.in
+++ b/ddclient.in
@@ -1311,6 +1311,17 @@ our %protocols = (
             'server'   => setv(T_FQDNP,  0, 'spaceship.dev', undef),
         },
     ),
+    'scaleway' => ddclient::Protocol->new(
+        'update'   => \&nic_scaleway_update,
+        'examples' => \&nic_scaleway_examples,
+        'cfgvars'  => {
+            %{$cfgvars{'protocol-common-defaults'}},
+            'password' => undef,
+            'zone'     => setv(T_FQDN,  1, undef,                          undef),
+            'ttl'      => setv(T_NUMBER, 0, 300,                            undef),
+            'server'   => setv(T_FQDNP,  0, 'api.scaleway.com/domain/v2beta1', undef),
+        },
+    ),
     'sitelutions' => ddclient::LegacyProtocol->new(
         'update'     => \&nic_sitelutions_update,
         'examples'   => \&nic_sitelutions_examples,
@@ -2254,7 +2265,7 @@ sub init_config {
     load_sha1_support(join(', ', @needs_sha1)) if @needs_sha1;
     my @needs_json = grep({ my $p = $_; grep($_ eq $p, @protos); }
                           qw(1984 cloudflare digitalocean directnic dnsexit2 gandi godaddy hetzner
-                             ionos nfsn njalla ns1 porkbun spaceship yandex));
+                             ionos nfsn njalla ns1 porkbun scaleway spaceship yandex));
     load_json_support(join(', ', @needs_json)) if @needs_json;
 }
 
@@ -7966,6 +7977,111 @@ sub nic_cloudns_update {
         $recap{$_}{'mtime'} = $now for @hosts;
         $recap{$_}{'status'} = 'good' for @hosts;
         success("IP address set to $ip");
+    }
+}
+
+######################################################################
+## nic_scaleway_examples
+######################################################################
+sub nic_scaleway_examples {
+    my $self = shift;
+    return <<"EoEXAMPLE";
+o 'scaleway'
+
+The 'scaleway' protocol is used by the DNS service offered by www.scaleway.com.
+
+Configuration variables applicable to the 'scaleway' protocol are:
+  protocol=scaleway            ##
+  server=fqdn.of.service       ## can be omitted, defaults to api.scaleway.com/domain/v2beta1
+  zone=dns.zone                ## the DNS zone to update (required)
+  password=service-password    ## Scaleway API secret key
+  ttl=seconds                  ## optional; DNS record TTL in seconds.  Defaults to 300.
+  fully.qualified.host         ## the host registered with the service.
+
+Example \${program}.conf file entries:
+  protocol=scaleway                                            \\
+  password=my-scaleway-api-secret-key                          \\
+  zone=example.com                                             \\
+  myhost.example.com
+
+EoEXAMPLE
+}
+
+######################################################################
+## nic_scaleway_update
+######################################################################
+sub nic_scaleway_update {
+    my $self = shift;
+    for my $h (@_) {
+        local $_l = pushlogctx($h);
+
+        my $zone = opt('zone', $h);
+        (my $subdomain = $h) =~ s/(?:^|\.)\Q$zone\E$//;
+        $subdomain ||= '@';
+
+        for my $ipv ('4', '6') {
+            my $ip = delete $config{$h}{"wantipv$ipv"} or next;
+            my $rrtype = $ipv eq '4' ? 'A' : 'AAAA';
+            $recap{$h}{"status-ipv$ipv"} = 'failed';
+            info("setting IPv$ipv address to $ip");
+
+            my $url = opt('server', $h) . "/dns-zones/$zone/records";
+            my $data = encode_json({
+                return_all_records => JSON::PP::false(),
+                changes => [{
+                    set => {
+                        name    => $subdomain,
+                        type    => $rrtype,
+                        records => [{
+                            name => $subdomain,
+                            data => $ip,
+                            type => $rrtype,
+                            ttl  => opt('ttl', $h) + 0,
+                        }],
+                    },
+                }],
+            });
+            my $reply = geturl(
+                proxy   => opt('proxy'),
+                url     => $url,
+                method  => 'PATCH',
+                headers => [
+                    'Content-Type: application/json',
+                    'Accept: application/json',
+                    'X-Auth-Token: ' . opt('password', $h),
+                ],
+                data    => $data,
+            );
+
+            if (!$reply) {
+                failed("could not connect to " . opt('server', $h));
+                next;
+            }
+
+            my ($status) = ($reply =~ m{^HTTP/\S+\s+(\d+)}i);
+            if (!defined $status) {
+                failed("unexpected HTTP response from " . opt('server', $h));
+                next;
+            }
+
+            if ($status !~ /^2/) {
+                (my $resp_body = $reply) =~ s/^.*?\n\n//s;
+                $resp_body =~ s/^\s+|\s+$//g;
+                my $detail = '';
+                if ($resp_body) {
+                    my $parsed = eval { decode_json($resp_body) };
+                    $detail = ": $parsed->{message}"
+                        if ref($parsed) eq 'HASH' && defined $parsed->{message};
+                }
+                failed("API error $status$detail");
+                next;
+            }
+
+            $recap{$h}{"ipv$ipv"}        = $ip;
+            $recap{$h}{'mtime'}          = $now;
+            $recap{$h}{"status-ipv$ipv"} = 'good';
+            success("IPv$ipv address set to $ip");
+        }
     }
 }
 

--- a/t/protocol_scaleway.pl
+++ b/t/protocol_scaleway.pl
@@ -1,0 +1,267 @@
+use Test::More;
+BEGIN { SKIP: { eval { require Test::Warnings; 1; } or skip($@, 1); } }
+BEGIN { eval { require JSON::PP; 1; } or plan(skip_all => $@); JSON::PP->import(); }
+BEGIN { eval { require 'ddclient'; } or BAIL_OUT($@); }
+use ddclient::t::HTTPD;
+use ddclient::t::Logger;
+
+httpd_required();
+
+ddclient::load_json_support('scaleway');
+
+my $j = ['Content-Type' => 'application/json'];
+
+sub records_resp {
+    encode_json({records => []});
+}
+
+httpd()->run();
+
+my @test_cases = (
+    {
+        desc => 'IPv4 success',
+        cfg => {'host.example.com' => {
+            protocol => 'scaleway',
+            password => 'mytoken',
+            zone     => 'example.com',
+            ttl      => 300,
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [200, $j, [encode_json({records => [{name => 'host', type => 'A', data => '192.0.2.1', ttl => 300}]})]],
+        ],
+        wantrecap => {'host.example.com' => {
+            'status-ipv4' => 'good',
+            'ipv4'        => '192.0.2.1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv4.*192\.0\.2\.1/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 1, 'exactly 1 PATCH request');
+            is($reqs[0]->method(), 'PATCH', 'request is PATCH');
+            like($reqs[0]->uri()->path(), qr{/dns-zones/example\.com/records}, 'path correct');
+            my $body = decode_json($reqs[0]->content());
+            is($body->{changes}[0]{set}{name},             'host',      'set name is subdomain');
+            is($body->{changes}[0]{set}{type},             'A',         'set type is A');
+            is($body->{changes}[0]{set}{records}[0]{data}, '192.0.2.1', 'record data correct');
+            is($body->{changes}[0]{set}{records}[0]{ttl},  300,         'record ttl correct');
+        },
+    },
+    {
+        desc => 'IPv6 success',
+        cfg => {'host.example.com' => {
+            protocol => 'scaleway',
+            password => 'mytoken',
+            zone     => 'example.com',
+            ttl      => 300,
+            server   => httpd()->endpoint(),
+            wantipv6 => '2001:db8::1',
+        }},
+        responses => [
+            [200, $j, [encode_json({records => [{name => 'host', type => 'AAAA', data => '2001:db8::1', ttl => 300}]})]],
+        ],
+        wantrecap => {'host.example.com' => {
+            'status-ipv6' => 'good',
+            'ipv6'        => '2001:db8::1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv6.*2001:db8::1/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 1, 'exactly 1 PATCH request');
+            my $body = decode_json($reqs[0]->content());
+            is($body->{changes}[0]{set}{type},             'AAAA',       'set type is AAAA');
+            is($body->{changes}[0]{set}{records}[0]{data}, '2001:db8::1','record data correct');
+        },
+    },
+    {
+        desc => 'both IPv4 and IPv6 success',
+        cfg => {'host.example.com' => {
+            protocol => 'scaleway',
+            password => 'mytoken',
+            zone     => 'example.com',
+            ttl      => 300,
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+            wantipv6 => '2001:db8::1',
+        }},
+        responses => [
+            [200, $j, [encode_json({records => [{name => 'host', type => 'A',    data => '192.0.2.1',   ttl => 300}]})]],
+            [200, $j, [encode_json({records => [{name => 'host', type => 'AAAA', data => '2001:db8::1', ttl => 300}]})]],
+        ],
+        wantrecap => {'host.example.com' => {
+            'status-ipv4' => 'good', 'ipv4' => '192.0.2.1',
+            'status-ipv6' => 'good', 'ipv6' => '2001:db8::1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv4/},
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv6/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 2, '2 PATCH requests: one per IP version');
+            is($reqs[0]->method(), 'PATCH', 'first is PATCH');
+            is($reqs[1]->method(), 'PATCH', 'second is PATCH');
+        },
+    },
+    {
+        desc => 'apex domain (zone == hostname)',
+        cfg => {'example.com' => {
+            protocol => 'scaleway',
+            password => 'mytoken',
+            zone     => 'example.com',
+            ttl      => 300,
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [200, $j, [encode_json({records => [{name => '@', type => 'A', data => '192.0.2.1', ttl => 300}]})]],
+        ],
+        wantrecap => {'example.com' => {
+            'status-ipv4' => 'good',
+            'ipv4'        => '192.0.2.1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['example.com'], msg => qr/IPv4/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            my $body = decode_json($reqs[0]->content());
+            is($body->{changes}[0]{set}{name}, '@', 'apex uses @ as subdomain');
+        },
+    },
+    {
+        desc => 'API error response',
+        cfg => {'host.example.com' => {
+            protocol => 'scaleway',
+            password => 'badtoken',
+            zone     => 'example.com',
+            ttl      => 300,
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [401, $j, [encode_json({message => 'Invalid authentication credentials'})]],
+        ],
+        wantrecap => {'host.example.com' => {'status-ipv4' => 'failed'}},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['host.example.com'], msg => qr/API error 401.*Invalid authentication/},
+        ],
+    },
+    {
+        desc => 'HTTP 500 error',
+        cfg => {'host.example.com' => {
+            protocol => 'scaleway',
+            password => 'mytoken',
+            zone     => 'example.com',
+            ttl      => 300,
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [500, $j, [encode_json({message => 'Internal Server Error'})]],
+        ],
+        wantrecap => {'host.example.com' => {'status-ipv4' => 'failed'}},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['host.example.com'], msg => qr/API error 500/},
+        ],
+    },
+    {
+        desc => 'correct X-Auth-Token header sent',
+        cfg => {'host.example.com' => {
+            protocol => 'scaleway',
+            password => 'supersecretkey',
+            zone     => 'example.com',
+            ttl      => 300,
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [200, $j, [encode_json({records => [{name => 'host', type => 'A', data => '192.0.2.1', ttl => 300}]})]],
+        ],
+        wantrecap => {'host.example.com' => {
+            'status-ipv4' => 'good',
+            'ipv4'        => '192.0.2.1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv4/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is($reqs[0]->header('X-Auth-Token'), 'supersecretkey',
+                'X-Auth-Token header is correct');
+        },
+    },
+    {
+        desc => 'no-op: no IPs requested',
+        cfg => {'host.example.com' => {
+            protocol => 'scaleway',
+            password => 'mytoken',
+            zone     => 'example.com',
+            ttl      => 300,
+            server   => httpd()->endpoint(),
+        }},
+        responses => [],
+        wantrecap => {},
+        wantlogs  => [],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 0, 'no requests made when no IPs requested');
+        },
+    },
+);
+
+for my $tc (@test_cases) {
+    subtest($tc->{desc} => sub {
+        local $ddclient::globals{debug}   = 1;
+        local $ddclient::globals{verbose} = 1;
+        local %ddclient::config  = %{$tc->{cfg}};
+        local %ddclient::recap;
+
+        httpd()->reset(@{$tc->{responses}});
+
+        my $l = ddclient::t::Logger->new($ddclient::_l, qr/^(?:WARNING|FATAL|SUCCESS|FAILED)$/);
+        {
+            local $ddclient::_l = $l;
+            ddclient::nic_scaleway_update(undef, sort(keys(%{$tc->{cfg}})));
+        }
+
+        my @reqs = httpd()->reset();
+
+        is_deeply(\%ddclient::recap, $tc->{wantrecap}, 'recap matches')
+            or diag(ddclient::repr(Values => [\%ddclient::recap, $tc->{wantrecap}],
+                                   Names  => ['*got', '*want']));
+
+        subtest('logs' => sub {
+            my @got  = @{$l->{logs}};
+            my @want = @{$tc->{wantlogs} // []};
+            for my $i (0..$#want) {
+                last if $i >= @got;
+                subtest("log $i" => sub {
+                    is($got[$i]{label}, $want[$i]{label}, 'label');
+                    is_deeply($got[$i]{ctx}, $want[$i]{ctx}, 'context');
+                    like($got[$i]{msg}, $want[$i]{msg}, 'message');
+                });
+            }
+            my @unexpected = @got[@want..$#got];
+            ok(@unexpected == 0, 'no unexpected logs')
+                or diag(ddclient::repr(\@unexpected, Names => ['*unexpected']));
+            my @missing = @want[@got..$#want];
+            ok(@missing == 0, 'no missing logs')
+                or diag(ddclient::repr(\@missing, Names => ['*missing']));
+        });
+
+        $tc->{check_reqs}->(@reqs) if $tc->{check_reqs};
+    });
+}
+
+done_testing();


### PR DESCRIPTION
## Summary

- Adds `scaleway` protocol for Scaleway DNS (https://www.scaleway.com/en/dns/)
- Uses the Scaleway Domains and DNS REST API v2beta1 via `PATCH /dns-zones/{zone}/records`
- Authenticates with `X-Auth-Token` header using an API secret key
- Supports IPv4 (A) and IPv6 (AAAA) record updates via the `changes`/`set` operation
- A single PATCH request per IP version — no pre-flight GET needed

## Files changed

- `ddclient.in`: `nic_scaleway_examples`, `nic_scaleway_update`, `%protocols` entry, `@needs_json`
- `t/protocol_scaleway.pl`: 8 test cases (IPv4, IPv6, dual-stack, apex, auth, API error, HTTP 500, no-op)
- `Makefile.am`: add test to `handwritten_tests`
- `README.md`: add Scaleway to supported providers list
- `ddclient.conf.in`: add example configuration block
- `ChangeLog.md`: add entry under `v4.0.1-rc.2` New feature

## Test plan

- [ ] `make check TESTS=t/protocol_scaleway.pl VERBOSE=1` — all 9 tests pass
- [ ] `make check` — full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)