### PR TITLE
feat: add Netlify DNS protocol

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -33,6 +33,7 @@ repository history](https://github.com/ddclient/ddclient/commits/main).
 
 ### New feature
 
+  * Added `netlify` protocol for Netlify DNS (https://docs.netlify.com/domains-https/netlify-dns/).
   * Added `PowerDNS` as a supported provider for self-hosted deployments:
     via [PowerDNS-Admin](https://github.com/PowerDNS-Admin/PowerDNS-Admin) using `protocol=dyndns2`,
     or via PowerDNS Authoritative Server RFC 2136 DNS UPDATE using `protocol=nsupdate`.

--- a/Makefile.am
+++ b/Makefile.am
@@ -81,6 +81,7 @@ handwritten_tests = \
 	t/protocol_dynu.pl \
 	t/protocol_hetzner.pl \
 	t/protocol_ionos.pl \
+	t/protocol_netlify.pl \
 	t/protocol_ns1.pl \
 	t/protocol_simplycom.pl \
 	t/protocol_spaceship.pl \

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Dynamic DNS services currently supported include:
   * [Mythic Beasts](https://www.mythic-beasts.com/support/api/dnsv2/dynamic-dns)
   * [NameCheap](https://www.namecheap.com)
   * [NearlyFreeSpeech.net](https://www.nearlyfreespeech.net/services/dns)
+  * [Netlify](https://docs.netlify.com/domains-https/netlify-dns/)
   * [NIC.RU](https://www.nic.ru)
   * [Njalla](https://njal.la/docs/ddns)
   * [Noip](https://www.noip.com)

--- a/ddclient.conf.in
+++ b/ddclient.conf.in
@@ -561,6 +561,25 @@ pid=@runstatedir@/ddclient.pid  # record PID in file.
 # yourhost.yourdomain.com
 
 ##
+## LuaDNS (https://luadns.com) - programmable DNS with DDNS support
+## Use your account email as login and your API key as password.
+##
+# protocol=dyndns2,                         \
+# server=app.luadns.com,                    \
+# login=your-luadns-email,                  \
+# password=your-luadns-api-key              \
+# yourhostname.example.com
+
+##
+## Netlify DNS (https://docs.netlify.com/domains-https/netlify-dns/)
+## Use your Netlify personal access token as password.
+##
+# protocol=netlify,                        \
+# password=your-netlify-access-token,      \
+# zone=example.com,                        \
+# myhost.example.com
+
+##
 ## NIC.RU (https://www.nic.ru) - Russian .ru domain registry
 ## Use your NIC.RU account login and password from the DNS hosting panel.
 ##
@@ -578,16 +597,6 @@ pid=@runstatedir@/ddclient.pid  # record PID in file.
 # login=my-updatedip-login
 # password=my-updatedip-password
 # subdomain.updatedip.com
-
-##
-## LuaDNS (https://luadns.com) - programmable DNS with DDNS support
-## Use your account email as login and your API key as password.
-##
-# protocol=dyndns2,                         \
-# server=app.luadns.com,                    \
-# login=your-luadns-email,                  \
-# password=your-luadns-api-key              \
-# yourhostname.example.com
 
 ##
 ## WebSupport (https://www.websupport.sk)

--- a/ddclient.in
+++ b/ddclient.in
@@ -1216,6 +1216,16 @@ our %protocols = (
             'server'       => setv(T_FQDNP, 0, 'dynamicdns.park-your-domain.com', undef),
         },
     ),
+    'netlify' => ddclient::Protocol->new(
+        'update'   => \&nic_netlify_update,
+        'examples' => \&nic_netlify_examples,
+        'cfgvars' => {
+            %{$cfgvars{'protocol-common-defaults'}},
+            'password' => undef,
+            'zone'     => undef,
+            'server'   => setv(T_FQDNP, 0, 'api.netlify.com/api/v1', undef),
+        },
+    ),
     'nfsn' => ddclient::LegacyProtocol->new(
         'update'     => \&nic_nfsn_update,
         'examples'   => \&nic_nfsn_examples,
@@ -2254,7 +2264,7 @@ sub init_config {
     load_sha1_support(join(', ', @needs_sha1)) if @needs_sha1;
     my @needs_json = grep({ my $p = $_; grep($_ eq $p, @protos); }
                           qw(1984 cloudflare digitalocean directnic dnsexit2 gandi godaddy hetzner
-                             ionos nfsn njalla ns1 porkbun spaceship yandex));
+                             ionos netlify nfsn njalla ns1 porkbun spaceship yandex));
     load_json_support(join(', ', @needs_json)) if @needs_json;
 }
 
@@ -5141,6 +5151,150 @@ sub nic_namecheap_update {
         } else {
             $recap{$h}{'status'} = 'failed';
             failed("invalid reply: $reply");
+        }
+    }
+}
+
+######################################################################
+
+######################################################################
+## nic_netlify_examples
+######################################################################
+sub nic_netlify_examples {
+    my $self = shift;
+    return <<"EoEXAMPLE";
+o 'netlify'
+
+The 'netlify' protocol is used by the DNS service offered by Netlify
+(https://docs.netlify.com/domains-https/netlify-dns/).
+
+Configuration variables applicable to the 'netlify' protocol are:
+  protocol=netlify             ##
+  server=fqdn.of.service       ## can be omitted, defaults to api.netlify.com/api/v1
+  zone=dns.zone                ## the DNS zone to update
+  password=service-password    ## Netlify personal access token
+  fully.qualified.host         ## the host registered with the service.
+
+Example ${program}.conf file entries:
+  protocol=netlify                                             \\
+  zone=example.com                                             \\
+  password=my-netlify-personal-access-token                    \\
+  myhost.example.com
+EoEXAMPLE
+}
+
+######################################################################
+## nic_netlify_update
+######################################################################
+sub nic_netlify_update {
+    my $self = shift;
+    for my $h (@_) {
+        local $_l = pushlogctx($h);
+
+        my $zone     = opt('zone', $h);
+        my $password = opt('password', $h);
+        my $headers  = [
+            "Authorization: Bearer $password",
+            "Content-Type: application/json",
+        ];
+        (my $hostname = $h) =~ s/\Q.$zone\E$//;
+        my $ipv4 = delete $config{$h}{'wantipv4'};
+        my $ipv6 = delete $config{$h}{'wantipv6'};
+
+        # Find the zone ID
+        info("looking up Netlify DNS zone '%s'", $zone);
+        $recap{$h}{'status-ipv4'} = 'failed' if $ipv4;
+        $recap{$h}{'status-ipv6'} = 'failed' if $ipv6;
+
+        my $url = opt('server', $h) . "/dns_zones";
+        my $reply = geturl(
+            proxy   => opt('proxy'),
+            url     => $url,
+            headers => $headers,
+        );
+        next if !header_ok($reply);
+        (my $body = $reply) =~ s/^.*?\r?\n\r?\n//s;
+        my $zones = eval { decode_json($body) };
+        if (ref($zones) ne 'ARRAY') {
+            failed("invalid JSON response from dns_zones: %s", $body);
+            next;
+        }
+        my ($zone_obj) = grep { $_->{name} eq $zone } @{$zones};
+        unless ($zone_obj && $zone_obj->{id}) {
+            failed("zone '%s' not found in Netlify DNS", $zone);
+            next;
+        }
+        my $zone_id = $zone_obj->{id};
+        info("Netlify DNS zone ID: %s", $zone_id);
+
+        # IPv4 and IPv6 handling are similar enough to do in a loop...
+        for my $ip ($ipv4, $ipv6) {
+            next if !$ip;
+            my $ipv  = ($ip eq ($ipv6 // '')) ? '6' : '4';
+            my $type = ($ip eq ($ipv6 // '')) ? 'AAAA' : 'A';
+
+            info("setting IPv%s address to %s", $ipv, $ip);
+            $recap{$h}{"status-ipv$ipv"} = 'failed';
+
+            # List existing records to find a matching record to delete
+            $url   = opt('server', $h) . "/dns_zones/$zone_id/dns_records";
+            $reply = geturl(
+                proxy   => opt('proxy'),
+                url     => $url,
+                headers => $headers,
+            );
+            next if !header_ok($reply);
+            ($body = $reply) =~ s/^.*?\r?\n\r?\n//s;
+            my $records = eval { decode_json($body) };
+            if (ref($records) ne 'ARRAY') {
+                failed("invalid JSON response from dns_records: %s", $body);
+                next;
+            }
+
+            # Delete any existing record of the same type and hostname
+            for my $rec (@{$records}) {
+                next unless defined $rec->{type} && $rec->{type} eq $type;
+                next unless defined $rec->{hostname} && $rec->{hostname} eq $h;
+                my $rec_id = $rec->{id};
+                debug("deleting existing '%s' record id %s", $type, $rec_id);
+                $recap{$h}{"status-ipv$ipv"} = 'failed';
+                my $del_url = opt('server', $h) . "/dns_zones/$zone_id/dns_records/$rec_id";
+                my $del_reply = geturl(
+                    proxy   => opt('proxy'),
+                    url     => $del_url,
+                    headers => $headers,
+                    method  => 'DELETE',
+                );
+                next if !header_ok($del_reply);
+            }
+
+            # Create the new record
+            my $data = encode_json({
+                type     => $type,
+                hostname => $h,
+                value    => $ip,
+                ttl      => 1,
+            });
+            $url   = opt('server', $h) . "/dns_zones/$zone_id/dns_records";
+            $reply = geturl(
+                proxy   => opt('proxy'),
+                url     => $url,
+                headers => $headers,
+                method  => 'POST',
+                data    => $data,
+            );
+            next if !header_ok($reply);
+            ($body = $reply) =~ s/^.*?\r?\n\r?\n//s;
+            my $result = eval { decode_json($body) };
+            if (ref($result) ne 'HASH' || !$result->{id}) {
+                failed("unexpected response creating DNS record: %s", $body);
+                next;
+            }
+
+            success("IPv%s address set to %s", $ipv, $ip);
+            $recap{$h}{"ipv$ipv"}        = $ip;
+            $recap{$h}{'mtime'}          = $now;
+            $recap{$h}{"status-ipv$ipv"} = 'good';
         }
     }
 }

--- a/ddclient.in
+++ b/ddclient.in
@@ -1223,6 +1223,7 @@ our %protocols = (
             %{$cfgvars{'protocol-common-defaults'}},
             'password' => undef,
             'zone'     => undef,
+            'ssl'      => setv(T_BOOL,  0, 1,                         undef),
             'server'   => setv(T_FQDNP, 0, 'api.netlify.com/api/v1', undef),
         },
     ),

--- a/t/protocol_netlify.pl
+++ b/t/protocol_netlify.pl
@@ -1,0 +1,336 @@
+use Test::More;
+BEGIN { SKIP: { eval { require Test::Warnings; 1; } or skip($@, 1); } }
+BEGIN { eval { require JSON::PP; 1; } or plan(skip_all => $@); JSON::PP->import(); }
+BEGIN { eval { require 'ddclient'; } or BAIL_OUT($@); }
+use ddclient::t::HTTPD;
+use ddclient::t::Logger;
+
+httpd_required();
+
+ddclient::load_json_support('netlify');
+
+my $j = ['Content-Type' => 'application/json'];
+
+# Helper responses
+sub zones_ok { encode_json([{id => 'zone123', name => 'example.com'}]) }
+sub records_empty { encode_json([]) }
+sub records_with_a {
+    encode_json([{id => 'rec456', type => 'A', hostname => 'host.example.com',
+                  value => '192.0.2.99', ttl => 1}])
+}
+sub records_with_aaaa {
+    encode_json([{id => 'rec789', type => 'AAAA', hostname => 'host.example.com',
+                  value => '2001:db8::99', ttl => 1}])
+}
+sub records_with_both {
+    encode_json([
+        {id => 'rec456', type => 'A',    hostname => 'host.example.com',
+         value => '192.0.2.99', ttl => 1},
+        {id => 'rec789', type => 'AAAA', hostname => 'host.example.com',
+         value => '2001:db8::99', ttl => 1},
+    ])
+}
+sub create_ok { encode_json({id => 'recnew', type => 'A', hostname => 'host.example.com',
+                              value => '192.0.2.1', ttl => 1}) }
+sub create_aaaa_ok { encode_json({id => 'recnew', type => 'AAAA', hostname => 'host.example.com',
+                                  value => '2001:db8::1', ttl => 1}) }
+
+httpd()->run();
+
+my @test_cases = (
+    {
+        desc => 'IPv4 success, no existing record (create)',
+        cfg => {'host.example.com' => {
+            protocol => 'netlify',
+            password => 'mytoken',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [200, $j, [zones_ok()]],
+            [200, $j, [records_empty()]],
+            [201, $j, [create_ok()]],
+        ],
+        wantrecap => {'host.example.com' => {
+            'status-ipv4' => 'good',
+            'ipv4'        => '192.0.2.1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv4.*192\.0\.2\.1/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 3, '3 requests: GET zones + GET records + POST create');
+            is($reqs[0]->method(), 'GET',  'first is GET');
+            like($reqs[0]->uri()->path(), qr{/dns_zones$}, 'GET zones path correct');
+            is($reqs[1]->method(), 'GET',  'second is GET records');
+            like($reqs[1]->uri()->path(), qr{/dns_zones/zone123/dns_records}, 'GET records path correct');
+            is($reqs[2]->method(), 'POST', 'third is POST create');
+            like($reqs[2]->uri()->path(), qr{/dns_zones/zone123/dns_records}, 'POST to dns_records for create');
+            my $body = decode_json($reqs[2]->content());
+            is($body->{type},     'A',           'create type is A');
+            is($body->{hostname}, 'host.example.com', 'create hostname is fqdn');
+            is($body->{value},    '192.0.2.1',   'create value correct');
+        },
+    },
+    {
+        desc => 'IPv4 success, existing record (delete + create)',
+        cfg => {'host.example.com' => {
+            protocol => 'netlify',
+            password => 'mytoken',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.2',
+        }},
+        responses => [
+            [200, $j, [zones_ok()]],
+            [200, $j, [records_with_a()]],
+            [204, $j, ['']],
+            [201, $j, [encode_json({id => 'recnew', type => 'A',
+                                    hostname => 'host.example.com',
+                                    value => '192.0.2.2', ttl => 1})]],
+        ],
+        wantrecap => {'host.example.com' => {
+            'status-ipv4' => 'good',
+            'ipv4'        => '192.0.2.2',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv4.*192\.0\.2\.2/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 4, '4 requests: GET zones + GET records + DELETE + POST');
+            is($reqs[2]->method(), 'DELETE', 'third is DELETE');
+            like($reqs[2]->uri()->path(), qr{/dns_zones/zone123/dns_records/rec456},
+                'DELETE targets existing record ID');
+            is($reqs[3]->method(), 'POST', 'fourth is POST create');
+        },
+    },
+    {
+        desc => 'IPv6 success, no existing record',
+        cfg => {'host.example.com' => {
+            protocol => 'netlify',
+            password => 'mytoken',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv6 => '2001:db8::1',
+        }},
+        responses => [
+            [200, $j, [zones_ok()]],
+            [200, $j, [records_empty()]],
+            [201, $j, [create_aaaa_ok()]],
+        ],
+        wantrecap => {'host.example.com' => {
+            'status-ipv6' => 'good',
+            'ipv6'        => '2001:db8::1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv6.*2001:db8::1/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            my $body = decode_json($reqs[2]->content());
+            is($body->{type},  'AAAA',        'create type is AAAA for IPv6');
+            is($body->{value}, '2001:db8::1', 'create value correct');
+        },
+    },
+    {
+        desc => 'both IPv4 and IPv6 success',
+        cfg => {'host.example.com' => {
+            protocol => 'netlify',
+            password => 'mytoken',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+            wantipv6 => '2001:db8::1',
+        }},
+        responses => [
+            # zone lookup (shared)
+            [200, $j, [zones_ok()]],
+            # IPv4: records + create
+            [200, $j, [records_empty()]],
+            [201, $j, [create_ok()]],
+            # IPv6: records + create
+            [200, $j, [records_empty()]],
+            [201, $j, [create_aaaa_ok()]],
+        ],
+        wantrecap => {'host.example.com' => {
+            'status-ipv4' => 'good', 'ipv4' => '192.0.2.1',
+            'status-ipv6' => 'good', 'ipv6' => '2001:db8::1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv4/},
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv6/},
+        ],
+    },
+    {
+        desc => 'zone not found',
+        cfg => {'host.example.com' => {
+            protocol => 'netlify',
+            password => 'mytoken',
+            zone     => 'notfound.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [200, $j, [zones_ok()]],
+        ],
+        wantrecap => {'host.example.com' => {
+            'status-ipv4' => 'failed',
+        }},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['host.example.com'], msg => qr/zone.*notfound\.com.*not found/},
+        ],
+    },
+    {
+        desc => 'HTTP error on zone lookup',
+        cfg => {'host.example.com' => {
+            protocol => 'netlify',
+            password => 'mytoken',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [401, $j, [encode_json({message => 'Unauthorized'})]],
+        ],
+        wantrecap => {'host.example.com' => {
+            'status-ipv4' => 'failed',
+        }},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['host.example.com'], msg => qr/401/},
+        ],
+    },
+    {
+        desc => 'HTTP error on record listing',
+        cfg => {'host.example.com' => {
+            protocol => 'netlify',
+            password => 'mytoken',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [200, $j, [zones_ok()]],
+            [500, $j, [encode_json({message => 'Internal Server Error'})]],
+        ],
+        wantrecap => {'host.example.com' => {
+            'status-ipv4' => 'failed',
+        }},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['host.example.com'], msg => qr/500/},
+        ],
+    },
+    {
+        desc => 'correct Authorization header sent',
+        cfg => {'host.example.com' => {
+            protocol => 'netlify',
+            password => 'supersecrettoken',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [200, $j, [zones_ok()]],
+            [200, $j, [records_empty()]],
+            [201, $j, [create_ok()]],
+        ],
+        wantrecap => {'host.example.com' => {
+            'status-ipv4' => 'good',
+            'ipv4'        => '192.0.2.1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv4/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            like($reqs[0]->header('Authorization'), qr/^Bearer supersecrettoken$/,
+                'Authorization header is correct');
+        },
+    },
+    {
+        desc => 'no-op: no IPs to update',
+        cfg => {'host.example.com' => {
+            protocol => 'netlify',
+            password => 'mytoken',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+        }},
+        responses => [
+            [200, $j, [zones_ok()]],
+        ],
+        wantrecap => {},
+        wantlogs  => [],
+    },
+    {
+        desc => 'invalid JSON from dns_zones',
+        cfg => {'host.example.com' => {
+            protocol => 'netlify',
+            password => 'mytoken',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [200, ['Content-Type' => 'application/json'], ['not-json']],
+        ],
+        wantrecap => {'host.example.com' => {
+            'status-ipv4' => 'failed',
+        }},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['host.example.com'], msg => qr/invalid JSON/},
+        ],
+    },
+);
+
+for my $tc (@test_cases) {
+    subtest($tc->{desc} => sub {
+        local $ddclient::globals{debug}   = 1;
+        local $ddclient::globals{verbose} = 1;
+        local %ddclient::config  = %{$tc->{cfg}};
+        local %ddclient::recap;
+
+        httpd()->reset(@{$tc->{responses}});
+
+        my $l = ddclient::t::Logger->new($ddclient::_l, qr/^(?:WARNING|FATAL|SUCCESS|FAILED)$/);
+        {
+            local $ddclient::_l = $l;
+            ddclient::nic_netlify_update(undef, sort(keys(%{$tc->{cfg}})));
+        }
+
+        my @reqs = httpd()->reset();
+
+        is_deeply(\%ddclient::recap, $tc->{wantrecap}, 'recap matches')
+            or diag(ddclient::repr(Values => [\%ddclient::recap, $tc->{wantrecap}],
+                                   Names  => ['*got', '*want']));
+
+        subtest('logs' => sub {
+            my @got  = @{$l->{logs}};
+            my @want = @{$tc->{wantlogs} // []};
+            for my $i (0..$#want) {
+                last if $i >= @got;
+                subtest("log $i" => sub {
+                    is($got[$i]{label}, $want[$i]{label}, 'label');
+                    is_deeply($got[$i]{ctx}, $want[$i]{ctx}, 'context');
+                    like($got[$i]{msg}, $want[$i]{msg}, 'message');
+                });
+            }
+            my @unexpected = @got[@want..$#got];
+            ok(@unexpected == 0, 'no unexpected logs')
+                or diag(ddclient::repr(\@unexpected, Names => ['*unexpected']));
+            my @missing = @want[@got..$#want];
+            ok(@missing == 0, 'no missing logs')
+                or diag(ddclient::repr(\@missing, Names => ['*missing']));
+        });
+
+        $tc->{check_reqs}->(@reqs) if $tc->{check_reqs};
+    });
+}
+
+done_testing();


### PR DESCRIPTION
## Summary

- Adds `netlify` protocol for Netlify hosted DNS, using the Netlify REST API
- Authenticates with a personal access token via `Authorization: Bearer` header
- Supports IPv4 (A) and IPv6 (AAAA) record updates
- Update flow: look up zone ID → list records → DELETE existing matching record → POST new record
- All 10 test cases pass (plus warnings check)

## Configuration example

```
protocol=netlify,                        \
password=your-netlify-personal-access-token, \
zone=example.com,                        \
myhost.example.com
```

## Test plan

- [x] `IPv4 success, no existing record (create)` — zone lookup + empty records + POST
- [x] `IPv4 success, existing record (delete + create)` — zone lookup + DELETE + POST
- [x] `IPv6 success, no existing record` — AAAA type handling
- [x] `both IPv4 and IPv6 success` — dual-stack update
- [x] `zone not found` — graceful failure when zone not in account
- [x] `HTTP error on zone lookup` — 401/error propagation
- [x] `HTTP error on record listing` — 500/error propagation
- [x] `correct Authorization header sent` — `Bearer <token>` format verified
- [x] `no-op: no IPs to update` — empty recap, no DNS changes
- [x] `invalid JSON from dns_zones` — malformed response handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)