### PR TITLE
feat: add DreamHost DNS protocol

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -69,6 +69,7 @@ repository history](https://github.com/ddclient/ddclient/commits/main).
     [#907](https://github.com/ddclient/ddclient/pull/907)
   * Added `spaceship` protocol for Spaceship (https://www.spaceship.com/).
     [#896](https://github.com/ddclient/ddclient/pull/896)
+  * Added `dreamhost` protocol for DreamHost (https://www.dreamhost.com).
   * Added `updatedip` built-in web IP check service for UpdatedIP (https://www.updatedip.com).
     [#868](https://github.com/ddclient/ddclient/pull/868)
   * Added `dynadot` protocol for Dynadot (https://www.dynadot.com/).

--- a/Makefile.am
+++ b/Makefile.am
@@ -76,6 +76,7 @@ handwritten_tests = \
 	t/protocol_cloudflare.pl \
 	t/protocol_directnic.pl \
 	t/protocol_dnsexit2.pl \
+	t/protocol_dreamhost.pl \
 	t/protocol_dynadot.pl \
 	t/protocol_dyndns2.pl \
 	t/protocol_dynu.pl \

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Dynamic DNS services currently supported include:
   * [DNSExit](https://dnsexit.com/dns/dns-api)
   * [dnsHome.de](https://www.dnshome.de)
   * [Domeneshop](https://api.domeneshop.no/docs/#tag/ddns/paths/~1dyndns~1update/get)
+  * [DreamHost](https://www.dreamhost.com)
   * [DslReports](https://www.dslreports.com)
   * [Duck DNS](https://duckdns.org)
   * [Dynadot](https://www.dynadot.com)

--- a/ddclient.conf.in
+++ b/ddclient.conf.in
@@ -561,6 +561,24 @@ pid=@runstatedir@/ddclient.pid  # record PID in file.
 # yourhost.yourdomain.com
 
 ##
+## DreamHost (https://www.dreamhost.com)
+## Use your DreamHost API key as password (generate at dreamhost.com/api/).
+##
+# protocol=dreamhost,                      \
+# password=your-dreamhost-api-key,         \
+# myhost.example.com
+
+##
+## LuaDNS (https://luadns.com) - programmable DNS with DDNS support
+## Use your account email as login and your API key as password.
+##
+# protocol=dyndns2,                         \
+# server=app.luadns.com,                    \
+# login=your-luadns-email,                  \
+# password=your-luadns-api-key              \
+# yourhostname.example.com
+
+##
 ## NIC.RU (https://www.nic.ru) - Russian .ru domain registry
 ## Use your NIC.RU account login and password from the DNS hosting panel.
 ##
@@ -578,16 +596,6 @@ pid=@runstatedir@/ddclient.pid  # record PID in file.
 # login=my-updatedip-login
 # password=my-updatedip-password
 # subdomain.updatedip.com
-
-##
-## LuaDNS (https://luadns.com) - programmable DNS with DDNS support
-## Use your account email as login and your API key as password.
-##
-# protocol=dyndns2,                         \
-# server=app.luadns.com,                    \
-# login=your-luadns-email,                  \
-# password=your-luadns-api-key              \
-# yourhostname.example.com
 
 ##
 ## WebSupport (https://www.websupport.sk)

--- a/ddclient.in
+++ b/ddclient.in
@@ -1029,6 +1029,15 @@ our %protocols = (
             'server' => setv(T_FQDNP, 0, 'dondns.dondominio.com', undef),
         },
     ),
+    'dreamhost' => ddclient::Protocol->new(
+        'update'   => \&nic_dreamhost_update,
+        'examples' => \&nic_dreamhost_examples,
+        'cfgvars' => {
+            %{$cfgvars{'protocol-common-defaults'}},
+            'password' => undef,
+            'server'   => setv(T_FQDNP, 0, 'api.dreamhost.com', undef),
+        },
+    ),
     'dslreports1' => ddclient::LegacyProtocol->new(
         'update'     => \&nic_dslreports1_update,
         'examples'   => \&nic_dslreports1_examples,
@@ -2253,7 +2262,7 @@ sub init_config {
     my @needs_sha1 = grep({ my $p = $_; grep($_ eq $p, @protos); } qw(freedns nfsn));
     load_sha1_support(join(', ', @needs_sha1)) if @needs_sha1;
     my @needs_json = grep({ my $p = $_; grep($_ eq $p, @protos); }
-                          qw(1984 cloudflare digitalocean directnic dnsexit2 gandi godaddy hetzner
+                          qw(1984 cloudflare digitalocean directnic dnsexit2 dreamhost gandi godaddy hetzner
                              ionos nfsn njalla ns1 porkbun spaceship yandex));
     load_json_support(join(', ', @needs_json)) if @needs_json;
 }
@@ -4854,6 +4863,116 @@ sub nic_domeneshop_update {
     }
 }
 
+
+######################################################################
+## nic_dreamhost_examples
+######################################################################
+sub nic_dreamhost_examples {
+    my $self = shift;
+    return <<"EoEXAMPLE";
+o 'dreamhost'
+
+The 'dreamhost' protocol is used by the DNS service offered by www.dreamhost.com.
+
+Configuration variables applicable to the 'dreamhost' protocol are:
+  protocol=dreamhost           ##
+  server=fqdn.of.service       ## defaults to api.dreamhost.com
+  password=service-password    ## DreamHost API key
+
+Example ${program}.conf file entries:
+  protocol=dreamhost                        \\
+  password=my-dreamhost-api-key             \\
+  my.example.com
+EoEXAMPLE
+}
+
+######################################################################
+## nic_dreamhost_update
+######################################################################
+sub nic_dreamhost_update {
+    my $self = shift;
+    for my $h (@_) {
+        local $_l = pushlogctx($h);
+        my $ipv4 = delete $config{$h}{'wantipv4'};
+        my $ipv6 = delete $config{$h}{'wantipv6'};
+
+        for my $ip ($ipv4, $ipv6) {
+            next if !$ip;
+            my $ipv  = ($ip eq ($ipv6 // '')) ? '6' : '4';
+            my $type = ($ip eq ($ipv6 // '')) ? 'AAAA' : 'A';
+
+            info("setting IPv$ipv address to $ip");
+            $recap{$h}{"status-ipv$ipv"} = 'failed';
+
+            my $uid = sprintf('%08x%08x', int(rand(0xffffffff)), int(rand(0xffffffff)));
+            my $key = opt('password', $h);
+            my $base = opt('server', $h);
+
+            # Step 1: list existing records
+            my $url = "$base/?key=$key&unique_id=${uid}a&cmd=dns-list_records&format=json";
+            my $reply = geturl(proxy => opt('proxy'), url => $url);
+            next if !header_ok($reply);
+            $reply =~ qr/{(?:[^{}]*|(?R))*}/mp;
+            my $response = eval { decode_json(${^MATCH}) };
+            if (!$response || ($response->{result} // '') ne 'success') {
+                my $err = ($response && $response->{data}) ? $response->{data} : 'unknown error';
+                failed("dns-list_records failed: $err");
+                next;
+            }
+
+            # Step 2: find existing record for this host+type
+            my $old_ip;
+            for my $rec (@{$response->{data} // []}) {
+                next unless (($rec->{record} // '') eq $h) && (($rec->{type} // '') eq $type);
+                $old_ip = $rec->{value};
+                last;
+            }
+
+            if (defined $old_ip && $old_ip eq $ip) {
+                success("IPv$ipv address was already set to $ip");
+                $recap{$h}{"ipv$ipv"} = $ip;
+                $recap{$h}{'mtime'} = $now;
+                $recap{$h}{"status-ipv$ipv"} = 'good';
+                next;
+            }
+
+            # Step 3: remove old record if present
+            if (defined $old_ip) {
+                my $uid2 = sprintf('%08x%08x', int(rand(0xffffffff)), int(rand(0xffffffff)));
+                $url = "$base/?key=$key&unique_id=${uid2}&cmd=dns-remove_record&format=json"
+                     . "&record=$h&type=$type&value=$old_ip";
+                $reply = geturl(proxy => opt('proxy'), url => $url);
+                next if !header_ok($reply);
+                $reply =~ qr/{(?:[^{}]*|(?R))*}/mp;
+                $response = eval { decode_json(${^MATCH}) };
+                if (!$response || ($response->{result} // '') ne 'success') {
+                    my $err = ($response && $response->{data}) ? $response->{data} : 'unknown error';
+                    failed("dns-remove_record failed: $err");
+                    next;
+                }
+            }
+
+            # Step 4: add new record
+            my $uid3 = sprintf('%08x%08x', int(rand(0xffffffff)), int(rand(0xffffffff)));
+            $url = "$base/?key=$key&unique_id=${uid3}&cmd=dns-add_record&format=json"
+                 . "&record=$h&type=$type&value=$ip";
+            $reply = geturl(proxy => opt('proxy'), url => $url);
+            next if !header_ok($reply);
+            $reply =~ qr/{(?:[^{}]*|(?R))*}/mp;
+            $response = eval { decode_json(${^MATCH}) };
+            if (!$response || ($response->{result} // '') ne 'success') {
+                my $err = ($response && $response->{data}) ? $response->{data} : 'unknown error';
+                failed("dns-add_record failed: $err");
+                next;
+            }
+
+            success("IPv$ipv address set to $ip");
+            $recap{$h}{"ipv$ipv"} = $ip;
+            $recap{$h}{'mtime'} = $now;
+            $recap{$h}{"status-ipv$ipv"} = 'good';
+        }
+    }
+}
 
 ######################################################################
 ## nic_zoneedit1_examples

--- a/ddclient.in
+++ b/ddclient.in
@@ -1035,6 +1035,7 @@ our %protocols = (
         'cfgvars' => {
             %{$cfgvars{'protocol-common-defaults'}},
             'password' => undef,
+            'ssl'      => setv(T_BOOL,  0, 1,                   undef),
             'server'   => setv(T_FQDNP, 0, 'api.dreamhost.com', undef),
         },
     ),

--- a/t/protocol_dreamhost.pl
+++ b/t/protocol_dreamhost.pl
@@ -1,0 +1,358 @@
+use Test::More;
+BEGIN { SKIP: { eval { require Test::Warnings; 1; } or skip($@, 1); } }
+BEGIN { eval { require JSON::PP; 1; } or plan(skip_all => $@); JSON::PP->import(); }
+BEGIN { eval { require 'ddclient'; } or BAIL_OUT($@); }
+use ddclient::t::HTTPD;
+use ddclient::t::Logger;
+
+httpd_required();
+
+ddclient::load_json_support('dreamhost');
+
+# Start httpd with no custom handler; responses are queued via httpd()->reset().
+httpd()->run(undef);
+
+my $hostname = httpd()->endpoint();
+
+sub cfg {
+    my (%extra) = @_;
+    return {
+        server   => $hostname,
+        password => 'MY-API-KEY',
+        %extra,
+    };
+}
+
+sub list_response {
+    my @records = @_;
+    return [200, ['Content-Type' => 'application/json'],
+            [encode_json({result => 'success', data => \@records})]];
+}
+
+sub success_response {
+    return [200, ['Content-Type' => 'application/json'],
+            [encode_json({result => 'success'})]];
+}
+
+sub error_response {
+    my ($msg) = @_;
+    $msg //= 'record not found';
+    return [200, ['Content-Type' => 'application/json'],
+            [encode_json({result => 'error', data => $msg})]];
+}
+
+sub http_error_response {
+    return [500, ['Content-Type' => 'text/plain'], ['Internal Server Error']];
+}
+
+my @test_cases = (
+    {
+        desc => 'IPv4 update: no existing record, add new',
+        cfg => {
+            'myhost.example.com' => cfg(wantipv4 => '192.0.2.1'),
+        },
+        responses => [
+            list_response(),     # list returns empty data array
+            success_response(),  # add succeeds
+        ],
+        wantrecap => {
+            'myhost.example.com' => {
+                'status-ipv4' => 'good',
+                'ipv4'        => '192.0.2.1',
+                'mtime'       => $ddclient::now,
+            },
+        },
+        wantreqs  => 2,
+        wantcmds  => ['dns-list_records', 'dns-add_record'],
+        wantlogs  => [
+            {label => 'SUCCESS', ctx => ['myhost.example.com'], msg => qr/IPv4 address set to 192\.0\.2\.1/},
+        ],
+    },
+    {
+        desc => 'IPv4 update: old record with different IP, remove then add',
+        cfg => {
+            'myhost.example.com' => cfg(wantipv4 => '192.0.2.2'),
+        },
+        responses => [
+            list_response({record => 'myhost.example.com', type => 'A',
+                           value => '192.0.2.1', zone => 'example.com',
+                           editable => '1', comment => ''}),
+            success_response(),  # remove succeeds
+            success_response(),  # add succeeds
+        ],
+        wantrecap => {
+            'myhost.example.com' => {
+                'status-ipv4' => 'good',
+                'ipv4'        => '192.0.2.2',
+                'mtime'       => $ddclient::now,
+            },
+        },
+        wantreqs  => 3,
+        wantcmds  => ['dns-list_records', 'dns-remove_record', 'dns-add_record'],
+        wantlogs  => [
+            {label => 'SUCCESS', ctx => ['myhost.example.com'], msg => qr/IPv4 address set to 192\.0\.2\.2/},
+        ],
+    },
+    {
+        desc => 'IPv4: same IP already set, no-op',
+        cfg => {
+            'myhost.example.com' => cfg(wantipv4 => '192.0.2.1'),
+        },
+        responses => [
+            list_response({record => 'myhost.example.com', type => 'A',
+                           value => '192.0.2.1', zone => 'example.com',
+                           editable => '1', comment => ''}),
+        ],
+        wantrecap => {
+            'myhost.example.com' => {
+                'status-ipv4' => 'good',
+                'ipv4'        => '192.0.2.1',
+                'mtime'       => $ddclient::now,
+            },
+        },
+        wantreqs  => 1,
+        wantcmds  => ['dns-list_records'],
+        wantlogs  => [
+            {label => 'SUCCESS', ctx => ['myhost.example.com'], msg => qr/IPv4 address was already set to 192\.0\.2\.1/},
+        ],
+    },
+    {
+        desc => 'IPv6 update: no existing record, add new',
+        cfg => {
+            'myhost.example.com' => cfg(wantipv6 => '2001:db8::1'),
+        },
+        responses => [
+            list_response(),     # list returns empty
+            success_response(),  # add succeeds
+        ],
+        wantrecap => {
+            'myhost.example.com' => {
+                'status-ipv6' => 'good',
+                'ipv6'        => '2001:db8::1',
+                'mtime'       => $ddclient::now,
+            },
+        },
+        wantreqs  => 2,
+        wantcmds  => ['dns-list_records', 'dns-add_record'],
+        wantlogs  => [
+            {label => 'SUCCESS', ctx => ['myhost.example.com'], msg => qr/IPv6 address set to 2001:db8::1/},
+        ],
+    },
+    {
+        desc => 'IPv6: same IP already set, no-op',
+        cfg => {
+            'myhost.example.com' => cfg(wantipv6 => '2001:db8::1'),
+        },
+        responses => [
+            list_response({record => 'myhost.example.com', type => 'AAAA',
+                           value => '2001:db8::1', zone => 'example.com',
+                           editable => '1', comment => ''}),
+        ],
+        wantrecap => {
+            'myhost.example.com' => {
+                'status-ipv6' => 'good',
+                'ipv6'        => '2001:db8::1',
+                'mtime'       => $ddclient::now,
+            },
+        },
+        wantreqs  => 1,
+        wantcmds  => ['dns-list_records'],
+        wantlogs  => [
+            {label => 'SUCCESS', ctx => ['myhost.example.com'], msg => qr/IPv6 address was already set to 2001:db8::1/},
+        ],
+    },
+    {
+        desc => 'dual-stack: both IPv4 and IPv6 updated',
+        cfg => {
+            'myhost.example.com' => cfg(wantipv4 => '192.0.2.1', wantipv6 => '2001:db8::1'),
+        },
+        responses => [
+            list_response(),     # IPv4 list: empty
+            success_response(),  # IPv4 add
+            list_response(),     # IPv6 list: empty
+            success_response(),  # IPv6 add
+        ],
+        wantrecap => {
+            'myhost.example.com' => {
+                'status-ipv4' => 'good',
+                'ipv4'        => '192.0.2.1',
+                'status-ipv6' => 'good',
+                'ipv6'        => '2001:db8::1',
+                'mtime'       => $ddclient::now,
+            },
+        },
+        wantreqs  => 4,
+        wantlogs  => [
+            {label => 'SUCCESS', ctx => ['myhost.example.com'], msg => qr/IPv4 address set to 192\.0\.2\.1/},
+            {label => 'SUCCESS', ctx => ['myhost.example.com'], msg => qr/IPv6 address set to 2001:db8::1/},
+        ],
+    },
+    {
+        desc => 'API error on dns-list_records',
+        cfg => {
+            'myhost.example.com' => cfg(wantipv4 => '192.0.2.1'),
+        },
+        responses => [
+            error_response('authentication failed'),
+        ],
+        wantrecap => {
+            'myhost.example.com' => {
+                'status-ipv4' => 'failed',
+            },
+        },
+        wantreqs  => 1,
+        wantcmds  => ['dns-list_records'],
+        wantlogs  => [
+            {label => 'FAILED', ctx => ['myhost.example.com'], msg => qr/dns-list_records failed/},
+        ],
+    },
+    {
+        desc => 'HTTP error on list request',
+        cfg => {
+            'myhost.example.com' => cfg(wantipv4 => '192.0.2.1'),
+        },
+        responses => [
+            http_error_response(),
+        ],
+        wantrecap => {
+            'myhost.example.com' => {
+                'status-ipv4' => 'failed',
+            },
+        },
+        wantreqs  => 1,
+        wantlogs  => [
+            {label => 'FAILED', ctx => ['myhost.example.com'], msg => qr/500/},
+        ],
+    },
+    {
+        desc => 'API error on dns-remove_record',
+        cfg => {
+            'myhost.example.com' => cfg(wantipv4 => '192.0.2.2'),
+        },
+        responses => [
+            list_response({record => 'myhost.example.com', type => 'A',
+                           value => '192.0.2.1', zone => 'example.com',
+                           editable => '1', comment => ''}),
+            error_response('cannot remove record'),
+        ],
+        wantrecap => {
+            'myhost.example.com' => {
+                'status-ipv4' => 'failed',
+            },
+        },
+        wantreqs  => 2,
+        wantcmds  => ['dns-list_records', 'dns-remove_record'],
+        wantlogs  => [
+            {label => 'FAILED', ctx => ['myhost.example.com'], msg => qr/dns-remove_record failed/},
+        ],
+    },
+    {
+        desc => 'API error on dns-add_record',
+        cfg => {
+            'myhost.example.com' => cfg(wantipv4 => '192.0.2.1'),
+        },
+        responses => [
+            list_response(),
+            error_response('record already exists'),
+        ],
+        wantrecap => {
+            'myhost.example.com' => {
+                'status-ipv4' => 'failed',
+            },
+        },
+        wantreqs  => 2,
+        wantcmds  => ['dns-list_records', 'dns-add_record'],
+        wantlogs  => [
+            {label => 'FAILED', ctx => ['myhost.example.com'], msg => qr/dns-add_record failed/},
+        ],
+    },
+    {
+        desc => 'list response has records for other hosts, ignored',
+        cfg => {
+            'myhost.example.com' => cfg(wantipv4 => '192.0.2.1'),
+        },
+        responses => [
+            list_response(
+                {record => 'other.example.com', type => 'A',
+                 value => '10.0.0.1', zone => 'example.com',
+                 editable => '1', comment => ''},
+                {record => 'myhost.example.com', type => 'AAAA',
+                 value => '2001:db8::1', zone => 'example.com',
+                 editable => '1', comment => ''},
+            ),
+            success_response(),  # add A record
+        ],
+        wantrecap => {
+            'myhost.example.com' => {
+                'status-ipv4' => 'good',
+                'ipv4'        => '192.0.2.1',
+                'mtime'       => $ddclient::now,
+            },
+        },
+        wantreqs  => 2,
+        wantcmds  => ['dns-list_records', 'dns-add_record'],
+        wantlogs  => [
+            {label => 'SUCCESS', ctx => ['myhost.example.com'], msg => qr/IPv4 address set to 192\.0\.2\.1/},
+        ],
+    },
+);
+
+for my $tc (@test_cases) {
+    diag('==============================================================================');
+    diag("Starting test: $tc->{desc}");
+    subtest($tc->{desc} => sub {
+        local $ddclient::globals{debug} = 1;
+        local $ddclient::globals{verbose} = 1;
+        # Queue responses and clear request log.
+        httpd()->reset(@{$tc->{responses}});
+        local %ddclient::config = %{$tc->{cfg}};
+        local %ddclient::recap;
+        my $l = ddclient::t::Logger->new($ddclient::_l, qr/^(?:WARNING|FATAL|SUCCESS|FAILED)$/);
+        {
+            local $ddclient::_l = $l;
+            ddclient::nic_dreamhost_update(undef, sort(keys(%{$tc->{cfg}})));
+        }
+        my @reqs = httpd()->reset();
+
+        is_deeply(\%ddclient::recap, $tc->{wantrecap}, "recap")
+            or diag(ddclient::repr(Values => [\%ddclient::recap, $tc->{wantrecap}],
+                                   Names => ['*got', '*want']));
+
+        if (exists $tc->{wantreqs}) {
+            is(scalar(@reqs), $tc->{wantreqs}, "sent $tc->{wantreqs} request(s)");
+        }
+
+        if ($tc->{wantcmds}) {
+            for my $i (0..$#{$tc->{wantcmds}}) {
+                last if $i >= @reqs;
+                my $q = $reqs[$i]->uri()->query() // '';
+                like($q, qr/cmd=$tc->{wantcmds}[$i]/, "request $i has cmd=$tc->{wantcmds}[$i]");
+                is($reqs[$i]->method(), 'GET', "request $i is a GET");
+            }
+        }
+
+        $tc->{wantlogs} //= [];
+        subtest("logs" => sub {
+            my @got = @{$l->{logs}};
+            my @want = @{$tc->{wantlogs}};
+            for my $i (0..$#want) {
+                last if $i >= @got;
+                my $got = $got[$i];
+                my $want = $want[$i];
+                subtest("log $i" => sub {
+                    is($got->{label}, $want->{label}, "label matches");
+                    is_deeply($got->{ctx}, $want->{ctx}, "context matches");
+                    like($got->{msg}, $want->{msg}, "message matches");
+                }) or diag(ddclient::repr(Values => [$got, $want], Names => ['*got', '*want']));
+            }
+            my @unexpected = @got[@want..$#got];
+            ok(@unexpected == 0, "no unexpected logs")
+                or diag(ddclient::repr(\@unexpected, Names => ['*unexpected']));
+            my @missing = @want[@got..$#want];
+            ok(@missing == 0, "no missing logs")
+                or diag(ddclient::repr(\@missing, Names => ['*missing']));
+        });
+    });
+}
+
+done_testing();


### PR DESCRIPTION
## Summary

- Adds `dreamhost` protocol for DreamHost DNS (https://www.dreamhost.com)
- Uses the proprietary key-based flat command API (`dns-list_records`, `dns-remove_record`, `dns-add_record`) via GET requests with query parameters
- Supports both IPv4 (A records) and IPv6 (AAAA records) updates
- Update flow: list existing records → remove old record if IP changed → add new record; detects same-IP and skips update cleanly

## Test plan

- [ ] `make check TESTS=t/protocol_dreamhost.pl VERBOSE=1` — all 11 subtests pass
- [ ] IPv4 add (no existing record)
- [ ] IPv4 update (remove old + add new)
- [ ] IPv4 no-op (same IP already set)
- [ ] IPv6 add
- [ ] IPv6 no-op
- [ ] Dual-stack (IPv4 + IPv6)
- [ ] API error on dns-list_records
- [ ] HTTP error on list request
- [ ] API error on dns-remove_record
- [ ] API error on dns-add_record
- [ ] Records for other hosts in list response are ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)