### PR TITLE
feat: add Bunny.net DNS protocol

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -33,6 +33,7 @@ repository history](https://github.com/ddclient/ddclient/commits/main).
 
 ### New feature
 
+  * Added `bunny` protocol for Bunny.net DNS (https://bunny.net/dns/).
   * Added `PowerDNS` as a supported provider for self-hosted deployments:
     via [PowerDNS-Admin](https://github.com/PowerDNS-Admin/PowerDNS-Admin) using `protocol=dyndns2`,
     or via PowerDNS Authoritative Server RFC 2136 DNS UPDATE using `protocol=nsupdate`.

--- a/Makefile.am
+++ b/Makefile.am
@@ -72,6 +72,7 @@ handwritten_tests = \
 	t/logmsg.pl \
 	t/jitter.pl \
 	t/parse_assignments.pl \
+	t/protocol_bunny.pl \
 	t/protocol_ddnss.pl \
 	t/protocol_cloudflare.pl \
 	t/protocol_directnic.pl \

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Dynamic DNS services currently supported include:
 
   * [1984.is](https://www.1984.is/product/freedns)
   * [All-inkl.com](https://all-inkl.com)
+  * [Bunny.net](https://bunny.net/dns/)
   * [ChangeIP](https://www.changeip.com)
   * [CloudFlare](https://www.cloudflare.com)
   * [ClouDNS](https://www.cloudns.net)

--- a/ddclient.conf.in
+++ b/ddclient.conf.in
@@ -550,6 +550,15 @@ pid=@runstatedir@/ddclient.pid  # record PID in file.
 # myhost.example.com
 
 ##
+## Bunny.net DNS (https://bunny.net/dns/)
+## Use your Bunny.net account API key as password.
+##
+# protocol=bunny,                          \
+# password=your-bunny-api-key,             \
+# zone=example.com,                        \
+# myhost.example.com
+
+##
 ## All-inkl.com (https://all-inkl.com)
 ## Create DDNS credentials in KAS under Tools → DDNS Settings.
 ## Supports IPv4 and IPv6 (enable Dual-Stack in KAS for IPv6).

--- a/ddclient.in
+++ b/ddclient.in
@@ -939,6 +939,7 @@ our %protocols = (
         'examples' => \&nic_bunny_examples,
         'cfgvars' => {
             %{$cfgvars{'protocol-common-defaults'}},
+            'ssl'      => setv(T_BOOL,  0, 1,               undef),
             'password' => undef,
             'zone'     => undef,
             'server'   => setv(T_FQDNP, 0, 'api.bunny.net', undef),

--- a/ddclient.in
+++ b/ddclient.in
@@ -934,6 +934,16 @@ our %protocols = (
             'server' => setv(T_FQDNP, 0, 'api.1984.is', undef),
         },
     ),
+    'bunny' => ddclient::Protocol->new(
+        'update'   => \&nic_bunny_update,
+        'examples' => \&nic_bunny_examples,
+        'cfgvars' => {
+            %{$cfgvars{'protocol-common-defaults'}},
+            'password' => undef,
+            'zone'     => undef,
+            'server'   => setv(T_FQDNP, 0, 'api.bunny.net', undef),
+        },
+    ),
     'changeip' => ddclient::LegacyProtocol->new(
         'update'     => \&nic_changeip_update,
         'examples'   => \&nic_changeip_examples,
@@ -2253,7 +2263,7 @@ sub init_config {
     my @needs_sha1 = grep({ my $p = $_; grep($_ eq $p, @protos); } qw(freedns nfsn));
     load_sha1_support(join(', ', @needs_sha1)) if @needs_sha1;
     my @needs_json = grep({ my $p = $_; grep($_ eq $p, @protos); }
-                          qw(1984 cloudflare digitalocean directnic dnsexit2 gandi godaddy hetzner
+                          qw(1984 bunny cloudflare digitalocean directnic dnsexit2 gandi godaddy hetzner
                              ionos nfsn njalla ns1 porkbun spaceship yandex));
     load_json_support(join(', ', @needs_json)) if @needs_json;
 }
@@ -5770,6 +5780,155 @@ sub nic_1984_update {
             success("skipped: IP was already set to $response->{ip}");
         } else {
             success("updated successfully to $response->{ip}");
+        }
+    }
+}
+
+######################################################################
+## nic_bunny_examples
+######################################################################
+sub nic_bunny_examples {
+    my $self = shift;
+    return <<"EoEXAMPLE";
+o 'bunny'
+
+The 'bunny' protocol is used by DNS service offered by bunny.net.
+
+Configuration variables applicable to the 'bunny' protocol are:
+  protocol=bunny               ##
+  server=fqdn.of.service       ## defaults to api.bunny.net
+  zone=dns.zone                ## the DNS zone to update
+  password=service-password    ## Bunny.net account API key
+  fully.qualified.host         ## the host registered with the service.
+
+Example ${program}.conf file entries:
+  ## single host update
+  protocol=bunny,                          \\
+  zone=example.com,                        \\
+  password=your-bunny-api-key              \\
+  myhost.example.com
+EoEXAMPLE
+}
+
+######################################################################
+## nic_bunny_update
+######################################################################
+sub nic_bunny_update {
+    my $self = shift;
+    for my $h (@_) {
+        local $_l = pushlogctx($h);
+
+        my $zone = opt('zone', $h);
+        (my $hostname = $h) =~ s/\Q.$zone\E$//;
+        my $ipv4 = delete $config{$h}{'wantipv4'};
+        my $ipv6 = delete $config{$h}{'wantipv6'};
+
+        my @headers = (
+            "AccessKey: " . opt('password', $h),
+            "Content-Type: application/json",
+            "Accept: application/json",
+        );
+
+        # Look up zone ID by domain name
+        info("looking up Bunny.net zone ID for %s", $zone);
+        my $list_url = opt('server', $h) . "/dnszone?search=" . $zone;
+        my $list_reply = geturl(
+            proxy   => opt('proxy'),
+            url     => $list_url,
+            headers => \@headers,
+        );
+        next if !header_ok($list_reply);
+        (my $list_body = $list_reply) =~ s/^.*?\n\n//s;
+        my $list_response = eval { decode_json($list_body) };
+        unless (ref($list_response) eq 'HASH' && ref($list_response->{Items}) eq 'ARRAY') {
+            failed("invalid or unexpected response when listing DNS zones");
+            next;
+        }
+        my ($zone_obj) = grep { $_->{Domain} eq $zone } @{$list_response->{Items}};
+        unless ($zone_obj && defined $zone_obj->{Id}) {
+            failed("zone '%s' not found in Bunny.net account", $zone);
+            next;
+        }
+        my $zone_id = $zone_obj->{Id};
+        info("zone ID is %s", $zone_id);
+
+        # Fetch zone details to get records
+        my $zone_url = opt('server', $h) . "/dnszone/$zone_id";
+        my $zone_reply = geturl(
+            proxy   => opt('proxy'),
+            url     => $zone_url,
+            headers => \@headers,
+        );
+        next if !header_ok($zone_reply);
+        (my $zone_body = $zone_reply) =~ s/^.*?\n\n//s;
+        my $zone_detail = eval { decode_json($zone_body) };
+        unless (ref($zone_detail) eq 'HASH' && ref($zone_detail->{Records}) eq 'ARRAY') {
+            failed("invalid or unexpected response when fetching zone detail");
+            next;
+        }
+
+        # IPv4 and IPv6 updates
+        for my $ip ($ipv4, $ipv6) {
+            next unless $ip;
+            my $ipv  = ($ip eq ($ipv6 // '')) ? '6' : '4';
+            my $type = $ipv eq '6' ? 'AAAA' : 'A';
+            my $type_num = $ipv eq '6' ? 1 : 0;
+
+            info("setting IPv%s address to %s", $ipv, $ip);
+            $recap{$h}{"status-ipv$ipv"} = 'failed';
+
+            # Find existing record matching hostname and type
+            my ($record) = grep {
+                defined($_->{Type}) && $_->{Type} == $type_num
+                    && defined($_->{Name}) && $_->{Name} eq $hostname
+            } @{$zone_detail->{Records}};
+
+            if ($record && defined $record->{Value} && $record->{Value} eq $ip) {
+                $recap{$h}{"ipv$ipv"} = $ip;
+                $recap{$h}{'mtime'} = $now;
+                $recap{$h}{"status-ipv$ipv"} = 'good';
+                success("skipped: IPv%s address was already set to %s", $ipv, $ip);
+                next;
+            }
+
+            my ($method, $record_url, $data);
+            if ($record && defined $record->{Id}) {
+                # Update existing record
+                debug("updating existing DNS '%s' record id %s", $type, $record->{Id});
+                $record_url = opt('server', $h) . "/dnszone/$zone_id/records/$record->{Id}";
+                $method = 'POST';
+                $data = encode_json({
+                    Type  => $type_num,
+                    Name  => $hostname,
+                    Value => $ip,
+                    Ttl   => $record->{Ttl} // 300,
+                    Id    => $record->{Id},
+                });
+            } else {
+                # Create new record
+                debug("creating new DNS '%s' record for %s", $type, $hostname);
+                $record_url = opt('server', $h) . "/dnszone/$zone_id/records";
+                $method = 'PUT';
+                $data = encode_json({
+                    Type  => $type_num,
+                    Name  => $hostname,
+                    Value => $ip,
+                    Ttl   => 300,
+                });
+            }
+
+            my $reply = geturl(
+                proxy   => opt('proxy'),
+                url     => $record_url,
+                headers => \@headers,
+                method  => $method,
+                data    => $data,
+            );
+            next if !header_ok($reply);
+            $recap{$h}{"ipv$ipv"} = $ip;
+            $recap{$h}{'mtime'} = $now;
+            $recap{$h}{"status-ipv$ipv"} = 'good';
+            success("IPv%s address set to %s", $ipv, $ip);
         }
     }
 }

--- a/t/protocol_bunny.pl
+++ b/t/protocol_bunny.pl
@@ -1,0 +1,331 @@
+use Test::More;
+BEGIN { SKIP: { eval { require Test::Warnings; 1; } or skip($@, 1); } }
+BEGIN { eval { require JSON::PP; 1; } or plan(skip_all => $@); JSON::PP->import(); }
+BEGIN { eval { require 'ddclient'; } or BAIL_OUT($@); }
+use ddclient::t::HTTPD;
+use ddclient::t::Logger;
+
+httpd_required();
+
+local $ddclient::globals{debug} = 1;
+local $ddclient::globals{verbose} = 1;
+
+ddclient::load_json_support('bunny');
+
+httpd()->run();
+
+# Helper: build a standard zone-list response
+sub zone_list_response {
+    my ($zone, $zone_id) = @_;
+    return [200, ['Content-Type' => 'application/json'], [encode_json({
+        Items       => [{ Id => $zone_id, Domain => $zone }],
+        TotalItems  => 1,
+        CurrentPage => 1,
+        HasMoreItems => 0,
+    })]];
+}
+
+# Helper: build a zone-detail response with optional records
+sub zone_detail_response {
+    my ($zone_id, @records) = @_;
+    return [200, ['Content-Type' => 'application/json'], [encode_json({
+        Id      => $zone_id,
+        Domain  => 'example.com',
+        Records => \@records,
+    })]];
+}
+
+my $ep  = httpd()->endpoint();
+my $now = $ddclient::now;
+
+my @test_cases = (
+
+    {
+        desc => 'IPv4 success, existing record updated',
+        cfg => {
+            'myhost.example.com' => {
+                server   => $ep,
+                password => 'test-api-key',
+                zone     => 'example.com',
+                wantipv4 => '192.0.2.1',
+            },
+        },
+        responses => [
+            zone_list_response('example.com', 42),
+            zone_detail_response(42, {Id => 10, Type => 0, Name => 'myhost', Value => '198.51.100.1', Ttl => 300}),
+            [200, ['Content-Type' => 'application/json'], [encode_json({})]],
+        ],
+        wantrecap => {
+            'myhost.example.com' => {
+                'status-ipv4' => 'good',
+                'ipv4'        => '192.0.2.1',
+                'mtime'       => $now,
+            },
+        },
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['myhost.example.com'], msg => qr/IPv4 address set to 192\.0\.2\.1/},
+        ],
+        wantreqs => [
+            {method => 'GET', path_re => qr{/dnszone\b}},
+            {method => 'GET', path_re => qr{/dnszone/42$}},
+            {method => 'POST', path_re => qr{/dnszone/42/records/10$}},
+        ],
+    },
+
+    {
+        desc => 'IPv6 success, existing record updated',
+        cfg => {
+            'myhost.example.com' => {
+                server   => $ep,
+                password => 'test-api-key',
+                zone     => 'example.com',
+                wantipv6 => '2001:db8::1',
+            },
+        },
+        responses => [
+            zone_list_response('example.com', 42),
+            zone_detail_response(42, {Id => 20, Type => 1, Name => 'myhost', Value => '2001:db8::2', Ttl => 300}),
+            [200, ['Content-Type' => 'application/json'], [encode_json({})]],
+        ],
+        wantrecap => {
+            'myhost.example.com' => {
+                'status-ipv6' => 'good',
+                'ipv6'        => '2001:db8::1',
+                'mtime'       => $now,
+            },
+        },
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['myhost.example.com'], msg => qr/IPv6 address set to 2001:db8::1/},
+        ],
+        wantreqs => [
+            {method => 'GET', path_re => qr{/dnszone\b}},
+            {method => 'GET', path_re => qr{/dnszone/42$}},
+            {method => 'POST', path_re => qr{/dnszone/42/records/20$}},
+        ],
+    },
+
+    {
+        desc => 'dual-stack success, both records updated',
+        cfg => {
+            'myhost.example.com' => {
+                server   => $ep,
+                password => 'test-api-key',
+                zone     => 'example.com',
+                wantipv4 => '192.0.2.1',
+                wantipv6 => '2001:db8::1',
+            },
+        },
+        responses => [
+            zone_list_response('example.com', 42),
+            zone_detail_response(42,
+                {Id => 10, Type => 0, Name => 'myhost', Value => '198.51.100.1', Ttl => 300},
+                {Id => 20, Type => 1, Name => 'myhost', Value => '2001:db8::2', Ttl => 300},
+            ),
+            [200, ['Content-Type' => 'application/json'], [encode_json({})]],
+            [200, ['Content-Type' => 'application/json'], [encode_json({})]],
+        ],
+        wantrecap => {
+            'myhost.example.com' => {
+                'status-ipv4' => 'good',
+                'ipv4'        => '192.0.2.1',
+                'status-ipv6' => 'good',
+                'ipv6'        => '2001:db8::1',
+                'mtime'       => $now,
+            },
+        },
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['myhost.example.com'], msg => qr/IPv4 address set to 192\.0\.2\.1/},
+            {label => 'SUCCESS', ctx => ['myhost.example.com'], msg => qr/IPv6 address set to 2001:db8::1/},
+        ],
+        wantreqs => [
+            {method => 'GET', path_re => qr{/dnszone\b}},
+            {method => 'GET', path_re => qr{/dnszone/42$}},
+            {method => 'POST', path_re => qr{/dnszone/42/records/10$}},
+            {method => 'POST', path_re => qr{/dnszone/42/records/20$}},
+        ],
+    },
+
+    {
+        desc => 'zone not found',
+        cfg => {
+            'myhost.example.com' => {
+                server   => $ep,
+                password => 'test-api-key',
+                zone     => 'example.com',
+                wantipv4 => '192.0.2.1',
+            },
+        },
+        responses => [
+            [200, ['Content-Type' => 'application/json'], [encode_json({
+                Items       => [],
+                TotalItems  => 0,
+                CurrentPage => 1,
+                HasMoreItems => 0,
+            })]],
+        ],
+        wantrecap => {},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['myhost.example.com'], msg => qr/zone 'example\.com' not found/},
+        ],
+        wantreqs => [
+            {method => 'GET', path_re => qr{/dnszone\b}},
+        ],
+    },
+
+    {
+        desc => 'record not found, created via PUT',
+        cfg => {
+            'myhost.example.com' => {
+                server   => $ep,
+                password => 'test-api-key',
+                zone     => 'example.com',
+                wantipv4 => '192.0.2.1',
+            },
+        },
+        responses => [
+            zone_list_response('example.com', 42),
+            zone_detail_response(42),
+            [200, ['Content-Type' => 'application/json'], [encode_json({})]],
+        ],
+        wantrecap => {
+            'myhost.example.com' => {
+                'status-ipv4' => 'good',
+                'ipv4'        => '192.0.2.1',
+                'mtime'       => $now,
+            },
+        },
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['myhost.example.com'], msg => qr/IPv4 address set to 192\.0\.2\.1/},
+        ],
+        wantreqs => [
+            {method => 'GET', path_re => qr{/dnszone\b}},
+            {method => 'GET', path_re => qr{/dnszone/42$}},
+            {method => 'PUT', path_re => qr{/dnszone/42/records$}},
+        ],
+    },
+
+    {
+        desc => 'HTTP error on zone list',
+        cfg => {
+            'myhost.example.com' => {
+                server   => $ep,
+                password => 'test-api-key',
+                zone     => 'example.com',
+                wantipv4 => '192.0.2.1',
+            },
+        },
+        responses => [
+            [401, ['Content-Type' => 'application/json'], [encode_json({Message => 'Unauthorized'})]],
+        ],
+        wantrecap => {},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['myhost.example.com'], msg => qr/401/},
+        ],
+        wantreqs => [
+            {method => 'GET', path_re => qr{/dnszone\b}},
+        ],
+    },
+
+    {
+        desc => 'no-op when IP already matches',
+        cfg => {
+            'myhost.example.com' => {
+                server   => $ep,
+                password => 'test-api-key',
+                zone     => 'example.com',
+                wantipv4 => '192.0.2.1',
+            },
+        },
+        responses => [
+            zone_list_response('example.com', 42),
+            zone_detail_response(42, {Id => 10, Type => 0, Name => 'myhost', Value => '192.0.2.1', Ttl => 300}),
+        ],
+        wantrecap => {
+            'myhost.example.com' => {
+                'status-ipv4' => 'good',
+                'ipv4'        => '192.0.2.1',
+                'mtime'       => $now,
+            },
+        },
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['myhost.example.com'], msg => qr/skipped: IPv4 address was already set to 192\.0\.2\.1/},
+        ],
+        wantreqs => [
+            {method => 'GET', path_re => qr{/dnszone\b}},
+            {method => 'GET', path_re => qr{/dnszone/42$}},
+        ],
+    },
+
+);
+
+for my $tc (@test_cases) {
+    diag('=' x 78);
+    diag("Starting test: $tc->{desc}");
+    diag('=' x 78);
+
+    httpd()->reset(@{$tc->{responses}});
+
+    local %ddclient::config = ();
+    my @hosts = sort(keys(%{$tc->{cfg}}));
+    for my $h (@hosts) {
+        $ddclient::config{$h} = {%{$tc->{cfg}{$h}}};
+    }
+    local %ddclient::recap;
+    my $l = ddclient::t::Logger->new(
+        $ddclient::_l,
+        qr/^(?:WARNING|FATAL|SUCCESS|FAILED)$/,
+    );
+    {
+        local $ddclient::_l = $l;
+        ddclient::nic_bunny_update(undef, @hosts);
+    }
+    my @got_reqs = httpd()->reset();
+
+    is_deeply(\%ddclient::recap, $tc->{wantrecap}, "$tc->{desc}: recap")
+        or diag(ddclient::repr(
+            Values => [\%ddclient::recap, $tc->{wantrecap}],
+            Names  => ['*got', '*want'],
+        ));
+
+    subtest("$tc->{desc}: requests" => sub {
+        my @wantreqs = @{$tc->{wantreqs} // []};
+        is(scalar(@got_reqs), scalar(@wantreqs), "request count matches");
+        for my $i (0 .. $#wantreqs) {
+            last if $i >= @got_reqs;
+            my $req  = $got_reqs[$i];
+            my $want = $wantreqs[$i];
+            subtest("request $i" => sub {
+                is($req->method(), $want->{method}, "method is $want->{method}");
+                like($req->uri()->path(), $want->{path_re}, "path matches");
+                is($req->header('AccessKey'), 'test-api-key', 'AccessKey header present');
+            });
+        }
+    });
+
+    $tc->{wantlogs} //= [];
+    subtest("$tc->{desc}: logs" => sub {
+        my @got  = @{$l->{logs}};
+        my @want = @{$tc->{wantlogs}};
+        for my $i (0 .. $#want) {
+            last if $i >= @got;
+            my $got  = $got[$i];
+            my $want = $want[$i];
+            subtest("log $i" => sub {
+                is($got->{label},      $want->{label},   "label matches");
+                is_deeply($got->{ctx}, $want->{ctx},     "context matches");
+                like($got->{msg},      $want->{msg},     "message matches");
+            }) or diag(ddclient::repr(
+                Values => [$got, $want],
+                Names  => ['*got', '*want'],
+            ));
+        }
+        my @unexpected = @got[@want .. $#got];
+        ok(@unexpected == 0, "no unexpected logs")
+            or diag(ddclient::repr(\@unexpected, Names => ['*unexpected']));
+        my @missing = @want[@got .. $#want];
+        ok(@missing == 0, "no missing logs")
+            or diag(ddclient::repr(\@missing, Names => ['*missing']));
+    });
+}
+
+done_testing();


### PR DESCRIPTION
## Summary

- Adds `bunny` protocol for [Bunny.net DNS](https://bunny.net/dns/) hosting
- Authenticates with the Bunny.net account-level API key via `AccessKey` header
- Supports IPv4 (A) and IPv6 (AAAA) record updates
- Looks up the zone ID by domain name via `GET /dnszone?search=<zone>`, fetches zone records, then updates existing records (POST) or creates new ones (PUT)
- All 22 tests pass

## Implementation notes

- URL construction uses `opt('server', $h)` directly — no hardcoded `https://` — so the test server endpoint works without scheme mangling
- Protocol entry added alphabetically in `%protocols` between `1984` and `changeip`
- Added to `@needs_json` in `init_config`

## Test plan

- [x] `make check TESTS=t/protocol_bunny.pl VERBOSE=1` — all 22 tests pass
- [x] IPv4 update (existing record)
- [x] IPv6 update (existing record)
- [x] Dual-stack update (both records)
- [x] Zone not found → `FAILED` logged
- [x] Record not found → created via `PUT`
- [x] HTTP error (401) → `FAILED` logged
- [x] No-op when IP already matches → `skipped` success logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)