### PR TITLE
feat: add namesilo protocol for NameSilo DNS

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -67,6 +67,7 @@ repository history](https://github.com/ddclient/ddclient/commits/main).
     dual-stack configuration examples.
   * Added `ns1` protocol for NS1 / IBM NS1 Connect (https://ns1.com/).
     [#907](https://github.com/ddclient/ddclient/pull/907)
+  * Added `namesilo` protocol for NameSilo (https://www.namesilo.com/).
   * Added `spaceship` protocol for Spaceship (https://www.spaceship.com/).
     [#896](https://github.com/ddclient/ddclient/pull/896)
   * Added `updatedip` built-in web IP check service for UpdatedIP (https://www.updatedip.com).

--- a/Makefile.am
+++ b/Makefile.am
@@ -81,6 +81,7 @@ handwritten_tests = \
 	t/protocol_dynu.pl \
 	t/protocol_hetzner.pl \
 	t/protocol_ionos.pl \
+	t/protocol_namesilo.pl \
 	t/protocol_ns1.pl \
 	t/protocol_simplycom.pl \
 	t/protocol_spaceship.pl \

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Dynamic DNS services currently supported include:
   * [LuaDNS](https://luadns.com)
   * [Mythic Beasts](https://www.mythic-beasts.com/support/api/dnsv2/dynamic-dns)
   * [NameCheap](https://www.namecheap.com)
+  * [NameSilo](https://www.namesilo.com)
   * [NearlyFreeSpeech.net](https://www.nearlyfreespeech.net/services/dns)
   * [NIC.RU](https://www.nic.ru)
   * [Njalla](https://njal.la/docs/ddns)

--- a/ddclient.conf.in
+++ b/ddclient.conf.in
@@ -561,6 +561,24 @@ pid=@runstatedir@/ddclient.pid  # record PID in file.
 # yourhost.yourdomain.com
 
 ##
+## LuaDNS (https://luadns.com) - programmable DNS with DDNS support
+## Use your account email as login and your API key as password.
+##
+# protocol=dyndns2,                         \
+# server=app.luadns.com,                    \
+# login=your-luadns-email,                  \
+# password=your-luadns-api-key              \
+# yourhostname.example.com
+
+##
+## NameSilo (https://www.namesilo.com/)
+##
+# protocol=namesilo,                        \
+# zone=example.com,                         \
+# password=your-namesilo-api-key,           \
+# myhost.example.com
+
+##
 ## NIC.RU (https://www.nic.ru) - Russian .ru domain registry
 ## Use your NIC.RU account login and password from the DNS hosting panel.
 ##
@@ -578,16 +596,6 @@ pid=@runstatedir@/ddclient.pid  # record PID in file.
 # login=my-updatedip-login
 # password=my-updatedip-password
 # subdomain.updatedip.com
-
-##
-## LuaDNS (https://luadns.com) - programmable DNS with DDNS support
-## Use your account email as login and your API key as password.
-##
-# protocol=dyndns2,                         \
-# server=app.luadns.com,                    \
-# login=your-luadns-email,                  \
-# password=your-luadns-api-key              \
-# yourhostname.example.com
 
 ##
 ## WebSupport (https://www.websupport.sk)

--- a/ddclient.in
+++ b/ddclient.in
@@ -1216,6 +1216,17 @@ our %protocols = (
             'server'       => setv(T_FQDNP, 0, 'dynamicdns.park-your-domain.com', undef),
         },
     ),
+    'namesilo' => ddclient::Protocol->new(
+        'update'   => \&nic_namesilo_update,
+        'examples' => \&nic_namesilo_examples,
+        'cfgvars'  => {
+            %{$cfgvars{'protocol-common-defaults'}},
+            'password' => undef,
+            'zone'     => setv(T_FQDN,   1, undef,              undef),
+            'ttl'      => setv(T_NUMBER, 0, 3600,               undef),
+            'server'   => setv(T_FQDNP,  0, 'www.namesilo.com', undef),
+        },
+    ),
     'nfsn' => ddclient::LegacyProtocol->new(
         'update'     => \&nic_nfsn_update,
         'examples'   => \&nic_nfsn_examples,
@@ -2254,7 +2265,7 @@ sub init_config {
     load_sha1_support(join(', ', @needs_sha1)) if @needs_sha1;
     my @needs_json = grep({ my $p = $_; grep($_ eq $p, @protos); }
                           qw(1984 cloudflare digitalocean directnic dnsexit2 gandi godaddy hetzner
-                             ionos nfsn njalla ns1 porkbun spaceship yandex));
+                             ionos namesilo nfsn njalla ns1 porkbun spaceship yandex));
     load_json_support(join(', ', @needs_json)) if @needs_json;
 }
 
@@ -5141,6 +5152,126 @@ sub nic_namecheap_update {
         } else {
             $recap{$h}{'status'} = 'failed';
             failed("invalid reply: $reply");
+        }
+    }
+}
+
+######################################################################
+
+######################################################################
+## nic_namesilo_examples
+######################################################################
+sub nic_namesilo_examples {
+    my $self = shift;
+    return <<"EoEXAMPLE";
+o 'namesilo'
+
+The 'namesilo' protocol is used by the NameSilo DNS service (www.namesilo.com).
+
+Before configuring, create an API key in the NameSilo account settings under
+API Manager and grant DNS read and write access.
+
+Configuration variables applicable to the 'namesilo' protocol are:
+  protocol=namesilo            ##
+  server=fqdn.of.service       ## can be omitted, defaults to www.namesilo.com
+  zone=dns.zone                ## the registered domain (required)
+  password=service-password    ## NameSilo API key
+  ttl=seconds                  ## optional; DNS TTL in seconds.  Defaults to 3600.
+  fully.qualified.host         ## the host registered with the service.
+
+Example \${program}.conf file entries:
+  protocol=namesilo                                            \\
+  zone=example.com                                             \\
+  password=your-namesilo-api-key                               \\
+  myhost.example.com
+
+EoEXAMPLE
+}
+
+######################################################################
+## nic_namesilo_update
+######################################################################
+sub nic_namesilo_update {
+    my $self = shift;
+    for my $h (@_) {
+        local $_l = pushlogctx($h);
+        my $zone = opt('zone', $h);
+        if ($h !~ /(?:^|\.)\Q$zone\E$/) {
+            failed("hostname '$h' does not end with zone '$zone'");
+            next;
+        }
+        (my $subdomain = $h) =~ s/(?:^|\.)\Q$zone\E$//;
+        $subdomain ||= '@';
+
+        for my $ipv ('4', '6') {
+            my $ip = delete $config{$h}{"wantipv$ipv"} or next;
+            my $rrtype = $ipv eq '4' ? 'A' : 'AAAA';
+            info("setting IPv$ipv address to $ip");
+            $recap{$h}{"status-ipv$ipv"} = 'failed';
+
+            my $key    = opt('password', $h);
+            my $server = opt('server', $h);
+            my $ttl    = opt('ttl', $h);
+
+            # Step 1: list existing records
+            my $list_url = "$server/api/dnsListRecords?version=1&type=json&key=$key&domain=$zone";
+            my $list_reply = geturl(proxy => opt('proxy'), url => $list_url);
+            next if !header_ok($list_reply);
+            $list_reply =~ qr/{(?:[^{}]*|(?R))*}/mp;
+            my $list_resp = eval { decode_json(${^MATCH}) };
+            unless ($list_resp && $list_resp->{reply}) {
+                failed("invalid JSON response from dnsListRecords");
+                next;
+            }
+            my $reply_obj = $list_resp->{reply};
+            if ($reply_obj->{code} != 300) {
+                failed("dnsListRecords failed: %s", $reply_obj->{detail});
+                next;
+            }
+
+            # Find existing record matching type and FQDN
+            my $records = $reply_obj->{resource_record} // [];
+            $records = [$records] if ref($records) eq 'HASH';  # single record returned as hash
+            my ($existing) = grep {
+                $_->{type} eq $rrtype && $_->{host} eq $h
+            } @$records;
+
+            my $api_reply;
+            if ($existing) {
+                # Step 2a: update existing record
+                my $rrid = $existing->{record_id};
+                debug("found existing $rrtype record ID $rrid; updating");
+                my $upd_url = "$server/api/dnsUpdateRecord?version=1&type=json"
+                    . "&key=$key&domain=$zone&rrid=$rrid"
+                    . "&rrhost=$subdomain&rrvalue=$ip&rrttl=$ttl";
+                $api_reply = geturl(proxy => opt('proxy'), url => $upd_url);
+                next if !header_ok($api_reply);
+            } else {
+                # Step 2b: add new record
+                debug("no existing $rrtype record; adding new record");
+                my $add_url = "$server/api/dnsAddRecord?version=1&type=json"
+                    . "&key=$key&domain=$zone&rrtype=$rrtype"
+                    . "&rrhost=$subdomain&rrvalue=$ip&rrttl=$ttl";
+                $api_reply = geturl(proxy => opt('proxy'), url => $add_url);
+                next if !header_ok($api_reply);
+            }
+
+            $api_reply =~ qr/{(?:[^{}]*|(?R))*}/mp;
+            my $api_resp = eval { decode_json(${^MATCH}) };
+            unless ($api_resp && $api_resp->{reply}) {
+                failed("invalid JSON response from NameSilo API");
+                next;
+            }
+            my $api_reply_obj = $api_resp->{reply};
+            if ($api_reply_obj->{code} != 300) {
+                failed("NameSilo API error: %s", $api_reply_obj->{detail});
+                next;
+            }
+
+            $recap{$h}{"ipv$ipv"}        = $ip;
+            $recap{$h}{'mtime'}          = $now;
+            $recap{$h}{"status-ipv$ipv"} = 'good';
+            success("IPv$ipv address set to $ip");
         }
     }
 }

--- a/ddclient.in
+++ b/ddclient.in
@@ -1224,6 +1224,7 @@ our %protocols = (
             'password' => undef,
             'zone'     => setv(T_FQDN,   1, undef,              undef),
             'ttl'      => setv(T_NUMBER, 0, 3600,               undef),
+            'ssl'      => setv(T_BOOL,   0, 1,                  undef),
             'server'   => setv(T_FQDNP,  0, 'www.namesilo.com', undef),
         },
     ),

--- a/t/protocol_namesilo.pl
+++ b/t/protocol_namesilo.pl
@@ -1,0 +1,375 @@
+use Test::More;
+BEGIN { SKIP: { eval { require Test::Warnings; 1; } or skip($@, 1); } }
+BEGIN { eval { require JSON::PP; 1; } or plan(skip_all => $@); JSON::PP->import(); }
+BEGIN { eval { require 'ddclient'; } or BAIL_OUT($@); }
+use ddclient::t::HTTPD;
+use ddclient::t::Logger;
+
+httpd_required();
+
+ddclient::load_json_support('namesilo');
+
+my $j = ['Content-Type' => 'application/json'];
+
+sub list_resp {
+    my ($records) = @_;
+    $records //= [];
+    return [200, $j, [encode_json({
+        reply => {
+            code            => 300,
+            detail          => 'success',
+            resource_record => $records,
+        },
+    })]];
+}
+
+sub list_resp_single_record {
+    my ($record) = @_;
+    return [200, $j, [encode_json({
+        reply => {
+            code            => 300,
+            detail          => 'success',
+            resource_record => $record,
+        },
+    })]];
+}
+
+sub ok_resp {
+    return [200, $j, [encode_json({
+        reply => {
+            code   => 300,
+            detail => 'success',
+        },
+    })]];
+}
+
+sub error_resp {
+    my ($code, $detail) = @_;
+    return [200, $j, [encode_json({
+        reply => {
+            code   => $code,
+            detail => $detail,
+        },
+    })]];
+}
+
+httpd()->run();
+
+my @test_cases = (
+    {
+        desc => 'IPv4 success, add new record',
+        cfg => {'host.example.com' => {
+            protocol => 'namesilo',
+            password => 'myapikey',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            list_resp([]),
+            ok_resp(),
+        ],
+        wantrecap => {'host.example.com' => {
+            'status-ipv4' => 'good',
+            'ipv4'        => '192.0.2.1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv4/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 2, 'exactly 2 requests: list + add');
+            like($reqs[0]->uri()->path(), qr{/api/dnsListRecords}, 'first request is dnsListRecords');
+            like($reqs[0]->uri()->query(), qr/domain=example\.com/, 'list query has domain');
+            like($reqs[0]->uri()->query(), qr/key=myapikey/, 'list query has API key');
+            like($reqs[1]->uri()->path(), qr{/api/dnsAddRecord}, 'second request is dnsAddRecord');
+            like($reqs[1]->uri()->query(), qr/rrtype=A/, 'add query has rrtype=A');
+            like($reqs[1]->uri()->query(), qr/rrvalue=192\.0\.2\.1/, 'add query has correct IP');
+            like($reqs[1]->uri()->query(), qr/rrhost=host/, 'add query has subdomain');
+        },
+    },
+    {
+        desc => 'IPv4 success, update existing record',
+        cfg => {'host.example.com' => {
+            protocol => 'namesilo',
+            password => 'myapikey',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.2',
+        }},
+        responses => [
+            list_resp([{
+                record_id => 'rec123',
+                type      => 'A',
+                host      => 'host.example.com',
+                value     => '192.0.2.1',
+                ttl       => 3600,
+            }]),
+            ok_resp(),
+        ],
+        wantrecap => {'host.example.com' => {
+            'status-ipv4' => 'good',
+            'ipv4'        => '192.0.2.2',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv4/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 2, 'exactly 2 requests: list + update');
+            like($reqs[0]->uri()->path(), qr{/api/dnsListRecords}, 'first request is dnsListRecords');
+            like($reqs[1]->uri()->path(), qr{/api/dnsUpdateRecord}, 'second request is dnsUpdateRecord');
+            like($reqs[1]->uri()->query(), qr/rrid=rec123/, 'update query has record ID');
+            like($reqs[1]->uri()->query(), qr/rrvalue=192\.0\.2\.2/, 'update query has new IP');
+            like($reqs[1]->uri()->query(), qr/rrhost=host/, 'update query has subdomain');
+        },
+    },
+    {
+        desc => 'IPv6 success, add new record',
+        cfg => {'host.example.com' => {
+            protocol => 'namesilo',
+            password => 'myapikey',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv6 => '2001:db8::1',
+        }},
+        responses => [
+            list_resp([]),
+            ok_resp(),
+        ],
+        wantrecap => {'host.example.com' => {
+            'status-ipv6' => 'good',
+            'ipv6'        => '2001:db8::1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv6/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 2, 'exactly 2 requests: list + add');
+            like($reqs[1]->uri()->path(), qr{/api/dnsAddRecord}, 'second request is dnsAddRecord');
+            like($reqs[1]->uri()->query(), qr/rrtype=AAAA/, 'add query has rrtype=AAAA');
+        },
+    },
+    {
+        desc => 'both IPv4 and IPv6 success',
+        cfg => {'host.example.com' => {
+            protocol => 'namesilo',
+            password => 'myapikey',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+            wantipv6 => '2001:db8::1',
+        }},
+        responses => [
+            list_resp([]),
+            ok_resp(),
+            list_resp([]),
+            ok_resp(),
+        ],
+        wantrecap => {'host.example.com' => {
+            'status-ipv4' => 'good', 'ipv4' => '192.0.2.1',
+            'status-ipv6' => 'good', 'ipv6' => '2001:db8::1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv4/},
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv6/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 4, '4 requests: list+add for each version');
+        },
+    },
+    {
+        desc => 'API error on list records',
+        cfg => {'host.example.com' => {
+            protocol => 'namesilo',
+            password => 'badkey',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            error_resp(110, 'Invalid API Key'),
+        ],
+        wantrecap => {'host.example.com' => {'status-ipv4' => 'failed'}},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['host.example.com'], msg => qr/Invalid API Key/},
+        ],
+    },
+    {
+        desc => 'API error on update record',
+        cfg => {'host.example.com' => {
+            protocol => 'namesilo',
+            password => 'myapikey',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            list_resp([{
+                record_id => 'rec456',
+                type      => 'A',
+                host      => 'host.example.com',
+                value     => '192.0.2.99',
+                ttl       => 3600,
+            }]),
+            error_resp(200, 'Record update failed'),
+        ],
+        wantrecap => {'host.example.com' => {'status-ipv4' => 'failed'}},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['host.example.com'], msg => qr/Record update failed/},
+        ],
+    },
+    {
+        desc => 'hostname does not end with zone',
+        cfg => {'other.example.org' => {
+            protocol => 'namesilo',
+            password => 'myapikey',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [],
+        wantrecap => {},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['other.example.org'], msg => qr/does not end with zone/},
+        ],
+    },
+    {
+        desc => 'custom TTL is sent',
+        cfg => {'host.example.com' => {
+            protocol => 'namesilo',
+            password => 'myapikey',
+            zone     => 'example.com',
+            ttl      => 7200,
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            list_resp([]),
+            ok_resp(),
+        ],
+        wantrecap => {'host.example.com' => {
+            'status-ipv4' => 'good',
+            'ipv4'        => '192.0.2.1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv4/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            like($reqs[1]->uri()->query(), qr/rrttl=7200/, 'custom TTL 7200 sent in add request');
+        },
+    },
+    {
+        desc => 'apex domain uses @ as subdomain',
+        cfg => {'example.com' => {
+            protocol => 'namesilo',
+            password => 'myapikey',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            list_resp([]),
+            ok_resp(),
+        ],
+        wantrecap => {'example.com' => {
+            'status-ipv4' => 'good',
+            'ipv4'        => '192.0.2.1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['example.com'], msg => qr/IPv4/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            like($reqs[1]->uri()->query(), qr/rrhost=(?:@|%40)/, 'apex domain sends @ as subdomain');
+        },
+    },
+    {
+        desc => 'single existing record returned as hash (not array)',
+        cfg => {'host.example.com' => {
+            protocol => 'namesilo',
+            password => 'myapikey',
+            zone     => 'example.com',
+            server   => httpd()->endpoint(),
+            wantipv4 => '192.0.2.5',
+        }},
+        responses => [
+            list_resp_single_record({
+                record_id => 'recabc',
+                type      => 'A',
+                host      => 'host.example.com',
+                value     => '192.0.2.4',
+                ttl       => 3600,
+            }),
+            ok_resp(),
+        ],
+        wantrecap => {'host.example.com' => {
+            'status-ipv4' => 'good',
+            'ipv4'        => '192.0.2.5',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv4/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            like($reqs[1]->uri()->path(), qr{/api/dnsUpdateRecord}, 'update used when single hash record matches');
+            like($reqs[1]->uri()->query(), qr/rrid=recabc/, 'correct record ID used');
+        },
+    },
+);
+
+for my $tc (@test_cases) {
+    subtest($tc->{desc} => sub {
+        local $ddclient::globals{debug}   = 1;
+        local $ddclient::globals{verbose} = 1;
+        local %ddclient::config  = %{$tc->{cfg}};
+        local %ddclient::recap;
+
+        httpd()->reset(@{$tc->{responses}});
+
+        my $l = ddclient::t::Logger->new($ddclient::_l, qr/^(?:WARNING|FATAL|SUCCESS|FAILED)$/);
+        {
+            local $ddclient::_l = $l;
+            ddclient::nic_namesilo_update(undef, sort(keys(%{$tc->{cfg}})));
+        }
+
+        my @reqs = httpd()->reset();
+
+        is_deeply(\%ddclient::recap, $tc->{wantrecap}, 'recap matches')
+            or diag(ddclient::repr(Values => [\%ddclient::recap, $tc->{wantrecap}],
+                                   Names  => ['*got', '*want']));
+
+        subtest('logs' => sub {
+            my @got  = @{$l->{logs}};
+            my @want = @{$tc->{wantlogs} // []};
+            for my $i (0..$#want) {
+                last if $i >= @got;
+                subtest("log $i" => sub {
+                    is($got[$i]{label}, $want[$i]{label}, 'label');
+                    is_deeply($got[$i]{ctx}, $want[$i]{ctx}, 'context');
+                    like($got[$i]{msg}, $want[$i]{msg}, 'message');
+                });
+            }
+            my @unexpected = @got[@want..$#got];
+            ok(@unexpected == 0, 'no unexpected logs')
+                or diag(ddclient::repr(\@unexpected, Names => ['*unexpected']));
+            my @missing = @want[@got..$#want];
+            ok(@missing == 0, 'no missing logs')
+                or diag(ddclient::repr(\@missing, Names => ['*missing']));
+        });
+
+        $tc->{check_reqs}->(@reqs) if $tc->{check_reqs};
+    });
+}
+
+done_testing();


### PR DESCRIPTION
## Summary

- Add `namesilo` protocol supporting the [NameSilo](https://www.namesilo.com) DNS API
- Uses GET-based API calls with JSON responses (`version=1&type=json`)
- Implements list-then-update-or-add workflow: `dnsListRecords` → `dnsUpdateRecord` or `dnsAddRecord`
- Supports IPv4 (A) and IPv6 (AAAA) records, custom TTL (default 3600), and apex domain (`@`) handling
- Handles edge case where NameSilo returns a single record as a JSON object instead of an array

## Files changed

- `ddclient.in`: `%protocols` entry, `@needs_json`, `nic_namesilo_examples()`, `nic_namesilo_update()`
- `t/protocol_namesilo.pl`: 10 subtests covering add/update/IPv4/IPv6/error/apex/TTL/hash-record cases
- `Makefile.am`: test added to `handwritten_tests` (alphabetical)
- `README.md`: NameSilo listed alphabetically
- `ddclient.conf.in`: example config block appended
- `ChangeLog.md`: entry under `## v4.0.1-rc.2 (unreleased work-in-progress)` → `### New feature`

## Test plan

- [x] `./autogen && ./configure && make && make check TESTS=t/protocol_namesilo.pl VERBOSE=1` — all 10 subtests pass (plus warnings subtest)
- [ ] Manual test with a real NameSilo account and API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)