### PR TITLE
feat: add celeros protocol for Celeros DNS (celeros.de)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,11 @@ repository history](https://github.com/ddclient/ddclient/commits/main).
 
 ## v4.0.1-rc.2 (unreleased work-in-progress)
 
+### New features
+
+  * Added `celeros` protocol for Celeros (https://www.celeros.de). Supports updating
+    IPv4 and IPv6 in a single request.
+
 ### Provider updates
 
   * `sitelutions`: Update default server to `api2.sitelutions.com` (APIv2); add optional

--- a/Makefile.am
+++ b/Makefile.am
@@ -73,6 +73,7 @@ handwritten_tests = \
 	t/jitter.pl \
 	t/parse_assignments.pl \
 	t/protocol_ddnss.pl \
+	t/protocol_celeros.pl \
 	t/protocol_cloudflare.pl \
 	t/protocol_directnic.pl \
 	t/protocol_dnsexit2.pl \

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Dynamic DNS services currently supported include:
 
   * [1984.is](https://www.1984.is/product/freedns)
   * [All-inkl.com](https://all-inkl.com)
+  * [Celeros](https://www.celeros.de)
   * [ChangeIP](https://www.changeip.com)
   * [CloudFlare](https://www.cloudflare.com)
   * [ClouDNS](https://www.cloudns.net)

--- a/ddclient.conf.in
+++ b/ddclient.conf.in
@@ -166,6 +166,14 @@ pid=@runstatedir@/ddclient.pid  # record PID in file.
 # your-host.domain.com, your-2nd-host.domain.com
 
 ##
+## Celeros (https://www.celeros.de)
+## Use the API key from your celeros.de account.
+##
+# protocol=celeros,                         \
+# password=your-celeros-api-key,            \
+# myhost.example.com
+
+##
 ## ChangeIP (changeip.com)
 ##
 ## single host update

--- a/ddclient.in
+++ b/ddclient.in
@@ -940,6 +940,7 @@ our %protocols = (
         'cfgvars'  => {
             %{$cfgvars{'protocol-common-defaults'}},
             'login'  => undef,
+            'ssl'      => setv(T_BOOL,  0, 1,               undef),
             'server' => setv(T_FQDNP, 0, 'kc.celeros.de', undef),
         },
     ),

--- a/ddclient.in
+++ b/ddclient.in
@@ -934,6 +934,15 @@ our %protocols = (
             'server' => setv(T_FQDNP, 0, 'api.1984.is', undef),
         },
     ),
+    'celeros' => ddclient::Protocol->new(
+        'update'   => \&nic_celeros_update,
+        'examples' => \&nic_celeros_examples,
+        'cfgvars'  => {
+            %{$cfgvars{'protocol-common-defaults'}},
+            'login'  => undef,
+            'server' => setv(T_FQDNP, 0, 'kc.celeros.de', undef),
+        },
+    ),
     'changeip' => ddclient::LegacyProtocol->new(
         'update'     => \&nic_changeip_update,
         'examples'   => \&nic_changeip_examples,
@@ -7461,6 +7470,80 @@ sub nic_ddnss_update {
             $recap{$h}{"status-ipv$ipv"} = 'good';
             success("IPv$ipv address set to $ip");
         }
+    }
+}
+
+######################################################################
+## nic_celeros_examples
+######################################################################
+sub nic_celeros_examples {
+    my $self = shift;
+    return <<"EoEXAMPLE";
+o 'celeros'
+
+The 'celeros' protocol is used by the dynamic DNS service offered by celeros.de.
+API endpoint: https://kc.celeros.de/dyndns
+
+Configuration variables applicable to the 'celeros' protocol are:
+  protocol=celeros              ##
+  password=your-api-key        ## API key from your celeros.de account
+  fully.qualified.host         ## the host registered with the service.
+
+Example \${program}.conf file entries:
+  ## IPv4 update
+  protocol=celeros,            \\
+  password=your-api-key,       \\
+  myhost.example.com
+
+  ## dual-stack update (IPv4 and IPv6 in one request)
+  protocol=celeros,            \\
+  password=your-api-key,       \\
+  myhost.example.com
+
+EoEXAMPLE
+}
+
+######################################################################
+## nic_celeros_update
+## https://kc.celeros.de/dyndns?domain=<domain>&ip=<ipaddr>&ip6=<ip6addr>&key=<pass>
+## Supports updating IPv4 and IPv6 in a single request.
+######################################################################
+sub nic_celeros_update {
+    my $self = shift;
+    for my $h (@_) {
+        local $_l = pushlogctx($h);
+        my $ipv4 = delete $config{$h}{'wantipv4'};
+        my $ipv6 = delete $config{$h}{'wantipv6'};
+        next unless $ipv4 || $ipv6;
+        info("setting IPv4 address to $ipv4") if $ipv4;
+        info("setting IPv6 address to $ipv6") if $ipv6;
+        my $params = "domain=$h&key=" . opt('password', $h);
+        $params .= "&ip=$ipv4"  if $ipv4;
+        $params .= "&ip6=$ipv6" if $ipv6;
+        my $reply = geturl(
+            proxy => opt('proxy'),
+            url   => opt('server', $h) . "/dyndns?$params",
+        );
+        next if !header_ok($reply);
+        (my $body = $reply) =~ s/^.*?\n\n//s or do {
+            failed("invalid response from server");
+            next;
+        };
+        if ($body !~ /\b(good|nochg)\b/i) {
+            failed("server said: $body");
+            next;
+        }
+        if ($ipv4) {
+            $recap{$h}{'ipv4'}        = $ipv4;
+            $recap{$h}{'status-ipv4'} = 'good';
+        }
+        if ($ipv6) {
+            $recap{$h}{'ipv6'}        = $ipv6;
+            $recap{$h}{'status-ipv6'} = 'good';
+        }
+        $recap{$h}{'mtime'} = $now;
+        success("IPv4 address set to $ipv4") if $ipv4;
+        success("IPv6 address set to $ipv6") if $ipv6;
     }
 }
 

--- a/t/protocol_celeros.pl
+++ b/t/protocol_celeros.pl
@@ -1,0 +1,211 @@
+use Test::More;
+BEGIN { SKIP: { eval { require Test::Warnings; 1; } or skip($@, 1); } }
+BEGIN { eval { require 'ddclient'; } or BAIL_OUT($@); }
+use ddclient::t::HTTPD;
+use ddclient::t::Logger;
+
+httpd_required();
+
+my $textplain = ['Content-Type' => 'text/plain'];
+
+httpd()->run();
+
+my @test_cases = (
+    {
+        desc => 'IPv4 success',
+        cfg => {'myhost.example.com' => {
+            protocol => 'celeros',
+            server   => httpd()->endpoint(),
+            password => 'myapikey',
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [200, $textplain, ["good\n"]],
+        ],
+        wantrecap => {'myhost.example.com' => {
+            'status-ipv4' => 'good',
+            'ipv4'        => '192.0.2.1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['myhost.example.com'], msg => qr/IPv4.*192\.0\.2\.1/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 1, '1 request for IPv4-only update');
+            is($reqs[0]->uri()->path(), '/dyndns', 'correct path');
+            my $q = $reqs[0]->uri()->query();
+            like($q,   qr/domain=myhost\.example\.com/, 'domain param present');
+            like($q,   qr/key=myapikey/,                'key param present');
+            like($q,   qr/\bip=192\.0\.2\.1\b/,         'ip param present');
+            unlike($q, qr/\bip6=/,                       'no ip6 param');
+        },
+    },
+    {
+        desc => 'IPv6 success',
+        cfg => {'myhost.example.com' => {
+            protocol => 'celeros',
+            server   => httpd()->endpoint(),
+            password => 'myapikey',
+            wantipv6 => '2001:db8::1',
+        }},
+        responses => [
+            [200, $textplain, ["good\n"]],
+        ],
+        wantrecap => {'myhost.example.com' => {
+            'status-ipv6' => 'good',
+            'ipv6'        => '2001:db8::1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['myhost.example.com'], msg => qr/IPv6.*2001:db8::1/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 1, '1 request for IPv6-only update');
+            is($reqs[0]->uri()->path(), '/dyndns', 'correct path');
+            my $q = $reqs[0]->uri()->query();
+            like($q,   qr/domain=myhost\.example\.com/, 'domain param present');
+            like($q,   qr/key=myapikey/,                'key param present');
+            like($q,   qr/ip6=/,                         'ip6 param present');
+            unlike($q, qr/[&?]ip=/,                      'no bare ip param');
+        },
+    },
+    {
+        desc => 'dual-stack success (single request)',
+        cfg => {'myhost.example.com' => {
+            protocol => 'celeros',
+            server   => httpd()->endpoint(),
+            password => 'myapikey',
+            wantipv4 => '192.0.2.1',
+            wantipv6 => '2001:db8::1',
+        }},
+        responses => [
+            [200, $textplain, ["good\n"]],
+        ],
+        wantrecap => {'myhost.example.com' => {
+            'status-ipv4' => 'good',
+            'ipv4'        => '192.0.2.1',
+            'status-ipv6' => 'good',
+            'ipv6'        => '2001:db8::1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['myhost.example.com'], msg => qr/IPv4.*192\.0\.2\.1/},
+            {label => 'SUCCESS', ctx => ['myhost.example.com'], msg => qr/IPv6.*2001:db8::1/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 1, '1 request for dual-stack update');
+            my $q = $reqs[0]->uri()->query();
+            like($q, qr/\bip=192\.0\.2\.1\b/, 'ip param present');
+            like($q, qr/ip6=/,                  'ip6 param present');
+        },
+    },
+    {
+        desc => 'nochg response treated as success',
+        cfg => {'myhost.example.com' => {
+            protocol => 'celeros',
+            server   => httpd()->endpoint(),
+            password => 'myapikey',
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [200, $textplain, ["nochg\n"]],
+        ],
+        wantrecap => {'myhost.example.com' => {
+            'status-ipv4' => 'good',
+            'ipv4'        => '192.0.2.1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['myhost.example.com'], msg => qr/IPv4/},
+        ],
+    },
+    {
+        desc => 'server returns error response',
+        cfg => {'myhost.example.com' => {
+            protocol => 'celeros',
+            server   => httpd()->endpoint(),
+            password => 'badkey',
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [200, $textplain, ["badauth\n"]],
+        ],
+        wantrecap => {},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['myhost.example.com'], msg => qr/server said: badauth/},
+        ],
+    },
+    {
+        desc => 'HTTP error',
+        cfg => {'myhost.example.com' => {
+            protocol => 'celeros',
+            server   => httpd()->endpoint(),
+            password => 'myapikey',
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [500, $textplain, ["internal server error\n"]],
+        ],
+        wantrecap => {},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['myhost.example.com'], msg => qr/500/},
+        ],
+    },
+    {
+        desc => 'no wantipv4 or wantipv6, no request sent',
+        cfg => {'myhost.example.com' => {
+            protocol => 'celeros',
+            server   => httpd()->endpoint(),
+            password => 'myapikey',
+        }},
+        responses => [],
+        wantrecap => {},
+        wantlogs  => [],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 0, 'no requests sent');
+        },
+    },
+);
+
+for my $tc (@test_cases) {
+    subtest($tc->{desc} => sub {
+        local %ddclient::config = %{$tc->{cfg}};
+        local %ddclient::recap;
+        httpd()->reset(@{$tc->{responses}});
+        my $l = ddclient::t::Logger->new($ddclient::_l, qr/^(?:WARNING|FATAL|SUCCESS|FAILED)$/);
+        {
+            local $ddclient::_l = $l;
+            ddclient::nic_celeros_update(undef, sort(keys(%{$tc->{cfg}})));
+        }
+        my @reqs = httpd()->reset();
+        is_deeply(\%ddclient::recap, $tc->{wantrecap}, 'recap matches')
+            or diag(ddclient::repr(Values => [\%ddclient::recap, $tc->{wantrecap}],
+                                   Names => ['*got', '*want']));
+        subtest('logs' => sub {
+            my @got  = @{$l->{logs}};
+            my @want = @{$tc->{wantlogs}};
+            for my $i (0..$#want) {
+                last if $i >= @got;
+                my ($got, $want) = ($got[$i], $want[$i]);
+                subtest("log $i" => sub {
+                    is($got->{label},        $want->{label},  'label matches');
+                    is_deeply($got->{ctx},   $want->{ctx},    'context matches');
+                    like($got->{msg},        $want->{msg},    'message matches');
+                }) or diag(ddclient::repr(Values => [$got, $want], Names => ['*got', '*want']));
+            }
+            my @unexpected = @got[@want..$#got];
+            ok(@unexpected == 0, 'no unexpected logs')
+                or diag(ddclient::repr(\@unexpected, Names => ['*unexpected']));
+            my @missing = @want[@got..$#want];
+            ok(@missing == 0, 'no missing logs')
+                or diag(ddclient::repr(\@missing, Names => ['*missing']));
+        });
+        $tc->{check_reqs}->(@reqs) if $tc->{check_reqs};
+    });
+}
+
+done_testing();


### PR DESCRIPTION
## Summary

- Adds `protocol=celeros` for the DDNS service at [celeros.de](https://www.celeros.de)
- Uses the `kc.celeros.de/dyndns` API endpoint with `domain`, `key`, `ip`, and `ip6` query parameters
- Supports IPv4-only, IPv6-only, and dual-stack updates — notably, both addresses are sent in a **single request**
- No login required; authenticates via API key (`password=`)

Closes #640

## Test plan

- [ ] 7 test cases covering IPv4, IPv6, dual-stack, `nochg` response, auth failure, HTTP error, and no-op
- [ ] All pass locally (pre-existing HTTPD.pm warning unrelated to this change)
- [ ] Tested against live Celeros API: needs verification from a Celeros account holder

🤖 Generated with [Claude Code](https://claude.com/claude-code)