### PR TITLE
1984: migrate to Protocol, add IPv4/IPv6 dual-stack support

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,8 @@ repository history](https://github.com/ddclient/ddclient/commits/main).
 
 ### Provider updates
 
+  * `1984`: Add IPv6 (AAAA record) support; migrate from legacy single-IP update
+    to dual-stack protocol handling.
   * `sitelutions`: Update default server to `api2.sitelutions.com` (APIv2); add optional
     `ttl` configuration variable.
     [#865](https://github.com/ddclient/ddclient/pull/865)

--- a/Makefile.am
+++ b/Makefile.am
@@ -72,6 +72,7 @@ handwritten_tests = \
 	t/logmsg.pl \
 	t/jitter.pl \
 	t/parse_assignments.pl \
+	t/protocol_1984.pl \
 	t/protocol_ddnss.pl \
 	t/protocol_cloudflare.pl \
 	t/protocol_directnic.pl \

--- a/ddclient.in
+++ b/ddclient.in
@@ -925,12 +925,12 @@ our %cfgvars = (
 }
 
 our %protocols = (
-    '1984' => ddclient::LegacyProtocol->new(
-        'update' => \&nic_1984_update,
+    '1984' => ddclient::Protocol->new(
+        'update'   => \&nic_1984_update,
         'examples' => \&nic_1984_examples,
         'cfgvars' => {
             %{$cfgvars{'protocol-common-defaults'}},
-            'login' => undef,
+            'login'  => undef,
             'server' => setv(T_FQDNP, 0, 'api.1984.is', undef),
         },
     ),
@@ -5709,17 +5709,20 @@ sub nic_1984_examples {
 o '1984'
 
 The '1984' protocol is used by DNS services offered by 1984.is.
+Both IPv4 (A) and IPv6 (AAAA) records are supported; the server detects
+the record type from the address format.
 
 Configuration variables applicable to the '1984' protocol are:
   protocol=1984                ##
-  password=api-key             ## your API key
+  server=fqdn.of.service       ## can be omitted, defaults to api.1984.is
+  password=api-key             ## your API key from 1984.is
   fully.qualified.host         ## the domain to update
 
 Example ${program}.conf file entries:
   ## single host update
   protocol=1984,                                                   \\
   password=my-1984-api-key,                                        \\
-  myhost
+  myhost.example.com
 
 EoEXAMPLE
 }
@@ -5727,49 +5730,44 @@ EoEXAMPLE
 ######################################################################
 ## nic_1984_update
 ## https://api.1984.is/1.0/freedns/?apikey=xxx&domain=mydomain&ip=myip
-## The response is a JSON document containing the following entries
-## - ok: true or false depending on if the request was successful or not,
-##       if the ip is the same as before this will be true,
-## - msg: successes or why it is not working,
-## - lookup: if domain or subdomain was not found lookup will contain a list of names tried
+## The response is a JSON document:
+##   ok:  true on success (including when IP was already set)
+##   msg: human-readable result; contains "unaltered" when no change was needed
 ######################################################################
 sub nic_1984_update {
     my $self = shift;
     for my $host (@_) {
         local $_l = pushlogctx($host);
-        my $ip = delete $config{$host}{'wantip'};
-        info("setting IP address to $ip");
-
-        my $url;
-        $url  = 'https://' . opt('server', $host) . '/1.0/freedns/';
-        $url .= '?apikey=' . opt('password', $host);
-        $url .= "&domain=$host";
-        $url .= "&ip=$ip";
-
-        my $reply = geturl(
-            proxy => opt('proxy'),
-            url => $url,
-        );
-        next if !header_ok($reply);
-
-        # Strip header
-        $reply =~ qr/{(?:[^{}]*|(?R))*}/mp;
-        my $response = eval { decode_json(${^MATCH}) };
-        if ($@) {
-            failed("JSON decoding failure");
-            next;
-        }
-        unless ($response->{ok}) {
-            failed("%s", $response->{msg});
-            next;
-        }
-
-        $recap{$host}{'status'} = 'good';
-        $recap{$host}{'ip'} = $ip;
-        if ($response->{msg} =~ /unaltered/) {
-            success("skipped: IP was already set to $response->{ip}");
-        } else {
-            success("updated successfully to $response->{ip}");
+        for my $ipv ('4', '6') {
+            my $ip = delete $config{$host}{"wantipv$ipv"} or next;
+            info("setting IPv$ipv address to $ip");
+            my $url = opt('server', $host) . '/1.0/freedns/';
+            $url .= '?apikey=' . opt('password', $host);
+            $url .= "&domain=$host";
+            $url .= "&ip=$ip";
+            my $reply = geturl(
+                proxy => opt('proxy'),
+                url   => $url,
+            );
+            next if !header_ok($reply);
+            $reply =~ qr/{(?:[^{}]*|(?R))*}/mp;
+            my $response = eval { decode_json(${^MATCH}) };
+            if ($@) {
+                failed("JSON decoding failure");
+                next;
+            }
+            unless ($response->{ok}) {
+                failed("%s", $response->{msg} // 'unknown error');
+                next;
+            }
+            $recap{$host}{"ipv$ipv"}        = $ip;
+            $recap{$host}{"status-ipv$ipv"} = 'good';
+            $recap{$host}{'mtime'}          = $now;
+            if ($response->{msg} =~ /unaltered/i) {
+                success("IPv$ipv address was already set to $ip");
+            } else {
+                success("IPv$ipv address set to $ip");
+            }
         }
     }
 }

--- a/t/protocol_1984.pl
+++ b/t/protocol_1984.pl
@@ -1,0 +1,222 @@
+use Test::More;
+BEGIN { SKIP: { eval { require Test::Warnings; 1; } or skip($@, 1); } }
+BEGIN { eval { require JSON::PP; 1; } or plan(skip_all => $@); JSON::PP->import(); }
+BEGIN { eval { require 'ddclient'; } or BAIL_OUT($@); }
+use ddclient::t::HTTPD;
+use ddclient::t::Logger;
+
+httpd_required();
+
+ddclient::load_json_support('1984');
+
+my $j = ['Content-Type' => 'application/json'];
+
+httpd()->run();
+
+my @test_cases = (
+    {
+        desc => 'IPv4 success',
+        cfg => {'myhost.example.com' => {
+            protocol => '1984',
+            server   => httpd()->endpoint(),
+            password => 'myapikey',
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [200, $j, [encode_json({ok => JSON::PP::true, msg => 'updated', ip => '192.0.2.1'})]],
+        ],
+        wantrecap => {'myhost.example.com' => {
+            'status-ipv4' => 'good',
+            'ipv4'        => '192.0.2.1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['myhost.example.com'], msg => qr/IPv4.*192\.0\.2\.1/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 1, '1 request for IPv4 update');
+            my $q = $reqs[0]->uri()->query();
+            like($q, qr/apikey=myapikey/,            'apikey present');
+            like($q, qr/domain=myhost\.example\.com/, 'domain present');
+            like($q, qr/ip=192\.0\.2\.1/,             'ip present');
+        },
+    },
+    {
+        desc => 'IPv4 unaltered (already up to date)',
+        cfg => {'myhost.example.com' => {
+            protocol => '1984',
+            server   => httpd()->endpoint(),
+            password => 'myapikey',
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [200, $j, [encode_json({ok => JSON::PP::true, msg => 'Your IP is unaltered', ip => '192.0.2.1'})]],
+        ],
+        wantrecap => {'myhost.example.com' => {
+            'status-ipv4' => 'good',
+            'ipv4'        => '192.0.2.1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['myhost.example.com'], msg => qr/already set/},
+        ],
+    },
+    {
+        desc => 'IPv6 success',
+        cfg => {'myhost.example.com' => {
+            protocol => '1984',
+            server   => httpd()->endpoint(),
+            password => 'myapikey',
+            wantipv6 => '2001:db8::1',
+        }},
+        responses => [
+            [200, $j, [encode_json({ok => JSON::PP::true, msg => 'updated', ip => '2001:db8::1'})]],
+        ],
+        wantrecap => {'myhost.example.com' => {
+            'status-ipv6' => 'good',
+            'ipv6'        => '2001:db8::1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['myhost.example.com'], msg => qr/IPv6.*2001:db8::1/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 1, '1 request for IPv6 update');
+            my $q = $reqs[0]->uri()->query();
+            like($q, qr/ip=2001/, 'ip param contains IPv6 address');
+        },
+    },
+    {
+        desc => 'dual-stack sends two separate requests',
+        cfg => {'myhost.example.com' => {
+            protocol => '1984',
+            server   => httpd()->endpoint(),
+            password => 'myapikey',
+            wantipv4 => '192.0.2.1',
+            wantipv6 => '2001:db8::1',
+        }},
+        responses => [
+            [200, $j, [encode_json({ok => JSON::PP::true, msg => 'updated', ip => '192.0.2.1'})]],
+            [200, $j, [encode_json({ok => JSON::PP::true, msg => 'updated', ip => '2001:db8::1'})]],
+        ],
+        wantrecap => {'myhost.example.com' => {
+            'status-ipv4' => 'good',
+            'ipv4'        => '192.0.2.1',
+            'status-ipv6' => 'good',
+            'ipv6'        => '2001:db8::1',
+            'mtime'       => $ddclient::now,
+        }},
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['myhost.example.com'], msg => qr/IPv4.*192\.0\.2\.1/},
+            {label => 'SUCCESS', ctx => ['myhost.example.com'], msg => qr/IPv6.*2001:db8::1/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 2, '2 requests for dual-stack update');
+        },
+    },
+    {
+        desc => 'server returns ok:false',
+        cfg => {'myhost.example.com' => {
+            protocol => '1984',
+            server   => httpd()->endpoint(),
+            password => 'badkey',
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [200, $j, [encode_json({ok => JSON::PP::false, msg => 'Invalid API key'})]],
+        ],
+        wantrecap => {},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['myhost.example.com'], msg => qr/Invalid API key/},
+        ],
+    },
+    {
+        desc => 'JSON decode failure',
+        cfg => {'myhost.example.com' => {
+            protocol => '1984',
+            server   => httpd()->endpoint(),
+            password => 'myapikey',
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [200, $j, ["{not valid json}"]],
+        ],
+        wantrecap => {},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['myhost.example.com'], msg => qr/JSON decoding failure/},
+        ],
+    },
+    {
+        desc => 'HTTP error',
+        cfg => {'myhost.example.com' => {
+            protocol => '1984',
+            server   => httpd()->endpoint(),
+            password => 'myapikey',
+            wantipv4 => '192.0.2.1',
+        }},
+        responses => [
+            [500, $j, [encode_json({ok => JSON::PP::false, msg => 'server error'})]],
+        ],
+        wantrecap => {},
+        wantlogs => [
+            {label => 'FAILED', ctx => ['myhost.example.com'], msg => qr/500/},
+        ],
+    },
+    {
+        desc => 'no wantipv4 or wantipv6, no request sent',
+        cfg => {'myhost.example.com' => {
+            protocol => '1984',
+            server   => httpd()->endpoint(),
+            password => 'myapikey',
+        }},
+        responses => [],
+        wantrecap => {},
+        wantlogs  => [],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 0, 'no requests sent');
+        },
+    },
+);
+
+for my $tc (@test_cases) {
+    subtest($tc->{desc} => sub {
+        local %ddclient::config = %{$tc->{cfg}};
+        local %ddclient::recap;
+        httpd()->reset(@{$tc->{responses}});
+        my $l = ddclient::t::Logger->new($ddclient::_l, qr/^(?:WARNING|FATAL|SUCCESS|FAILED)$/);
+        {
+            local $ddclient::_l = $l;
+            ddclient::nic_1984_update(undef, sort(keys(%{$tc->{cfg}})));
+        }
+        my @reqs = httpd()->reset();
+        is_deeply(\%ddclient::recap, $tc->{wantrecap}, 'recap matches')
+            or diag(ddclient::repr(Values => [\%ddclient::recap, $tc->{wantrecap}],
+                                   Names => ['*got', '*want']));
+        subtest('logs' => sub {
+            my @got  = @{$l->{logs}};
+            my @want = @{$tc->{wantlogs}};
+            for my $i (0..$#want) {
+                last if $i >= @got;
+                my ($got, $want) = ($got[$i], $want[$i]);
+                subtest("log $i" => sub {
+                    is($got->{label},        $want->{label},  'label matches');
+                    is_deeply($got->{ctx},   $want->{ctx},    'context matches');
+                    like($got->{msg},        $want->{msg},    'message matches');
+                }) or diag(ddclient::repr(Values => [$got, $want], Names => ['*got', '*want']));
+            }
+            my @unexpected = @got[@want..$#got];
+            ok(@unexpected == 0, 'no unexpected logs')
+                or diag(ddclient::repr(\@unexpected, Names => ['*unexpected']));
+            my @missing = @want[@got..$#want];
+            ok(@missing == 0, 'no missing logs')
+                or diag(ddclient::repr(\@missing, Names => ['*missing']));
+        });
+        $tc->{check_reqs}->(@reqs) if $tc->{check_reqs};
+    });
+}
+
+done_testing();


### PR DESCRIPTION
## Summary

Migrates the `1984` protocol (1984.is FreeDNS) from `LegacyProtocol` to `Protocol`, adding dual-stack IPv4 and IPv6 support.

- Replaces `wantip` with `wantipv4` / `wantipv6` loop pattern; makes one API request per IP family.
- The 1984.is `/1.0/freedns/` endpoint accepts both IPv4 and IPv6 addresses via the same `ip=` parameter; the server selects the A or AAAA record from the address format.
- Updates recap fields from legacy `recap{h}{ip}` / `recap{h}{status}` to `recap{h}{ipv4}` / `recap{h}{status-ipv4}` (and v6 equivalents).
- Removes the hardcoded `https://` prefix from URL construction; `geturl()` handles the scheme via `opt('ssl')`.
- Adds `t/protocol_1984.pl` with 8 test cases: IPv4 success, IPv4 unaltered, IPv6 success, dual-stack (two separate requests), `ok:false` error, JSON decode failure, HTTP error, no-op.

Closes #940. Part of the broader IPv6 support tracking in #172.

## Test plan

- [x] `make check TESTS=t/protocol_1984.pl` — 9/9 pass
- [x] `make check TESTS="t/protocol_cloudflare.pl t/protocol_hetzner.pl t/protocol_spaceship.pl t/protocol_ns1.pl"` — 49/49 pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)