### PR TITLE
Fix command part of URL for dinahosting provider

### DIFF
--- a/ddclient.in
+++ b/ddclient.in
@@ -8428,7 +8428,7 @@ sub nic_dinahosting_update {
         my $url = 'https://' . opt('server', $h) . opt('script', $h);
         $url .= "?hostname=$hostname";
         $url .= "&domain=$domain";
-        $url .= "&command=Domain_Zone_UpdateType" . is_ipv6($ip) ? 'AAAA' : 'A';
+        $url .= "&command=Domain_Zone_UpdateType" . (is_ipv6($ip) ? 'AAAA' : 'A');
         $url .= "&ip=$ip";
         my $reply = geturl(
             proxy => opt('proxy'),


### PR DESCRIPTION
Hi,
I have tried to use ddclient for dinahosting provider but it looks like it is currently broken.
I managed to fix it just adding a parenthesis around the is_ipv6 condition.
Before the fix this is the URL I get:

```
https://dinahosting.com/special/api.php?hostname=host&domain=domain.orgAAAA&ip=192.168.1.1
```
which caused an ERROR 2000.
And after the fix:
```
https://dinahosting.com/special/api.php?hostname=host&domain=domain.org&command=Domain_Zone_UpdateTypeA&ip=192.168.1.1
```
which is now working.

Thanks!