### PR TITLE
feat: add Arvan Cloud DNS dynamic update protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Dynamic DNS services currently supported include:
 
   * [1984.is](https://www.1984.is/product/freedns)
   * [All-inkl.com](https://all-inkl.com)
+  * [Arvan Cloud](https://www.arvancloud.ir)
   * [ChangeIP](https://www.changeip.com)
   * [CloudFlare](https://www.cloudflare.com)
   * [ClouDNS](https://www.cloudns.net)

--- a/ddclient.conf.in
+++ b/ddclient.conf.in
@@ -193,6 +193,14 @@ pid=@runstatedir@/ddclient.pid  # record PID in file.
 # domain.tld,sub.domain.tld
 
 ##
+## Arvan Cloud (www.arvancloud.ir)
+##
+# protocol=arvancloud,               \
+# password=your-arvan-api-token,     \
+# ttl=300,                           \
+# myhost.example.com
+
+##
 ## Gandi (gandi.net)
 ##
 ## Single host update

--- a/ddclient.in
+++ b/ddclient.in
@@ -942,6 +942,18 @@ our %protocols = (
             'server' => setv(T_FQDNP, 0, 'nic.changeip.com', undef),
         },
     ),
+    'arvancloud' => ddclient::Protocol->new(
+        'update'     => \&nic_arvancloud_update,
+        'examples'   => \&nic_arvancloud_examples,
+        'cfgvars' => {
+            %{$cfgvars{'protocol-common-defaults'}},
+            'server'       => setv(T_FQDNP,  0, 'napi.arvancloud.ir/cdn/4.0', undef),
+            'min-interval' => setv(T_DELAY,  0, interval('5m'),                 0),
+        },
+        'cfgdoc' => {
+            'password' => 'Arvan Cloud API JWT token',
+        },
+    ),
     'cloudflare' => ddclient::Protocol->new(
         'update'     => \&nic_cloudflare_update,
         'examples'   => \&nic_cloudflare_examples,
@@ -2267,7 +2279,7 @@ sub init_config {
     my @needs_sha1 = grep({ my $p = $_; grep($_ eq $p, @protos); } qw(freedns nfsn));
     load_sha1_support(join(', ', @needs_sha1)) if @needs_sha1;
     my @needs_json = grep({ my $p = $_; grep($_ eq $p, @protos); }
-                          qw(1984 cloudflare digitalocean directnic dnsexit2 gandi godaddy hetzner
+                          qw(1984 arvancloud cloudflare digitalocean directnic dnsexit2 gandi godaddy hetzner
                              ionos netcup nfsn njalla ns1 porkbun spaceship yandex));
     load_json_support(join(', ', @needs_json)) if @needs_json;
 }
@@ -6903,6 +6915,165 @@ sub nic_cloudflare_update {
                     $recap{$domain}{"status-ipv$ipv"} = 'good';
                 } else {
                     failed("invalid json or result");
+                }
+            }
+        }
+    }
+}
+
+######################################################################
+## nic_arvancloud_examples
+######################################################################
+sub nic_arvancloud_examples {
+    my $self = shift;
+    return <<"EoEXAMPLE";
+o 'arvancloud'
+
+The 'arvancloud' protocol is used by DNS service offered by www.arvancloud.ir.
+
+Configuration variables applicable to the 'arvancloud' protocol are:
+  protocol=arvancloud          ##
+  server=fqdn.of.service       ## defaults to napi.arvancloud.ir/cdn/4.0
+  password=your-api-token      ## Arvan Cloud API JWT token
+  ttl=300                      ## optional, defaults to 300
+  fully.qualified.host         ## the host registered with the service.
+
+Example ${program}.conf file entries:
+  ## single host update
+  protocol=arvancloud,                                         \\
+  password=my-arvan-api-token,                                 \\
+  myhost.example.com
+
+  ## with custom TTL
+  protocol=arvancloud,                                         \\
+  password=my-arvan-api-token,                                 \\
+  ttl=600,                                                     \\
+  myhost.example.com
+EoEXAMPLE
+}
+
+######################################################################
+## nic_arvancloud_update
+######################################################################
+sub nic_arvancloud_update {
+    my $self = shift;
+    for my $group (group_hosts_by(\@_, qw(password))) {
+        my @hosts = @{$group->{hosts}};
+        my %groupcfg = %{$group->{cfg}};
+        my $headers = "Content-Type: application/json\n";
+        my $token = $groupcfg{'password'};
+        $headers .= "Authorization: Bearer $token\n";
+
+        for my $domain (@hosts) {
+            local $_l = pushlogctx($domain);
+            my $ipv4 = delete $config{$domain}{'wantipv4'};
+            my $ipv6 = delete $config{$domain}{'wantipv6'};
+
+            my $server = opt('server', $domain);
+            my $ttl = opt('ttl', $domain) // 300;
+
+            # IPv4 and IPv6 handling
+            for my $ip ($ipv4, $ipv6) {
+                next if (!$ip);
+                my $ipv = ($ip eq ($ipv6 // '')) ? '6' : '4';
+                my $type = ($ip eq ($ipv6 // '')) ? 'aaaa' : 'a';
+
+                info("setting IPv$ipv address to $ip");
+                $recap{$domain}{"status-ipv$ipv"} = 'failed';
+
+                # Extract subdomain name (just the host part before the domain)
+                my $subdomain = $domain;
+                if ($subdomain =~ /^(.+)\.[^.]+\.[^.]+$/) {
+                    $subdomain = $1;
+                } elsif ($subdomain =~ /^(.+)\.[^.]+$/) {
+                    $subdomain = $1;
+                }
+
+                # GET /domains/{domain}/dns-records?type={type}&search={subdomain}
+                my $url = "${server}/domains/" . uri_escape($domain)
+                        . "/dns-records?type=$type&search=" . uri_escape($subdomain);
+
+                my $reply = geturl(proxy => opt('proxy'),
+                                   url => $url,
+                                   headers => $headers
+                                  );
+                next if !header_ok($reply);
+                my $response = ($reply =~ qr/{(?:[^{}]*|(?R))*}/mp) ? eval {decode_json(${^MATCH})} : undef;
+                unless ($response && $response->{data}) {
+                    failed("invalid json or result");
+                    next;
+                }
+
+                # Find matching record by name
+                my ($rec) = map { $_->{name} eq $subdomain ? $_ : () } @{$response->{data}};
+                unless ($rec) {
+                    # No existing record found — create one (POST)
+                    debug("no existing '$type' record found, creating");
+                    my $body = encode_json({
+                        name  => $subdomain,
+                        type  => $type,
+                        value => [{ ip => $ip }],
+                        ttl   => $ttl,
+                        cloud => 0,
+                    });
+                    my $create_url = "${server}/domains/" . uri_escape($domain) . "/dns-records";
+                    $reply = geturl(proxy => opt('proxy'),
+                                    url => $create_url,
+                                    headers => $headers,
+                                    method => "POST",
+                                    data => $body
+                                   );
+                    next if !header_ok($reply);
+                    $response = ($reply =~ qr/{(?:[^{}]*|(?R))*}/mp) ? eval {decode_json(${^MATCH})} : undef;
+                    if ($response && $response->{data}) {
+                        success("IPv$ipv address set to $ip");
+                        $recap{$domain}{"ipv$ipv"} = $ip;
+                        $recap{$domain}{'mtime'} = $now;
+                        $recap{$domain}{"status-ipv$ipv"} = 'good';
+                    } else {
+                        failed("invalid json or result");
+                    }
+                } else {
+                    # Record found — check if value matches current IP
+                    my $current_ip = $rec->{value} && ref($rec->{value}) eq 'ARRAY'
+                                    && $rec->{value}[0] && $rec->{value}[0]->{ip}
+                                    ? $rec->{value}[0]->{ip} : undef;
+                    if ($current_ip && $current_ip eq $ip) {
+                        debug("IPv$ipv address already set to $ip, skipping");
+                        success("IPv$ipv address already set to $ip");
+                        $recap{$domain}{"ipv$ipv"} = $ip;
+                        $recap{$domain}{'mtime'} = $now;
+                        $recap{$domain}{"status-ipv$ipv"} = 'good';
+                        next;
+                    }
+
+                    # PUT /domains/{domain}/dns-records/{id}
+                    debug("updating existing '$type' record $rec->{id}");
+                    my $body = encode_json({
+                        name  => $subdomain,
+                        type  => $type,
+                        value => [{ ip => $ip }],
+                        ttl   => $ttl,
+                        cloud => 0,
+                    });
+                    my $update_url = "${server}/domains/" . uri_escape($domain)
+                                   . "/dns-records/" . $rec->{id};
+                    $reply = geturl(proxy => opt('proxy'),
+                                    url => $update_url,
+                                    headers => $headers,
+                                    method => "PUT",
+                                    data => $body
+                                   );
+                    next if !header_ok($reply);
+                    $response = ($reply =~ qr/{(?:[^{}]*|(?R))*}/mp) ? eval {decode_json(${^MATCH})} : undef;
+                    if ($response && $response->{data}) {
+                        success("IPv$ipv address set to $ip");
+                        $recap{$domain}{"ipv$ipv"} = $ip;
+                        $recap{$domain}{'mtime'} = $now;
+                        $recap{$domain}{"status-ipv$ipv"} = 'good';
+                    } else {
+                        failed("invalid json or result");
+                    }
                 }
             }
         }

--- a/t/protocol_arvancloud.pl
+++ b/t/protocol_arvancloud.pl
@@ -1,0 +1,451 @@
+use Test::More;
+BEGIN { SKIP: { eval { require Test::Warnings; 1; } or skip($@, 1); } }
+BEGIN { eval { require JSON::PP; 1; } or plan(skip_all => $@); JSON::PP->import(); }
+BEGIN { eval { require 'ddclient'; } or BAIL_OUT($@); }
+use ddclient::t::HTTPD;
+use ddclient::t::Logger;
+
+httpd_required();
+
+local $ddclient::globals{debug} = 1;
+local $ddclient::globals{verbose} = 1;
+
+ddclient::load_json_support('arvancloud');
+
+httpd()->run(sub { return undef });
+
+my $ep = httpd()->endpoint();
+
+sub records_resp {
+    my ($records) = @_;
+    return [200, ['Content-Type' => 'application/json'],
+            [encode_json({ data => $records })]];
+}
+
+sub put_resp {
+    my ($rec) = @_;
+    return [200, ['Content-Type' => 'application/json'],
+            [encode_json({ message => 'OK', data => $rec })]];
+}
+
+sub not_found_resp {
+    return [200, ['Content-Type' => 'application/json'],
+            [encode_json({ data => [] })]];
+}
+
+sub bad_json_resp {
+    return [200, ['Content-Type' => 'text/plain'], ['not json at all']];
+}
+
+my @test_cases = (
+    {
+        desc => 'IPv4 success, Bearer token auth',
+        cfg => {
+            'host.example.com' => {
+                login    => 'my-arvan-token',
+                server   => $ep,
+                wantipv4 => '192.0.2.1',
+            },
+        },
+        responses => [
+            records_resp([{
+                id     => 'rec-uuid-123',
+                name   => 'host',
+                type   => 'a',
+                value  => [{ ip => '1.2.3.4' }],
+                ttl    => 300,
+                cloud  => 0,
+            }]),
+            put_resp({
+                id     => 'rec-uuid-123',
+                name   => 'host',
+                type   => 'a',
+                value  => [{ ip => '192.0.2.1' }],
+                ttl    => 300,
+                cloud  => 0,
+            }),
+        ],
+        wantrecap => {
+            'host.example.com' => {
+                'status-ipv4' => 'good',
+                'ipv4'        => '192.0.2.1',
+                'mtime'       => $ddclient::now,
+            },
+        },
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv4/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 2, 'two requests made');
+            like($reqs[0]->uri->as_string, qr|/domains/example\.com/dns-records\?type=a&search=host|,
+                 'req 0 is A record lookup');
+            is($reqs[0]->header('Authorization'), 'Bearer my-arvan-token', 'Bearer token auth');
+            is($reqs[1]->method, 'PUT', 'req 1 is PUT');
+            like($reqs[1]->uri->as_string, qr|/domains/example\.com/dns-records/rec-uuid-123|,
+                 'req 1 targets correct record');
+            my $body = decode_json($reqs[1]->content);
+            is($body->{value}[0]{ip}, '192.0.2.1', 'PUT body contains correct IP');
+            is($body->{type}, 'a', 'PUT body has lowercase type');
+            is($body->{name}, 'host', 'PUT body has correct subdomain');
+        },
+    },
+    {
+        desc => 'IPv6 success',
+        cfg => {
+            'host.example.com' => {
+                login    => 'my-arvan-token',
+                server   => $ep,
+                wantipv6 => '2001:db8::1',
+            },
+        },
+        responses => [
+            records_resp([{
+                id     => 'rec-uuid-456',
+                name   => 'host',
+                type   => 'aaaa',
+                value  => [{ ip => '::1' }],
+                ttl    => 300,
+                cloud  => 0,
+            }]),
+            put_resp({
+                id     => 'rec-uuid-456',
+                name   => 'host',
+                type   => 'aaaa',
+                value  => [{ ip => '2001:db8::1' }],
+                ttl    => 300,
+                cloud  => 0,
+            }),
+        ],
+        wantrecap => {
+            'host.example.com' => {
+                'status-ipv6' => 'good',
+                'ipv6'        => '2001:db8::1',
+                'mtime'       => $ddclient::now,
+            },
+        },
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv6/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 2, 'two requests made');
+            like($reqs[0]->uri->as_string, qr|type=aaaa|, 'record lookup uses type aaaa');
+            is($reqs[1]->method, 'PUT', 'req 1 is PUT');
+        },
+    },
+    {
+        desc => 'IPv4 + IPv6 dual-stack',
+        cfg => {
+            'host.example.com' => {
+                login    => 'my-arvan-token',
+                server   => $ep,
+                wantipv4 => '192.0.2.1',
+                wantipv6 => '2001:db8::1',
+            },
+        },
+        responses => [
+            records_resp([{
+                id     => 'rec-a',
+                name   => 'host',
+                type   => 'a',
+                value  => [{ ip => '5.6.7.8' }],
+                ttl    => 300,
+                cloud  => 0,
+            }]),
+            put_resp({
+                id     => 'rec-a',
+                name   => 'host',
+                type   => 'a',
+                value  => [{ ip => '192.0.2.1' }],
+                ttl    => 300,
+                cloud  => 0,
+            }),
+            records_resp([{
+                id     => 'rec-aaaa',
+                name   => 'host',
+                type   => 'aaaa',
+                value  => [{ ip => 'fe80::1' }],
+                ttl    => 300,
+                cloud  => 0,
+            }]),
+            put_resp({
+                id     => 'rec-aaaa',
+                name   => 'host',
+                type   => 'aaaa',
+                value  => [{ ip => '2001:db8::1' }],
+                ttl    => 300,
+                cloud  => 0,
+            }),
+        ],
+        wantrecap => {
+            'host.example.com' => {
+                'status-ipv4' => 'good',
+                'ipv4'        => '192.0.2.1',
+                'status-ipv6' => 'good',
+                'ipv6'        => '2001:db8::1',
+                'mtime'       => $ddclient::now,
+            },
+        },
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv4/},
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv6/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 4, 'four requests: 2 lookups + 2 updates');
+            like($reqs[0]->uri->as_string, qr|type=a|, 'first lookup is A record');
+            like($reqs[2]->uri->as_string, qr|type=aaaa|, 'third lookup is AAAA record');
+        },
+    },
+    {
+        desc => 'IP already matches → no PUT request made',
+        cfg => {
+            'host.example.com' => {
+                login    => 'my-arvan-token',
+                server   => $ep,
+                wantipv4 => '192.0.2.1',
+            },
+        },
+        responses => [
+            records_resp([{
+                id     => 'rec-uuid-123',
+                name   => 'host',
+                type   => 'a',
+                value  => [{ ip => '192.0.2.1' }],
+                ttl    => 300,
+                cloud  => 0,
+            }]),
+        ],
+        wantrecap => {
+            'host.example.com' => {
+                'status-ipv4' => 'good',
+                'ipv4'        => '192.0.2.1',
+                'mtime'       => $ddclient::now,
+            },
+        },
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/already set to 192\.0\.2\.1/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 1, 'only one request made (GET only, no PUT)');
+            is($reqs[0]->method, 'GET', 'only GET request made');
+        },
+    },
+    {
+        desc => 'Record not found → create (POST)',
+        cfg => {
+            'host.example.com' => {
+                login    => 'my-arvan-token',
+                server   => $ep,
+                wantipv4 => '192.0.2.1',
+            },
+        },
+        responses => [
+            not_found_resp(),
+            put_resp({
+                id     => 'rec-created',
+                name   => 'host',
+                type   => 'a',
+                value  => [{ ip => '192.0.2.1' }],
+                ttl    => 300,
+                cloud  => 0,
+            }),
+        ],
+        wantrecap => {
+            'host.example.com' => {
+                'status-ipv4' => 'good',
+                'ipv4'        => '192.0.2.1',
+                'mtime'       => $ddclient::now,
+            },
+        },
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv4/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 2, 'two requests: GET + POST');
+            is($reqs[0]->method, 'GET', 'first request is GET');
+            is($reqs[1]->method, 'POST', 'second request is POST');
+            my $body = decode_json($reqs[1]->content);
+            is($body->{type}, 'a', 'POST body has type a');
+            is($body->{value}[0]{ip}, '192.0.2.1', 'POST body has correct IP');
+        },
+    },
+    {
+        desc => 'Invalid JSON handling',
+        cfg => {
+            'host.example.com' => {
+                login    => 'my-arvan-token',
+                server   => $ep,
+                wantipv4 => '192.0.2.1',
+            },
+        },
+        responses => [
+            bad_json_resp(),
+        ],
+        wantrecap => {
+            'host.example.com' => {'status-ipv4' => 'failed'},
+        },
+        wantlogs => [
+            {label => 'FAILED', ctx => ['host.example.com'], msg => qr/invalid json or result/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 1, 'only one request made');
+        },
+    },
+    {
+        desc => 'HTTP 401 handling',
+        cfg => {
+            'host.example.com' => {
+                login    => 'my-arvan-token',
+                server   => $ep,
+                wantipv4 => '192.0.2.1',
+            },
+        },
+        responses => [
+            [401, ['Content-Type' => 'application/json'],
+             [encode_json({ message => 'Unauthorized' })]],
+        ],
+        wantrecap => {
+            'host.example.com' => {'status-ipv4' => 'failed'},
+        },
+        wantlogs => [
+            {label => 'FAILED', ctx => ['host.example.com'], msg => qr/401/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 1, 'only one request made');
+        },
+    },
+    {
+        desc => 'Custom TTL passed through',
+        cfg => {
+            'host.example.com' => {
+                login    => 'my-arvan-token',
+                server   => $ep,
+                wantipv4 => '192.0.2.1',
+                ttl      => 600,
+            },
+        },
+        responses => [
+            records_resp([{
+                id     => 'rec-uuid-123',
+                name   => 'host',
+                type   => 'a',
+                value  => [{ ip => '5.6.7.8' }],
+                ttl    => 300,
+                cloud  => 0,
+            }]),
+            put_resp({
+                id     => 'rec-uuid-123',
+                name   => 'host',
+                type   => 'a',
+                value  => [{ ip => '192.0.2.1' }],
+                ttl    => 600,
+                cloud  => 0,
+            }),
+        ],
+        wantrecap => {
+            'host.example.com' => {
+                'status-ipv4' => 'good',
+                'ipv4'        => '192.0.2.1',
+                'mtime'       => $ddclient::now,
+            },
+        },
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['host.example.com'], msg => qr/IPv4/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            is(scalar(@reqs), 2, 'two requests made');
+            my $body = decode_json($reqs[1]->content);
+            is($body->{ttl}, 600, 'PUT body has custom TTL');
+        },
+    },
+    {
+        desc => 'Subdomain with multiple parts (deep subdomain)',
+        cfg => {
+            'www.api.example.com' => {
+                login    => 'my-arvan-token',
+                server   => $ep,
+                wantipv4 => '192.0.2.1',
+            },
+        },
+        responses => [
+            records_resp([{
+                id     => 'rec-deep',
+                name   => 'www.api',
+                type   => 'a',
+                value  => [{ ip => '9.9.9.9' }],
+                ttl    => 300,
+                cloud  => 0,
+            }]),
+            put_resp({
+                id     => 'rec-deep',
+                name   => 'www.api',
+                type   => 'a',
+                value  => [{ ip => '192.0.2.1' }],
+                ttl    => 300,
+                cloud  => 0,
+            }),
+        ],
+        wantrecap => {
+            'www.api.example.com' => {
+                'status-ipv4' => 'good',
+                'ipv4'        => '192.0.2.1',
+                'mtime'       => $ddclient::now,
+            },
+        },
+        wantlogs => [
+            {label => 'SUCCESS', ctx => ['www.api.example.com'], msg => qr/IPv4/},
+        ],
+        check_reqs => sub {
+            my @reqs = @_;
+            like($reqs[0]->uri->as_string, qr|search=www\.api|, 'search uses deep subdomain');
+            my $body = decode_json($reqs[1]->content);
+            is($body->{name}, 'www.api', 'PUT body has correct deep subdomain');
+        },
+    },
+);
+
+for my $tc (@test_cases) {
+    subtest($tc->{desc} => sub {
+        my @hosts = sort(keys(%{$tc->{cfg}}));
+        local %ddclient::config = %{$tc->{cfg}};
+        local %ddclient::recap;
+        my $l = ddclient::t::Logger->new($ddclient::_l, qr/^(?:WARNING|FATAL|SUCCESS|FAILED)$/);
+        httpd()->reset(@{$tc->{responses}});
+        {
+            local $ddclient::_l = $l;
+            ddclient::nic_arvancloud_update(undef, @hosts);
+        }
+        my @reqs = httpd()->reset();
+        is_deeply(\%ddclient::recap, $tc->{wantrecap}, 'recap matches')
+            or diag(ddclient::repr(Values => [\%ddclient::recap, $tc->{wantrecap}],
+                                   Names  => ['*got', '*want']));
+        subtest('logs' => sub {
+            my @got  = @{$l->{logs}};
+            my @want = @{$tc->{wantlogs}};
+            for my $i (0 .. $#want) {
+                last if $i >= @got;
+                subtest("log $i" => sub {
+                    is($got[$i]{label}, $want[$i]{label}, 'label');
+                    is_deeply($got[$i]{ctx}, $want[$i]{ctx}, 'context');
+                    like($got[$i]{msg}, $want[$i]{msg}, 'message');
+                }) or diag(ddclient::repr(Values => [$got[$i], $want[$i]], Names => ['*got', '*want']));
+            }
+            my @unexpected = @got[@want .. $#got];
+            ok(@unexpected == 0, 'no unexpected logs')
+                or diag(ddclient::repr(\@unexpected, Names => ['*unexpected']));
+            my @missing = @want[@got .. $#want];
+            ok(@missing == 0, 'no missing logs')
+                or diag(ddclient::repr(\@missing, Names => ['*missing']));
+        });
+        $tc->{check_reqs}->(@reqs) if $tc->{check_reqs};
+    });
+}
+
+done_testing();


### PR DESCRIPTION
## Summary
Add support for Arvan Cloud (www.arvancloud.ir) DNS service as a new ddclient protocol.

Arvan Cloud (Abr Arvan) is the largest CDN and cloud services provider in Iran. It serves as the dominant DNS/CDN provider in the Middle East and Iran region ranked as the 8th CDN provider globally by W3Techs. Adding support for Arvan Cloud is essential for users in the region who rely on it for their DNS management.

## Changes
- Register `arvancloud` protocol with default server `napi.arvancloud.ir/cdn/4.0`
- Implement `nic_arvancloud_update`: full CRUD for DNS records via GET/PUT/POST
  - Searches existing A/AAAA records by subdomain
  - Updates existing records or creates new ones via POST
  - Skips update if IP already matches (avoids unnecessary API calls)
  - Supports configurable TTL (default 300s)
- Add `nic_arvancloud_examples` with configuration documentation
- Add `arvancloud` to JSON-supported providers list
- Add config example to `ddclient.conf.in`
- Add Arvan Cloud to README.md supported services list
- Write comprehensive test suite (`t/protocol_arvancloud.pl`) covering:
  - IPv4/IPv6 success, dual-stack, same-IP skip, new record creation
  - Invalid JSON handling, HTTP 401, custom TTL, deep subdomains

## API Details
- Auth: Bearer token (JWT user token)
- Endpoints: `GET/PUT/POST /domains/{domain}/dns-records`
- Record type: `"a"` / `"aaaa"`
- Value format: `{"value": [{"ip": "..."}]}`
