### PR TITLE
namecheap: fix silent host/domain split corruption

### DIFF
--- a/ddclient.in
+++ b/ddclient.in
@@ -5099,7 +5099,7 @@ The 'namecheap' protocol is used by DNS service offered by www.namecheap.com.
 Configuration variables applicable to the 'namecheap' protocol are:
   protocol=namecheap           ##
   server=fqdn.of.service       ## defaults to dynamicdns.park-your-domain.com
-  login=service-login          ## the domain of the dynamic DNS record you want to update
+  login=service-login          ## the full domain name (with TLD) of the dynamic DNS record, e.g. example.com
   password=service-password    ## Generated password for your dynamic DNS record
   hostname                     ## the subdomain to update, use @ for base domain name, * for catch all
 
@@ -5136,7 +5136,11 @@ sub nic_namecheap_update {
         $url = 'https://' . opt('server', $h) . '/update';
         my $domain = opt('login', $h);
         my $host   = $h;
-        $host =~ s/(.*)\.$domain(.*)/$1$2/;
+        unless ($host =~ s/(?:^|\.)\Q$domain\E$//) {
+            failed("host '$h' does not end with the configured login domain '$domain'; login= must be the full domain name (e.g. 'example.com')");
+            next;
+        }
+        $host = '@' if $host eq '';
         $url .= "?host=$host";
         $url .= "&domain=$domain";
         $url .= '&password=' . opt('password', $h);


### PR DESCRIPTION
## Summary
- The namecheap protocol split the subdomain from the full hostname by interpolating the configured `login` value directly into a regex (`s/(.*)\.$domain(.*)/$1$2/`). Because the domain string was not escaped, any `.` in it acted as a regex wildcard rather than a literal character, so a mismatch between the configured `host` and `login` (e.g. `login` missing its TLD) silently produced a corrupted `host` parameter instead of an error.
- This makes the resulting Namecheap API failures ("Domain name not found") very hard to diagnose, since the sent URL looks superficially correct in the logs.
- Escapes the domain with `\Q...\E`, anchors the match to end-of-string, and fails loudly with an actionable message when the configured host doesn't actually end with the login domain. Also handles the apex case explicitly (mapping to `@` as documented).
- Clarifies the `login=` doc comment to state it must be the full domain including TLD.

Reported in #879, where a user's `login=` value was missing its TLD, causing the update URL to be built as `host=<sub>.com&domain=<tld-less-domain>` with no indication of what went wrong.

## Test plan
- [x] `make check` — full existing suite passes (983 tests, 0 failures)
- [x] Verified the fix against the exact strings from the bug report's debug log, plus apex-domain and multi-label-TLD cases, confirming correct splits and loud failures on mismatch